### PR TITLE
#68 Add minimum records for ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ built-in sources:
    - PostgreSQL
    - Oracle (a JDBC driver should be provided in the classpath)
    - Microsoft SQL Server
+   - DB2
    - Denodo (a JDBC driver should be provided in the classpath)
    - Hive 1/2
 - **Parquet on Hadoop** - allows fetching data in Parquet format from any Hadoop-compatible store: HDFS, S3, etc.
@@ -370,6 +371,24 @@ pramen.sources = [
     # ...
   }
   ## etc.
+]
+```
+
+You can specify a minimum records require to exist at the source in order to consider a table to have data.
+By default it is set to 1. You can override it for a specific source using `minimum.records` parameter.
+When set to 0, the source will be considered to have data even if it is empty. Therefore ingesting of empty
+tables will be allowed.
+
+You can override this parameter per-table using `minimum.records` parameter in the table definition. See the
+section on [sourcing jobs](#sourcing-jobs) for more details.
+```config
+pramen.sources = [
+  {
+    name = "source1_name"
+    factory.class = "za.co.absa.pramen.core.source.ParquetSource"
+    
+    minimum.records = 0
+  }
 ]
 ```
 
@@ -1442,6 +1461,7 @@ Here is an example configuration for a JDBC source:
       
       # You can override any of source settings here 
       source {
+        minimum.records = 1000 
         has.information.date.column = true
         information.date.column = "info_date"
       }
@@ -1449,6 +1469,9 @@ Here is an example configuration for a JDBC source:
   ]
 }
 ```
+
+The above example also shows how you can add a pre-ingestion validation on the number of records in the table
+using `minimum.records` parameter.
 
 Full example of JDBC ingestion pipelines: [examples/jdbc_sourcing](examples/jdbc_sourcing)
 

--- a/pramen-py/transformations/identity_transformer/__init__.py
+++ b/pramen-py/transformations/identity_transformer/__init__.py
@@ -39,5 +39,10 @@ class IdentityTransformer(Transformation):
         # just as example
         df = metastore.get_table(table_name)
 
-        assert df.count() != 0, f"Empty table {table_name} received"
+        empty_allowed = options.get("empty.allowed", "true").lower() == "true"
+
+        assert (
+            empty_allowed or df.count() != 0
+        ), f"Empty table {table_name} received"
+
         return df.withColumn("transform_id", rand())

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -30,7 +30,6 @@ import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ConfigUtils, StringUtil
 import java.time._
 import java.time.format.DateTimeFormatter
 import scala.collection.mutable.ListBuffer
-import scala.compat.Platform.EOL
 
 object PipelineNotificationBuilderHtml {
   val MIN_RPS_JOB_DURATION_SECONDS = 60
@@ -39,6 +38,8 @@ object PipelineNotificationBuilderHtml {
 class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNotificationBuilder {
 
   private val timestampFmt: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm Z")
+
+  private val EOL = java.lang.System.lineSeparator
 
   private val zoneId = getZoneId
 
@@ -375,7 +376,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
     task.runStatus match {
       case Failed(ex)                            => ex.getMessage
       case ValidationFailed(ex)                  => ex.getMessage
-      case InsufficientData(actual, expected, _) => s"Got $actual, expected $expected records"
+      case InsufficientData(actual, expected, _) => s"Got $actual, expected at least $expected records"
       case MissingDependencies(tables)           => s"Dependent job failures: ${tables.mkString(", ")}"
       case FailedDependencies(deps)              => s"Dependency check failures: ${deps.map(_.renderText).mkString("; ")}"
       case _                                     =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -39,7 +39,7 @@ class IngestionJob(operationDef: OperationDef,
                    specialCharacters: String)
                   (implicit spark: SparkSession)
   extends JobBase(operationDef, metastore, bookkeeper, outputTable) {
-  import IngestionJob._
+  import JobBase._
 
   private val log = LoggerFactory.getLogger(this.getClass)
 
@@ -136,9 +136,4 @@ class IngestionJob(operationDef: OperationDef,
       case None     => throw new RuntimeException(s"Failed to read data from '${sourceTable.query.query}'")
     }
   }
-}
-
-object IngestionJob {
-  val MINIMUM_RECORDS_KEY = "minimum.records"
-  val MINIMUM_RECORDS_DEFAULT = 1
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
@@ -158,3 +158,8 @@ abstract class JobBase(operationDef: OperationDef,
     (effectiveFrom, effectiveTo)
   }
 }
+
+object JobBase {
+  val MINIMUM_RECORDS_KEY = "minimum.records"
+  val MINIMUM_RECORDS_DEFAULT = 1
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobPreRunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobPreRunStatus.scala
@@ -23,5 +23,6 @@ object JobPreRunStatus {
   case object AlreadyRan extends JobPreRunStatus
   case object NeedsUpdate extends JobPreRunStatus
   case object NoData extends JobPreRunStatus
+  case class InsufficientData(actual: Long, expected: Long) extends JobPreRunStatus
   case class FailedDependencies(failures: Seq[DependencyFailure]) extends JobPreRunStatus
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobPreRunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobPreRunStatus.scala
@@ -23,6 +23,6 @@ object JobPreRunStatus {
   case object AlreadyRan extends JobPreRunStatus
   case object NeedsUpdate extends JobPreRunStatus
   case object NoData extends JobPreRunStatus
-  case class InsufficientData(actual: Long, expected: Long) extends JobPreRunStatus
+  case class InsufficientData(actual: Long, expected: Long, oldRecordCount: Option[Long]) extends JobPreRunStatus
   case class FailedDependencies(failures: Seq[DependencyFailure]) extends JobPreRunStatus
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
@@ -47,6 +47,10 @@ object RunStatus {
     val isFailure: Boolean = false
   }
 
+  case class InsufficientData(actual: Long, expected: Long) extends RunStatus {
+    val isFailure: Boolean = true
+  }
+
   case object NotRan extends RunStatus {
     val isFailure: Boolean = false
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
@@ -47,7 +47,7 @@ object RunStatus {
     val isFailure: Boolean = false
   }
 
-  case class InsufficientData(actual: Long, expected: Long) extends RunStatus {
+  case class InsufficientData(actual: Long, expected: Long, recordCountOld: Option[Long]) extends RunStatus {
     val isFailure: Boolean = true
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -81,9 +81,12 @@ abstract class TaskRunnerBase(conf: Config,
           case NeedsUpdate                  =>
             log.info(s"The table needs update: $outputTable for date: ${task.infoDate}.")
             Right(validationResult)
-          case NoData                       =>
+          case NoData =>
             log.info(s"NO DATA available for the task: $outputTable for date: ${task.infoDate}.")
             Left(TaskResult(task.job, RunStatus.NoData, getRunInfo(task.infoDate, started), Nil, validationResult.dependencyWarnings))
+          case InsufficientData(expected, actual) =>
+            log.info(s"INSUFFICIENT DATA available for the task: $outputTable for date: ${task.infoDate}. Expected = $expected, actual = $actual")
+            Left(TaskResult(task.job, RunStatus.InsufficientData(actual, expected), getRunInfo(task.infoDate, started), Nil, validationResult.dependencyWarnings))
           case AlreadyRan                   =>
             if (runtimeConfig.isRerun) {
               log.info(s"RE-RUNNING the task: $outputTable for date: ${task.infoDate}.")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -84,9 +84,9 @@ abstract class TaskRunnerBase(conf: Config,
           case NoData =>
             log.info(s"NO DATA available for the task: $outputTable for date: ${task.infoDate}.")
             Left(TaskResult(task.job, RunStatus.NoData, getRunInfo(task.infoDate, started), Nil, validationResult.dependencyWarnings))
-          case InsufficientData(expected, actual) =>
+          case InsufficientData(actual, expected, oldRecordCount) =>
             log.info(s"INSUFFICIENT DATA available for the task: $outputTable for date: ${task.infoDate}. Expected = $expected, actual = $actual")
-            Left(TaskResult(task.job, RunStatus.InsufficientData(actual, expected), getRunInfo(task.infoDate, started), Nil, validationResult.dependencyWarnings))
+            Left(TaskResult(task.job, RunStatus.InsufficientData(actual, expected, oldRecordCount), getRunInfo(task.infoDate, started), Nil, validationResult.dependencyWarnings))
           case AlreadyRan                   =>
             if (runtimeConfig.isRerun) {
               log.info(s"RE-RUNNING the task: $outputTable for date: ${task.infoDate}.")
@@ -252,8 +252,10 @@ abstract class TaskRunnerBase(conf: Config,
         log.warn(s"$FAILURE Task '${result.job.name}'$infoDateMsg has MISSING TABLES: ${tables.mkString(", ")}")
       case RunStatus.FailedDependencies(deps)    =>
         log.warn(s"$FAILURE Task '${result.job.name}'$infoDateMsg has FAILED DEPENDENCIES: ${deps.map(_.renderText).mkString("; ")}")
-      case RunStatus.NoData                      =>
+      case RunStatus.NoData =>
         log.info(s"$FAILURE Task '${result.job.name}'$infoDateMsg has NO DATA AT SOURCE.")
+      case _: RunStatus.InsufficientData =>
+        log.info(s"$FAILURE Task '${result.job.name}'$infoDateMsg has INSUFFICIENT DATA AT SOURCE.")
       case RunStatus.Skipped(msg)                =>
         log.info(s"$WARNING Task '${result.job.name}'$infoDateMsg is SKIPPED: $msg.")
       case RunStatus.NotRan                      =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/CmdLineSink.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/CmdLineSink.scala
@@ -135,30 +135,25 @@ class CmdLineSink(sinkConfig: Config,
 
     val count = df.count()
 
-    if (count > 0) {
-      val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempHadoopPath)
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempHadoopPath)
 
-      fsUtils.withTempDirectory(new Path(tempHadoopPath)) { tempPath =>
-        df.write
-          .format(format)
-          .mode(SaveMode.Overwrite)
-          .options(formatOptions)
-          .save(tempPath.toString)
+    fsUtils.withTempDirectory(new Path(tempHadoopPath)) { tempPath =>
+      df.write
+        .format(format)
+        .mode(SaveMode.Overwrite)
+        .options(formatOptions)
+        .save(tempPath.toString)
 
-        log.info(s"$count records saved to $tempPath.")
+      log.info(s"$count records saved to $tempPath.")
 
-        val cmdLine = getCmdLine(cmdLineTemplate, tempPath, infoDate)
+      val cmdLine = getCmdLine(cmdLineTemplate, tempPath, infoDate)
 
-        runCmd(cmdLine)
+      runCmd(cmdLine)
 
-        log.info(s"$count records sent to the cmd line sink ($cmdLine).")
-      }
-
-      count
-    } else {
-      log.info(s"Notting to send to $cmdLineTemplate.")
-      0L
+      log.info(s"$count records sent to the cmd line sink ($cmdLine).")
     }
+
+    count
   }
 
   private[core] def getCmdLine(cmdLineTemplate: String,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
@@ -28,11 +28,13 @@ class IdentityTransformer extends Transformer {
       throw new IllegalArgumentException(s"Option 'table' is not defined")
     }
 
+    val emptyAllowed = options.getOrElse("empty.allowed", "true").toBoolean
+
     val tableName = options("table")
 
     val df = metastore.getTable(tableName, Option(infoDate), Option(infoDate))
 
-    if (df.count() > 0) {
+    if (df.count() > 0 || emptyAllowed) {
       Reason.Ready
     } else {
       Reason.NotReady(s"No data for '$tableName' at $infoDate")

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceSuite.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.pramen.core.metastore.persistence
 
-import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.scalatest.{Assertion, WordSpec}
 import za.co.absa.pramen.api.Query
@@ -218,6 +218,15 @@ class MetastorePersistenceSuite extends WordSpec with SparkTestBase with TempDir
 
     assert(stats.recordCount == 3)
     assert(stats.dataSizeBytes.exists(_ > 0))
+  }
+
+  def testStatsAvailableForEmptyTable(mtp: MetastorePersistence): Assertion = {
+    mtp.saveTable(infoDate, getDf.filter(col("b") > 10), Some(0))
+
+    val stats = mtp.getStats(infoDate)
+
+    assert(stats.recordCount == 0)
+    assert(stats.dataSizeBytes.contains(0L))
   }
 
   def testStatsNotAvailable(mtp: MetastorePersistence): Assertion = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -27,7 +27,7 @@ import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TextComparisonFixtu
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.mocks.metastore.MetastoreSpy
-import za.co.absa.pramen.core.pipeline.IngestionJob._
+import za.co.absa.pramen.core.pipeline.JobBase._
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.source.SourceManager.getSourceByName
 import za.co.absa.pramen.core.utils.SparkUtils

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -19,7 +19,6 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.apache.spark.sql.DataFrame
 import org.scalatest.WordSpec
-import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{Query, Reason}
 import za.co.absa.pramen.core.OperationDefFactory
 import za.co.absa.pramen.core.base.SparkTestBase
@@ -28,10 +27,10 @@ import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TextComparisonFixtu
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.mocks.metastore.MetastoreSpy
+import za.co.absa.pramen.core.pipeline.IngestionJob._
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.source.SourceManager.getSourceByName
 import za.co.absa.pramen.core.utils.SparkUtils
-import za.co.absa.pramen.core.pipeline.IngestionJob._
 
 import java.sql.SQLSyntaxErrorException
 import java.time.{Instant, LocalDate}
@@ -150,13 +149,15 @@ class IngestionJobSuite extends WordSpec with SparkTestBase with TextComparisonF
 
           assert(result.status == JobPreRunStatus.NoData)
         }
+      }
 
+      "track insufficient data" when {
         "some records, custom minimum records" in {
           val (_, _, job) = getUseCase(minRecords = Some(4))
 
           val result = job.preRunCheckJob(infoDate, conf, Nil)
 
-          assert(result.status == JobPreRunStatus.NoData)
+          assert(result.status == JobPreRunStatus.InsufficientData(3, 4))
         }
       }
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/sink/LocalCsvSinkSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/sink/LocalCsvSinkSuite.scala
@@ -195,6 +195,16 @@ class LocalCsvSinkSuite extends WordSpec with SparkTestBase with TempDirFixture 
     }
   }
 
+  "getFinalFileName()" should {
+    "add the path and file extension to the file name" in {
+      val sink = getUseCase("/dummy", "A_@tableName_@infoDate")
+
+      val actual = sink.getFinalFileName("table1", infoDate, "/bigdata")
+
+      assert(actual == "/bigdata/A_table1_2022-02-18.csv")
+    }
+  }
+
   "convertDateTimeToString()" should {
     "convert date and timestamp fields to strings of the given format" in {
       val expected =


### PR DESCRIPTION
Adds a new parameter for specifying the minimum records required for
- Ingestion
- Sending data to a sink

Transformations can now run on date ranges containing 0 records, as long as ingestion and previous steps have succeeded.

![Screenshot 2022-11-08 at 16 11 36](https://user-images.githubusercontent.com/4082463/200602369-f79cd5b1-dd5b-4227-a9f3-b26709baa0cc.png)
