### PR TITLE
#85 Implement passing of format-specific options to pramen-py MetaSto…

### DIFF
--- a/pramen-py/src/pramen_py/metastore/writer.py
+++ b/pramen-py/src/pramen_py/metastore/writer.py
@@ -72,9 +72,9 @@ class MetastoreWriter(MetastoreWriterBase):
         df_repartitioned, count_df_items = self._apply_repartitioning(
             df_dropped, metastore_table.records_per_partition
         )
-        df_repartitioned.write.format("parquet").mode("overwrite").save(
-            target_path
-        )
+        df_repartitioned.write.options(
+            **metastore_table.writer_options
+        ).format("parquet").mode("overwrite").save(target_path)
         return target_path, count_df_items
 
     def _write_delta_format_table(
@@ -95,6 +95,7 @@ class MetastoreWriter(MetastoreWriterBase):
                 "replaceWhere",
                 f"{metastore_table.info_date_settings.column}='{self.info_date}'",
             )
+            .options(**metastore_table.writer_options)
         )
         if metastore_table.path:
             df_writer.save(metastore_table.path)

--- a/pramen-py/src/pramen_py/models/__init__.py
+++ b/pramen-py/src/pramen_py/models/__init__.py
@@ -71,6 +71,8 @@ class MetastoreTable:
     table: str = attrs.field(default="")
     description: str = attrs.field(default="")
     records_per_partition: int = attrs.field(default=500000)
+    reader_options: Dict[str, str] = attrs.field(factory=dict)
+    writer_options: Dict[str, str] = attrs.field(factory=dict)
 
     def __attrs_post_init__(self) -> None:
         default_fs = env.str("PRAMENPY_DEFAULT_FS", "hdfs").strip('"')

--- a/pramen-py/tests/resources/real_config.yaml
+++ b/pramen-py/tests/resources/real_config.yaml
@@ -37,6 +37,8 @@ metastore_tables:
   #  to identify the fs. Default fs is hdfs:///
   path: /tmp/dummy/table1
   records_per_partition: 1000000
+  reader_options: {}
+  writer_options: {}
 - description: Output table
   format: parquet
   info_date_settings:
@@ -45,3 +47,7 @@ metastore_tables:
     start: 2017-01-29
   name: table_out1
   path: /tmp/dummy/table_out1
+  reader_options:
+    mergeSchema: false
+  writer_options:
+    compression: snappy

--- a/pramen-py/tests/resources/test_metastore.conf
+++ b/pramen-py/tests/resources/test_metastore.conf
@@ -41,6 +41,12 @@ pramen.metastore {
       name = "teller"
       format = "delta"
       table = "teller"
+      read.option {
+        mergeSchema = "false"
+      }
+      write.option {
+        mergeSchema = "true"
+      }
     },
   ]
 }

--- a/pramen-py/tests/test_app/test_config_serialization.py
+++ b/pramen-py/tests/test_app/test_config_serialization.py
@@ -108,6 +108,8 @@ def test_structured_config_is_deserialized_properly(repo_root, monkeypatch):
                     "start": "2017-01-31",
                 },
                 "records_per_partition": 1000000,
+                "reader_options": {},
+                "writer_options": {},
             },
             {
                 "name": "table_out1",
@@ -120,6 +122,8 @@ def test_structured_config_is_deserialized_properly(repo_root, monkeypatch):
                     "start": "2017-01-29",
                 },
                 "records_per_partition": 500000,
+                "reader_options": {"mergeSchema": "false"},
+                "writer_options": {"compression": "snappy"},
             },
         ],
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -220,12 +220,17 @@ class PythonTransformationJob(operationDef: OperationDef,
         case _                     => ""
       }
 
+      val readOptions = addOptions(mt.readOptions, "reader_options")
+      val writeOptions = addOptions(mt.writeOptions, "writer_options")
+
       s"""- name: ${escapeString(mt.name)}$description
          |  format: ${mt.format.name}$path$recordsPerPartition
          |  info_date_settings:
          |    column: ${escapeString(mt.infoDateColumn)}
          |    format: ${escapeString(mt.infoDateFormat)}
-         |    start: ${mt.infoDateStart.toString}""".stripMargin
+         |    start: ${mt.infoDateStart.toString}
+         |$readOptions
+         |$writeOptions""".stripMargin
     }
 
     val sb = new mutable.StringBuilder()

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -32,13 +32,16 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
                    stats: MetaTableStats = MetaTableStats(0, None),
                    statsException: Throwable = null,
                    isTableAvailable: Boolean = true,
-                   isTableEmpty: Boolean = false) extends Metastore {
+                   isTableEmpty: Boolean = false,
+                   readOptions: Map[String, String] = Map.empty[String, String],
+                   writeOptions: Map[String, String] = Map.empty[String, String]) extends Metastore {
 
   val saveTableInvocations = new ListBuffer[(String, LocalDate, DataFrame)]
 
   override def getRegisteredTables: Seq[String] = registeredTables
 
-  override def getRegisteredMetaTables: Seq[MetaTable] = registeredTables.map(t => MetaTableFactory.getDummyMetaTable(t))
+  override def getRegisteredMetaTables: Seq[MetaTable] = registeredTables
+    .map(t => MetaTableFactory.getDummyMetaTable(t, readOptions = readOptions, writeOptions = writeOptions))
 
   override def isTableAvailable(tableName: String, infoDate: LocalDate): Boolean = registeredTables.contains(tableName) && availableDates.contains(infoDate)
 


### PR DESCRIPTION
Implemented passing of format-specific options from Pramen (HOCON config) to Pramen-Py (YAML config). 

HOCON config example:
```hocon
pramen.metastore {
  tables = [
    {
        name = "table"
        format = "parquet"
        path = "/some/path"
        read.option {
          compression = "gzip"
          mergeSchema = "true"
        }
        write.option {
          compression = "gzip"
        }
    },
  ]
}
```

Generated YAML which is then passed to Pramen-Py:
```yaml
metastore_tables:
- name: table
  format: parquet
  path: /some/path
  records_per_partition: 500000
  info_date_settings:
    column: pramen_info_date
    format: yyyy-MM-dd
    start: 2020-01-01
  reader_options:
    compression: "gzip"
  writer_options:
    compression: gzip
```

## Somes ideas for discussion
* on Scala side, I modified `MetastoreSpy` to allow specifying `readOptions` and `writeOptions` but those options are then applied to every mocked metastore table. I did this for simplicity reasons but is that ok/clean?
* on Python side, I kind of wrote "dumb" tests 😃 (one function per test, not any parametrization). I was toying with `@pytest.mark.parametrize` but the variation of my test cases was too big and I thought the intention of what is tested was lost. But happy to revise and rework it to a different form or to use the parametrization since I understand the tests maybe don't exactly match the repo's style.