### PR TITLE
Rename pramen_metastore_tables -> metastore_tables in generated yaml

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -198,7 +198,7 @@ class PythonTransformationJob(operationDef: OperationDef,
     def addMetastore(): String = {
       metastore.getRegisteredMetaTables
         .map(getTable)
-        .mkString("pramen_metastore_tables:\n", "\n", "")
+        .mkString("metastore_tables:\n", "\n", "")
     }
 
     def getTable(mt: MetaTable): String = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
@@ -269,7 +269,7 @@ class PythonTransformationJobSuite extends WordSpec with SparkTestBase with Text
         |  output_table: table2
         |  name: python_class
         |  options: {}
-        |pramen_metastore_tables:
+        |metastore_tables:
         |- name: table1
         |  description: description
         |  format: parquet
@@ -309,7 +309,7 @@ class PythonTransformationJobSuite extends WordSpec with SparkTestBase with Text
           |  output_table: table2
           |  name: python_class
           |  options: {}
-          |pramen_metastore_tables:
+          |metastore_tables:
           |- name: table1
           |  description: description
           |  format: parquet
@@ -345,7 +345,7 @@ class PythonTransformationJobSuite extends WordSpec with SparkTestBase with Text
           |  options:
           |    key.2: "value'2'"
           |    key1: "value1"
-          |pramen_metastore_tables:
+          |metastore_tables:
           |- name: table1
           |  description: description
           |  format: parquet


### PR DESCRIPTION
…for a project name agnostic integration.