### PR TITLE
Add support for DB2

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.TableReader
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
 import za.co.absa.pramen.core.sql.{SqlColumnType, SqlConfig, SqlGenerator}
+import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
 import za.co.absa.pramen.core.utils.{ConfigUtils, TimeUtils}
 
 import java.time.{Instant, LocalDate}
@@ -259,7 +260,8 @@ class TableReaderJdbc(tableName: String,
     log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")
     jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                $n"))
 
-    ConfigUtils.logExtraOptions("Extra JDBC reader Spark options:", extraOptions)
+    log.info("Extra JDBC reader Spark options:")
+    ConfigUtils.renderExtraOptions(extraOptions, JDBC_WORDS_TO_REDACT)(s => log.info(s))
   }
 }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.{DateType, DecimalType, TimestampType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.TableReader
+import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
 import za.co.absa.pramen.core.sql.{SqlColumnType, SqlConfig, SqlGenerator}
 import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
@@ -123,6 +124,10 @@ class TableReaderJdbc(tableName: String,
     log.info(s"JDBC Query: $sql")
     val qry = sqlGen.getDtable(sql)
 
+    if (log.isDebugEnabled) {
+      log.debug(s"Sending to JDBC: $qry")
+    }
+
     val databaseOptions = getOptions("database", jdbcReaderConfig.jdbcConfig.database)
 
     val connectionOptions = Map[String, String](
@@ -135,6 +140,11 @@ class TableReaderJdbc(tableName: String,
       databaseOptions ++
       jdbcReaderConfig.jdbcConfig.extraOptions ++
       extraOptions
+
+    if (log.isDebugEnabled) {
+      log.debug("Connection options:")
+      ConfigUtils.renderExtraOptions(connectionOptions, Keys.KEYS_TO_REDACT)(s => log.debug(s))
+    }
 
     var df = spark
       .read

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
@@ -47,7 +47,8 @@ object PipelineSparkSessionBuilder {
   def buildSparkSession(conf: Config): SparkSession = {
     val extraOptions = ConfigUtils.getExtraOptions(conf, EXTRA_OPTIONS_PREFIX)
 
-    ConfigUtils.logExtraOptions("Extra Spark Config:", extraOptions)
+    log.info("Extra Spark Config:")
+    ConfigUtils.renderExtraOptions(extraOptions, KEYS_TO_REDACT)(s => log.info(s))
 
     val sparkSessionBuilder =
       SparkSession

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
@@ -44,7 +44,8 @@ class SparkSource(format: String,
         throw new IllegalArgumentException(s"Unexpected 'sql' spec for the Spark reader. Only 'path' is supported. Config path: $sourceConfigParentPath")
       case Query.Path(path) =>
         log.info(s"Using TableReaderSpark to read '$format' from: $path")
-        ConfigUtils.logExtraOptions(s"Options passed for '$format':", options, KEYS_TO_REDACT)
+        log.info(s"Options passed for '$format':")
+        ConfigUtils.renderExtraOptions(options, KEYS_TO_REDACT)(s => log.info(s))
         schema.foreach(s => log.info(s"Using schema: $s"))
         new TableReaderSpark(format, schema, path, hasInfoDateCol, infoDateColumn, infoDateFormat, options)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -53,6 +53,7 @@ object SqlGenerator {
       case "com.simba.hive.jdbc41.HS2Driver"              => new SqlGeneratorHive(sqlConfig, extraConfig)
       case "com.simba.spark.jdbc.Driver"                  => new SqlGeneratorHive(sqlConfig, extraConfig)
       case "org.hsqldb.jdbc.JDBCDriver"                   => new SqlGeneratorHsqlDb(sqlConfig)
+      case "com.ibm.db2.jcc.DB2Driver"                    => new SqlGeneratorDb2(sqlConfig)
       case d                                              =>
         log.warn(s"Unsupported JDBC driver: '$d'. Trying to use a generic SQL generator.")
         new SqlGeneratorGeneric(sqlConfig)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.sql
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
+
+  private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
+
+  override def getDtable(sql: String): String = {
+    if (sql.exists(_ == ' ')) {
+      s"($sql) AS T"
+    } else {
+      sql
+    }
+  }
+
+  override def getCountQuery(tableName: String): String = {
+    s"SELECT COUNT(*) AS CNT FROM $tableName"
+  }
+
+  override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
+    val where = getWhere(infoDateBegin, infoDateEnd)
+    s"SELECT COUNT(*) AS CNT FROM $tableName WHERE $where"
+  }
+
+  override def getDataQuery(tableName: String, limit: Option[Int]): String = {
+    s"SELECT $columnExpr FROM $tableName${getLimit(limit)}"
+  }
+
+  override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, limit: Option[Int]): String = {
+    val where = getWhere(infoDateBegin, infoDateEnd)
+    s"SELECT $columnExpr FROM $tableName WHERE $where${getLimit(limit)}"
+  }
+
+  private def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
+    val dateBeginLit = getDateLiteral(dateBegin)
+    val dateEndLit = getDateLiteral(dateEnd)
+
+    val dateTypes: Array[SqlColumnType] = Array(SqlColumnType.DATETIME)
+
+    val infoDateColumnAdjusted =
+      if (dateTypes.contains(sqlConfig.infoDateType)) {
+        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+      } else {
+        sqlConfig.infoDateColumn
+      }
+
+    if (dateBeginLit == dateEndLit) {
+      s"$infoDateColumnAdjusted = $dateBeginLit"
+    } else {
+      s"$infoDateColumnAdjusted >= $dateBeginLit AND $infoDateColumnAdjusted <= $dateEndLit"
+    }
+  }
+
+  private def getDateLiteral(date: LocalDate): String = {
+    val dateStr = dateFormatterApp.format(date)
+
+    sqlConfig.infoDateType match {
+      case SqlColumnType.DATE => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
+      case SqlColumnType.DATETIME => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
+      case SqlColumnType.STRING => s"'$dateStr'"
+      case SqlColumnType.NUMBER => s"$dateStr"
+    }
+  }
+
+  private def getLimit(limit: Option[Int]): String = {
+    limit.map(n => s" LIMIT $n").getOrElse("")
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -73,8 +73,8 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
     val dateStr = dateFormatterApp.format(date)
 
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.DATETIME => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
+      case SqlColumnType.DATE => s"DATE '$dateStr'"
+      case SqlColumnType.DATETIME => s"DATE '$dateStr'"
       case SqlColumnType.STRING => s"'$dateStr'"
       case SqlColumnType.NUMBER => s"$dateStr"
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -25,19 +25,19 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
 
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
-      s"($sql) t"
+      s"($sql) AS t"
     } else {
       sql
     }
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM $tableName"
+    s"SELECT COUNT(*) AS CNT FROM $tableName"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM $tableName WHERE $where"
   }
 
   override def getDataQuery(tableName: String, limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
@@ -143,15 +143,17 @@ object ConfigUtils {
     }
   }
 
-  def logExtraOptions(description: String, extraOptions: Map[String, String], redactedKeys: Set[String] = Set.empty[String]): Unit = {
+  def renderExtraOptions(extraOptions: Map[String, String],
+                         redactedWords: Set[String] = Set.empty[String])
+                        (action: String => Unit): Unit = {
     if (extraOptions.nonEmpty) {
       val p = "\""
-      log.info(description)
       extraOptions.foreach { case (key, value) =>
-        if (redactedKeys.contains(key.toLowerCase())) {
-          log.info(s"$key = [redacted]")
+        val lowerCaseKey = key.toLowerCase()
+        if (redactedWords.exists(word => lowerCaseKey.contains(word))) {
+          action(s"$key = [redacted]")
         } else {
-          log.info(s"$key = $p$value$p")
+          action(s"$key = $p$value$p")
         }
       }
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -623,13 +623,13 @@ class SqlGeneratorSuite extends WordSpec with RelationalDbFixture {
 
   "Generic SQL generator" should {
     val genDate = fromDriverName("generic", sqlConfigDate, config)
-    val genDateTime = fromDriverName("org.postgresql.Driver", sqlConfigDateTime, config)
+    val genDateTime = fromDriverName("generic", sqlConfigDateTime, config)
     val genStr = fromDriverName("generic", sqlConfigString, config)
     val genNum = fromDriverName("generic", sqlConfigNumber, config)
     val genCol = fromDriverName("generic", sqlConfigWithListOfColumns, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) FROM A")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
     }
 
     "generate data queries without date ranges" in {
@@ -647,30 +647,30 @@ class SqlGeneratorSuite extends WordSpec with RelationalDbFixture {
     "generate ranged count queries" when {
       "date is in DATE format" in {
         assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
         assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in DATETIME format" in {
         assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
         assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in STRING format" in {
         assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
         assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
         assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = 20200817")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
         assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
     }
 
@@ -717,7 +717,7 @@ class SqlGeneratorSuite extends WordSpec with RelationalDbFixture {
       }
 
       "wrapped query without alias for SQL queries " in {
-        assert(genDate.getDtable("SELECT A FROM B") == "(SELECT A FROM B) t")
+        assert(genDate.getDtable("SELECT A FROM B") == "(SELECT A FROM B) AS t")
       }
     }
   }


### PR DESCRIPTION
DB2 is now supported as both JDBC Native connection (when an input query is used) or via Spark JDBC source (when an input table is specified).

During the implementation of the feature a bug was fixed - custom JDBC properties didn't propagate when JDBC Native was used. This is fixed.

Closes #52, #53