### PR TITLE
#122 allow overriding root log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2082,13 +2082,14 @@ Specify which dates to run:
 
 Execution options:
 
-| Argument          | Example             | Description                                                                                                                                                                                                         |
-|-------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --dry-run         | `--dry-run`         | If specified the pipeline won't be executed. Pramen will print which job it would have run.                                                                                                                         |
-| --verbose         | `--verbose`         | If specified, application logs will include more Spark execution details.                                                                                                                                           |
-| --check-late-only | `--check-late-only` | If specified, Pramen will do only late data checks and checks for retrospective updates. It won't run jobs that are not yet late. Useful for catch-up job schedules.                                                |
-| --check-new-only  | `--check-new-only`  | If specified, Pramen will not check for late and updated data and will run only jobs scheduled for the current date.                                                                                                |
-| --undercover      | `--undercover`      | If specified, Pramen will not update bookkeeper so any changes caused by the pipeline won't be recorded. Useful for re-running historical transformations without triggering execution of the rest of the pipeline. |
+| Argument             | Example                     | Description                                                                                                                                                                                                         |
+|----------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --dry-run            | `--dry-run`                 | If specified the pipeline won't be executed. Pramen will print which job it would have run.                                                                                                                         |
+| --verbose            | `--verbose`                 | If specified, application logs will include more Spark execution details.                                                                                                                                           |
+| --override-log-level | `--override-log-level INFO` | Overrides environment configured root log level.                                                                                                                                                                    |
+| --check-late-only    | `--check-late-only`         | If specified, Pramen will do only late data checks and checks for retrospective updates. It won't run jobs that are not yet late. Useful for catch-up job schedules.                                                |
+| --check-new-only     | `--check-new-only`          | If specified, Pramen will not check for late and updated data and will run only jobs scheduled for the current date.                                                                                                |
+| --undercover         | `--undercover`              | If specified, Pramen will not update bookkeeper so any changes caused by the pipeline won't be recorded. Useful for re-running historical transformations without triggering execution of the rest of the pipeline. |
 
 ### Command line examples
 

--- a/pramen/runner/src/main/scala/za/co/absa/pramen/runner/RunnerCommons.scala
+++ b/pramen/runner/src/main/scala/za/co/absa/pramen/runner/RunnerCommons.scala
@@ -32,7 +32,11 @@ object RunnerCommons {
   private val log = LoggerFactory.getLogger(this.getClass)
 
   def getMainContext(args: Array[String]): Config = {
+    val rootLogger = Logger.getRootLogger
+
     val cmdLineConfig = CmdLineConfig(args)
+
+    cmdLineConfig.overrideLogLevel.foreach(level => rootLogger.setLevel(Level.toLevel(level)))
 
     if (cmdLineConfig.files.nonEmpty) {
       val hadoopConfig = new Configuration()

--- a/pramen/runner/src/main/scala/za/co/absa/pramen/runner/cmd/CmdLineConfig.scala
+++ b/pramen/runner/src/main/scala/za/co/absa/pramen/runner/cmd/CmdLineConfig.scala
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter
 import scala.collection.JavaConverters.asJavaIterableConverter
 
 case class CmdLineConfig(
-                          configPathName: String = "",
+                          configPathName: Option[String] = None,
                           files: Seq[String] = Seq.empty[String],
                           operations: Seq[String] = Seq.empty[String],
                           currentDate: Option[LocalDate] = None,
@@ -171,7 +171,7 @@ object CmdLineConfig {
     var rawFormat: Option[String] = None
 
     opt[String]("workflow").optional().action((value, config) =>
-      config.copy(configPathName = value))
+      config.copy(configPathName = Option(value)))
       .text("Path to a workflow configuration")
 
     opt[String]("files").optional().action((value, config) =>

--- a/pramen/runner/src/main/scala/za/co/absa/pramen/runner/cmd/CmdLineConfig.scala
+++ b/pramen/runner/src/main/scala/za/co/absa/pramen/runner/cmd/CmdLineConfig.scala
@@ -43,7 +43,8 @@ case class CmdLineConfig(
                           mode: String = "",
                           inverseOrder: Option[Boolean] = None,
                           tableNum: Option[Int] = None,
-                          verbose: Option[Boolean] = None
+                          verbose: Option[Boolean] = None,
+                          overrideLogLevel: Option[String] = None
                         )
 
 object CmdLineConfig {
@@ -75,7 +76,8 @@ object CmdLineConfig {
       "[--date-from <date_from>]" +
       "[--date-to <date_to>]" +
       "[--run-mode { fill_gaps | check_updates | force }]" +
-      "[--inverse-order <true/false>]"
+      "[--inverse-order <true/false>]" +
+      "[--override-log-level <log_level>]"
     )
 
     parser.parse(args, CmdLineConfig())
@@ -236,6 +238,10 @@ object CmdLineConfig {
     opt[Unit]("verbose").optional().action((_, config) =>
       config.copy(verbose = Some(true)))
       .text("When specified, more detailed logs will be generated.")
+
+    opt[String]("override-log-level").optional().action((value, config) =>
+      config.copy(overrideLogLevel = Option(value)))
+      .text("Override environment configured root log level.")
 
     help("help").text("prints this usage text")
   }

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
@@ -94,6 +94,12 @@ class CmdLineLineConfigSuite extends AnyWordSpec {
         val cmd = CmdLineConfig.parseCmdLine(Array("--workflow", "dummy.config", "--rerun", "16/08/2020"))
         assert(cmd.isEmpty)
       }
+
+      "support log level override" in {
+        val cmd = CmdLineConfig.parseCmdLine(Array("--workflow", "dummy.config", "--override-log-level", "INFO"))
+        assert(cmd.nonEmpty)
+        assert(cmd.get.overrideLogLevel.contains("INFO"))
+      }
     }
   }
 

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
@@ -46,7 +46,7 @@ class CmdLineLineConfigSuite extends AnyWordSpec {
       "parse workflow location" in {
         val cmd = CmdLineConfig.parseCmdLine(Array("--workflow", "dummy.config"))
         assert(cmd.nonEmpty)
-        assert(cmd.get.configPathName == "dummy.config")
+        assert(cmd.get.configPathName.contains("dummy.config"))
         assert(cmd.get.dryRun.isEmpty)
         assert(cmd.get.undercover.isEmpty)
         assert(cmd.get.useLock.isEmpty)


### PR DESCRIPTION
The reason for the PR is that some environments have WARN as the default root level, possibly to make notebook output  quiet. But Pramen logs are unless at WARN level. So I'e introduced a command line argument that can override the root log level of log4j.