### PR TITLE
#115 Add Spark sink

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/LocalCsvSink.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/LocalCsvSink.scala
@@ -135,7 +135,7 @@ class LocalCsvSink(sinkConfig: Config,
       createCsvFromDf(df, count, tableName, infoDate, outputPath)
       count
     } else {
-      log.info(s"Notting to send to $outputPath.")
+      log.info(s"Nothing to send to $outputPath.")
       if (params.createEmptyCsv) {
         createEmptyCsv(df.schema, tableName, infoDate, outputPath)
       }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/SparkSink.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/SparkSink.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.sink
+
+import com.typesafe.config.Config
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.{ExternalChannelFactory, MetastoreReader, Sink}
+import za.co.absa.pramen.core.config.Keys.KEYS_TO_REDACT
+import za.co.absa.pramen.core.utils.ConfigUtils
+
+import java.time.LocalDate
+
+/**
+  * This sink allows writing data using Spark, similarly as you would do using 'df.write.format(...).save(...)'.
+  *
+  * In order to use the sink you need to define sink parameters.
+  *
+  * Example sink definition:
+  * {{{
+  *  {
+  *    # Define a name to reference from the pipeline:
+  *    name = "spark_sink"
+  *    factory.class = "za.co.absa.pramen.core.sink.SparkSink"
+  *
+  *    # Output format. Can be: csv, parquet, json, delta, etc (anything supported by Spark). Default: parquet
+  *    format = "parquet"
+  *
+  *    # Save mode. Can be overwrite, append, ignore, errorifexists. Default: errorifexists
+  *    mode = "overwrite"
+  *
+  *    ## Only one of these following two options should be specified
+  *    # Optionally repartition the dataframe according to the specified number of partitions
+  *    number.of.partitions = 10
+  *    # Optionally repartition te dataframe according to the number of records per partition
+  *    records.per.partition = 1000000
+  *
+  *    # If true (default), the data will be saved even if it does not contain any records. If false, the saving will be skipped
+  *    save.empty = true
+  *
+  *    # If non-empty, the data will be partitioned by the specified columns at the output path. Default: []
+  *    partition.by = [ pramen_info_date ]
+  *
+  *    # These are additional option passed to the writer as 'df.write(...).options(...)
+  *    option {
+  *      compression = "gzip"
+  *    }
+  *  }
+  * }}}
+  *
+  * Here is an example of a sink definition in a pipeline. As for any other operation you can specify
+  * dependencies, transformations, filters and columns to select.
+  *
+  * {{{
+  *  {
+  *    name = "Spark sink"
+  *    type = "sink"
+  *    sink = "spark_sink"
+  *
+  *    schedule.type = "daily"
+  *
+  *    # Optional dependencies
+  *    dependencies = [
+  *      {
+  *        tables = [ dependent_table ]
+  *        date.from = "@infoDate"
+  *      }
+  *    ]
+  *
+  *    tables = [
+  *      {
+  *        input.metastore.table = metastore_table
+  *        output.path = "/datalake/base/path"
+  *
+  *        # Date range to read the source table for. By default the job information date is used.
+  *        # But you can define an arbitrary expression based on the information date.
+  *        # More: see the section of documentation regarding date expressions, an the list of functions allowed.
+  *        date {
+  *          from = "@infoDate"
+  *          to = "@infoDate"
+  *        }
+  *
+  *        transformations = [
+  *         { col = "col1", expr = "lower(some_string_column)" }
+  *        ],
+  *        filters = [
+  *          "some_numeric_column > 100"
+  *        ]
+  *        columns = [ "col1", "col2", "col2", "some_numeric_column" ]
+  *
+  *        # This overrides options of the sink
+  *        sink {
+  *          mode = "append"
+  *
+  *          # These are additional options passed to the writer as 'df.write(...).options(...)'
+  *          option {
+  *             compression = "snappy"
+  *          }
+  *        }
+  *      }
+  *    ]
+  *  }
+  * }}}
+  *
+  */
+class SparkSink(format: String,
+                formatOptions: Map[String, String],
+                mode: String,
+                partitionBy: Seq[String],
+                numberOfPartitions: Option[Int],
+                recordsPerPartition: Option[Long],
+                saveEmpty: Boolean,
+                sinkConfig: Config) extends Sink {
+
+  import za.co.absa.pramen.core.sink.SparkSink._
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override val config: Config = sinkConfig
+
+  override def connect(): Unit = {}
+
+  override def close(): Unit = {}
+
+  override def send(df: DataFrame,
+                    tableName: String,
+                    metastore: MetastoreReader,
+                    infoDate: LocalDate,
+                    options: Map[String, String])
+                   (implicit spark: SparkSession): Long = {
+    val outputPath = getOutputPath(tableName, options)
+    val recordCount = df.count()
+
+    if (recordCount > 0 || saveEmpty) {
+      log.info(s"Saving $recordCount records to folder: ${outputPath.toUri.toString}")
+      log.info(s"Options passed for '$format':")
+      ConfigUtils.renderExtraOptions(formatOptions, KEYS_TO_REDACT)(log.info)
+
+      val dfToWrite = applyRepartitioning(df, recordCount, tableName)
+      writeData(dfToWrite, outputPath)
+    } else {
+      log.info(s"Nothing to save to folder: ${outputPath.toUri.toString}")
+    }
+
+    recordCount
+  }
+
+  private[core] def writeData(df: DataFrame, outputPath: Path): Unit = {
+    df
+      .write
+      .partitionBy(partitionBy: _*)
+      .format(format)
+      .mode(mode)
+      .options(formatOptions)
+      .save(outputPath.toUri.toString)
+  }
+
+  private[core] def applyRepartitioning(df: DataFrame, recordCount: Long, tableName: String): DataFrame = {
+    (numberOfPartitions, recordsPerPartition) match {
+      case (Some(_), Some(_)) =>
+        throw new IllegalArgumentException(
+          s"Both $NUMBER_OF_PARTITIONS_KEY and $RECORDS_PER_PARTITION_KEY are specified for Spark sink," +
+            s"table: $tableName. Please specify only one of those options")
+      case (Some(nop), None) =>
+        log.info(s"Repartitioning to $nop partitions")
+        df.repartition(nop)
+      case (None, Some(rpp)) =>
+        val n = Math.max(1, Math.ceil(recordCount.toDouble / rpp)).toInt
+        log.info(s"Repartitioning to $n partitions")
+        df.repartition(n)
+      case (None, None) =>
+        df
+    }
+  }
+
+  private[core] def getOutputPath(tableName: String, options: Map[String, String]): Path = {
+    if (!options.contains(OUTPUT_PATH_KEY)) {
+      throw new IllegalArgumentException(s"$OUTPUT_PATH_KEY is not specified for Spark sink, table: $tableName")
+    }
+
+    new Path(options(OUTPUT_PATH_KEY))
+  }
+
+}
+
+object SparkSink extends ExternalChannelFactory[SparkSink] {
+  val OUTPUT_PATH_KEY = "path"
+
+  val FORMAT_KEY = "format"
+  val MODE_KEY = "mode"
+  val PARTITION_BY_KEY = "partition.by"
+  val NUMBER_OF_PARTITIONS_KEY = "number.of.partitions"
+  val RECORDS_PER_PARTITION_KEY = "records.per.partition"
+  val SAVE_EMPTY_KEY = "save.empty"
+
+  val DEFAULT_FORMAT = "parquet"
+  val DEFAULT_MODE = "errorifexists"
+  val DEFAULT_SAVE_EMPTY = true
+
+  override def apply(conf: Config, parentPath: String, spark: SparkSession): SparkSink = {
+    new SparkSink(
+      ConfigUtils.getOptionString(conf, FORMAT_KEY).getOrElse(DEFAULT_FORMAT),
+      ConfigUtils.getExtraOptions(conf, "option"),
+      ConfigUtils.getOptionString(conf, MODE_KEY).getOrElse(DEFAULT_MODE),
+      ConfigUtils.getOptListStrings(conf, PARTITION_BY_KEY),
+      ConfigUtils.getOptionInt(conf, NUMBER_OF_PARTITIONS_KEY),
+      ConfigUtils.getOptionLong(conf, RECORDS_PER_PARTITION_KEY),
+      ConfigUtils.getOptionBoolean(conf, SAVE_EMPTY_KEY).getOrElse(DEFAULT_SAVE_EMPTY),
+      conf
+    )
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/sink/SparkSinkSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/sink/SparkSinkSuite.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.sink
+
+import com.typesafe.config.ConfigFactory
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.DataFrame
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.TempDirFixture
+import za.co.absa.pramen.core.utils.FsUtils
+
+import java.time.LocalDate
+
+class SparkSinkSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
+
+  import spark.implicits._
+
+  private val infoDate = LocalDate.of(2022, 2, 18)
+
+  private def inputDf: DataFrame = List(
+    ("A", 1, "2022-02-18"),
+    ("B", 2, "2022-02-18"),
+    ("C", 3, "2022-02-18")
+  ).toDF("a", "b", "info_date")
+
+  "apply()" should {
+    "construct a sink from config" in {
+      val conf = ConfigFactory.parseString(
+        """  format = "csv"
+          |  mode = "overwrite"
+          |  records.per.partition = 1
+          |  partition.by = [ info_date ]
+          |  save.empty = false
+          |
+          |  options {
+          |    compression = gzip
+          |  }
+          |""".stripMargin
+      )
+      val sink = SparkSink(conf, "parent", spark)
+
+      assert(sink.isInstanceOf[SparkSink])
+    }
+  }
+
+  def testWithDataFrameSentToSink(dataFrame: DataFrame, sink: SparkSink)(test: (FsUtils, Path) => Unit): Unit = {
+    withTempDirectory("spark_sink_write_test") { tempDir =>
+      val workingDirectory = new Path(tempDir)
+      val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, workingDirectory.toUri.toString)
+
+      sink.send(
+        dataFrame,
+        "dummy_table",
+        null,
+        infoDate,
+        Map("path" -> workingDirectory.toUri.toString)
+      )
+
+      test(fsUtils, workingDirectory)
+    }
+  }
+
+  "connect()" should {
+    "do nothing" in {
+      val sink = getUseCase()
+
+      sink.connect()
+    }
+  }
+
+  "close()" should {
+    "do nothing" in {
+      val sink = getUseCase()
+
+      sink.close()
+    }
+  }
+
+  "send()" should {
+    "write data to the target directory with specified partition structure" in {
+      val sink = getUseCase(partitionBy = Seq("info_date", "b"))
+
+      testWithDataFrameSentToSink(inputDf, sink) { (fsUtils, outputDir) =>
+        val partitionDirectory = new Path(outputDir, "info_date=2022-02-18/b=2")
+
+        assert(fsUtils.exists(partitionDirectory))
+        assert(fsUtils.getFilesRecursive(partitionDirectory, "*.parquet").nonEmpty)
+      }
+    }
+
+    "write data based on specified format and format options" in {
+      val sink = getUseCase(
+        format = "csv",
+        formatOptions = Map(
+          "compression" -> "gzip"
+        )
+      )
+
+      testWithDataFrameSentToSink(inputDf, sink) { (fsUtils, outputDir) =>
+        assert(fsUtils.getFilesRecursive(outputDir, "*.csv.gz").nonEmpty)
+      }
+    }
+
+    "write data based on specified mode" in {
+      withTempDirectory("spark_sink") { tempDir =>
+        val dfToAppend = Seq(
+          (1, 2)
+        ).toDF("a", "b")
+        val sinkWithAppendMode = getUseCase(mode = "append")
+        val outputDir = new Path(tempDir)
+        val options = Map("path" -> outputDir.toUri.toString)
+
+        sinkWithAppendMode.send(dfToAppend, "dummy_table", null, infoDate, options)
+        sinkWithAppendMode.send(dfToAppend, "dummy_table", null, infoDate, options)
+
+        val writtenDF = spark.read.parquet(outputDir.toUri.toString)
+        assert(writtenDF.count() == 2)
+      }
+    }
+
+    "partition the data based on specified records per partition" in {
+      val sink = getUseCase(recordsPerPartition = Some(1L))
+
+      testWithDataFrameSentToSink(inputDf, sink) { (fsUtils, outputDir) =>
+        val partitions = fsUtils.getFilesRecursive(outputDir, "*.parquet")
+        assert(partitions.size == 3)
+      }
+    }
+
+    "partition the data based on specified number of partitions" in {
+      val sink = getUseCase(numberOfPartitions = Some(2))
+
+      testWithDataFrameSentToSink(inputDf, sink) { (fsUtils, outputDir) =>
+        val partitions = fsUtils.getFilesRecursive(outputDir, "*.parquet")
+        assert(partitions.size == 2)
+      }
+    }
+
+    "save dataframe even if it is empty" in {
+      val emptyDataFrame = spark.emptyDataset[String].toDF("some_col")
+      val sink = getUseCase(saveEmpty = true)
+
+      testWithDataFrameSentToSink(emptyDataFrame, sink) { (fsUtils, outputDir) =>
+        val writtenDf = spark.read.parquet(outputDir.toUri.toString)
+        assert(writtenDf.count() == 0)
+        assert(fsUtils.getFilesRecursive(outputDir, "*.parquet").nonEmpty)
+      }
+    }
+
+    "if specified, not save an empty dataframe" in {
+      val emptyDataFrame = spark.emptyDataset[String].toDF("some_col")
+      val sink = getUseCase(saveEmpty = false)
+
+      testWithDataFrameSentToSink(emptyDataFrame, sink) { (fsUtils, outputDir) =>
+        assert(fsUtils.getFilesRecursive(outputDir, "*.parquet").isEmpty)
+      }
+    }
+
+    "throw an exception when of both records per partition and number of partitions are specified" in {
+      val sink = getUseCase(
+        numberOfPartitions = Some(2),
+        recordsPerPartition = Some(4L)
+      )
+
+      val ex = intercept[IllegalArgumentException] {
+        sink.send(inputDf, "dummy_table", null, infoDate, Map("path" -> "/does/not/exist"))
+      }
+
+      assert(ex.getMessage.contains("Both number.of.partitions and records.per.partition are specified for Spark sink"))
+      assert(ex.getMessage.contains("Please specify only one of those options"))
+    }
+
+    "throw an exception if output path is not specified" in {
+      val sink = getUseCase()
+
+      val ex = intercept[IllegalArgumentException] {
+        sink.send(inputDf, "dummy_table", null, infoDate, Map.empty)
+      }
+
+      assert(ex.getMessage.contains("path is not specified for Spark sink, table: dummy_table"))
+    }
+  }
+
+  def getUseCase(format: String = "parquet",
+                 formatOptions: Map[String, String] = Map.empty,
+                 mode: String = "overwrite",
+                 partitionBy: Seq[String] = Seq.empty,
+                 numberOfPartitions: Option[Int] = None,
+                 recordsPerPartition: Option[Long] = None,
+                 saveEmpty: Boolean = true
+                 ): SparkSink = {
+    val conf = ConfigFactory.empty()
+    new SparkSink(
+      format,
+      formatOptions,
+      mode,
+      partitionBy,
+      numberOfPartitions,
+      recordsPerPartition,
+      saveEmpty,
+      conf
+    )
+  }
+
+}


### PR DESCRIPTION
Added a simple Spark sink which performs `df.write(...)` under the hood (with options provided by the configuration of the sink).

Below are the possible config options to specify
```config
{
    # Define a name to reference from the pipeline:
    name = "spark_sink"
    factory.class = "za.co.absa.pramen.core.sink.SparkSink"
    
    # Output format. Can be: csv, parquet, json, delta, etc (anything supported by Spark). Default: parquet
    format = "parquet"
    
    # Save mode. Can be overwrite, append, ignore, errorifexists. Default: errorifexists
    mode = "overwrite"
    
    ## Only one of these following two options should be specified
    # Optionally repartition the dataframe according to the specified number of partitions
    number.of.partitions = 10
    # Optionally repartition te dataframe according to the number of records per partition
    records.per.partition = 1000000
    
    # If true (default), the data will be saved even if it does not contain any records. If false, the saving will be skipped
    save.empty = true
    
    # If non-empty, the data will be partitioned by the specified columns at the output path. Default: []
    partition.by = [ pramen_info_date ]
    
    # These are additional option passed to the writer as 'df.write(...).options(...)'
    option {
      compression = "gzip"
    }
}
```

# Ideas for discussion

Both `number.of.partitions` and `records.per.partition` can be set but not both at once.  If both are set, the sink raises IllegalArgumentException. However, this poses problem when we define a sink in `pramen.sinks` with `number.of.partitions = 5` and then override the sink setting in some specific table in `pramen.operations` with `record.per.partition = 50000`. Now both `number.of.partitions` and `records.per.partition` are defined for a table and sink raises IllegalArgumentException. Question is if we should leave it like this and users should use only one of the options for all tables in the operation or we should define some precedence. But precedence has its own problems I think.

I have also added some documentation entries, comments and log messages. However, I am not always the most eloquent person so in case we want some different formulations of the docs I added etc. then write me and I will correct them :)

Some (maybe minor) code issue is that SparkSink can be created with the companion object using a config but then - in the class - we are still using the companion object values NUMBER_OF_PARTITIONS_KEY and RECORDS_PER_PARTITION_KEY to throw exceptions. But those keys are there so that SparkSink class doesn't have to care about the config and the keys in the first place.