### PR TITLE
#113 Improved rendering of config arrays and objects in logs.

### DIFF
--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ConfigUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ConfigUtilsSuite.scala
@@ -221,6 +221,18 @@ class ConfigUtilsSuite extends AnyWordSpec with TempDirFixture with TextComparis
     }
   }
 
+  "getFlatConfigOfPrimitiveValues()" should {
+    "flatten the config including the arrays and objects" in {
+      val flat = ConfigUtils.getFlatConfigOfPrimitiveValues(testConfig)
+
+      assert(flat("mytest.password") == "xyz")
+      assert(flat("mytest.days.ok").asInstanceOf[util.ArrayList[Int]].asScala.toList == List(1, 2, 3))
+      assert(flat("mytest.object.array[0].numbers").asInstanceOf[util.ArrayList[Int]].asScala.toList == List(1, 2, 3))
+      assert(flat("mytest.object.array[0].options[1].opt2") == 200)
+      assert(flat("mytest.object.array[1].name") == "b")
+    }
+  }
+
   "getRedactedFlatConfig()" should {
     "redact keys containing the list of tokens" in {
       val flat = ConfigUtils.getRedactedFlatConfig(ConfigUtils.getFlatConfig(testConfig),


### PR DESCRIPTION
Improved rendering of config trees. Now arrays and objects are flattened and every line of the rendered config corresponds to a primitive value or array of primitive values. 

```
pramen.sources[0].factory.class="za.co.absa.pramen.core.source.SparkSource"
pramen.sources[0].name="csv"
pramen.sources[0].format="csv"
pramen.sources[0].notification.targets=["a"  "b"  "c"]
...
pramen.sources[1].jdbc.password=[ redacted ]
...
```
Because of the flattened keys like `pramen.sources[1].jdbc.password`, the `getRedactedFlatConfig()` method should now work properly on matching the "password" token inside the key and redacting the value. Before, the password was hiding inside `pramen.sources` array as a value and was not redacted.

I was thinking how to do this in a nice way and discovered the `ConfigValue`, `ConfigList` and `ConfigObject` interfaces which can be pattern matched against to traverse the config tree. `ConfigValueType` can then be used to check if the `ConfigList` only consists of primitive types. 

# Some ideas for discussion

I don't know if `getFlatConfigOfPrimitiveValues()` is a good name.

I only substituted the `getFlatConfig()` for the new `getFlatConfigOfPrimitiveValues()` in `logEffectiveConfigProps()` function which logs the config when running a pipeline. But I did not substitute it in other uses of `getFlatConfig()` (for example, creating .properties from the Config for Kafka configuration or rendering the smtp config in Sendable, `getExtraOptions()`) because in those other places, it may be undesirable.

