### PR TITLE
#132 make command line sink more generic

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/process/ProcessRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/process/ProcessRunner.scala
@@ -42,6 +42,13 @@ trait ProcessRunner {
     * @return stdout lines.
     */
   def getLastStderrLines: Array[String]
+
+  /**
+    * Returns the number of records written if such an expression is specified and encountered.
+    *
+    * @return records written (if available).
+    */
+  def recordCount: Option[Long]
 }
 
 object ProcessRunner {
@@ -50,7 +57,20 @@ object ProcessRunner {
             logStdErr: Boolean = true,
             stdOutLogPrefix: String = "CmdOut",
             stdErrLogPrefix: String = "CmdErr",
-            redirectErrorStream: Boolean = false): ProcessRunner = {
-    new ProcessRunnerImpl(includeOutputLines, logStdOut, logStdErr, stdOutLogPrefix, stdErrLogPrefix, redirectErrorStream)
+            redirectErrorStream: Boolean = false,
+            recordCountRegEx: Option[String] = None,
+            zeroRecordsSuccessRegEx: Option[String] = None,
+            failureRegEx: Option[String] = None,
+            outputFilterRegEx: Seq[String] = Seq.empty[String]): ProcessRunner = {
+    new ProcessRunnerImpl(includeOutputLines,
+      logStdOut,
+      logStdErr,
+      stdOutLogPrefix,
+      stdErrLogPrefix,
+      redirectErrorStream,
+      recordCountRegEx,
+      zeroRecordsSuccessRegEx,
+      failureRegEx,
+      outputFilterRegEx)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/CmdLineSink.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/CmdLineSink.scala
@@ -115,8 +115,8 @@ import scala.util.control.NonFatal
   *
   */
 class CmdLineSink(sinkConfig: Config,
-                  processRunner: ProcessRunner,
-                  dataParams: Option[CmdLineDataParams]
+                  val processRunner: ProcessRunner,
+                  val dataParams: Option[CmdLineDataParams]
                  ) extends Sink {
   private val log = LoggerFactory.getLogger(this.getClass)
 

--- a/pramen/core/src/test/resources/log4j.properties
+++ b/pramen/core/src/test/resources/log4j.properties
@@ -28,5 +28,4 @@ log4j.logger.za.co.absa.pramen.core.runner.task.TaskRunnerParallel=OFF
 log4j.logger.za.co.absa.pramen.core.state.PipelineStateImpl=OFF
 log4j.logger.za.co.absa.pramen.core.utils.ConfigUtils$=OFF
 log4j.logger.za.co.absa.pramen.core.utils.JdbcNativeUtils$=OFF
-log4j.logger.za.co.absa.pramen.extras.sink.EnceladusSink=OFF
 log4j.logger.za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded=OFF

--- a/pramen/core/src/test/resources/log4j2.properties
+++ b/pramen/core/src/test/resources/log4j2.properties
@@ -28,6 +28,4 @@ log4j.logger.za.co.absa.pramen.core.runner.task.TaskRunnerParallel=OFF
 log4j.logger.za.co.absa.pramen.core.state.PipelineStateImpl=OFF
 log4j.logger.za.co.absa.pramen.core.utils.ConfigUtils$=OFF
 log4j.logger.za.co.absa.pramen.core.utils.JdbcNativeUtils$=OFF
-log4j.logger.za.co.absa.pramen.extras.sink.EnceladusSink=OFF
 log4j.logger.za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded=OFF
-

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/ScriptProcessRunnerFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/ScriptProcessRunnerFixture.scala
@@ -68,7 +68,9 @@ trait ScriptProcessRunnerFixture {
                      includeOutputLines: Int = 10,
                      logStdOut: Boolean = true,
                      logStdErr: Boolean = true,
-                     redirectErrorStream: Boolean = false
+                     redirectErrorStream: Boolean = false,
+                     zeroRecordSuccessRegEx: Option[String] = None,
+                     failureRegEx: Option[String] = None
                     )(f: (ProcessRunnerImpl, String) => Unit): Unit = {
     val tmpPath = Files.createTempDirectory("ProcessRunner")
     val pathStr = tmpPath.toAbsolutePath.toString
@@ -90,7 +92,9 @@ trait ScriptProcessRunnerFixture {
     val runner = ProcessRunner(includeOutputLines,
       logStdOut,
       logStdErr,
-      redirectErrorStream = redirectErrorStream).asInstanceOf[ProcessRunnerImpl]
+      redirectErrorStream = redirectErrorStream,
+      zeroRecordsSuccessRegEx = zeroRecordSuccessRegEx,
+      failureRegEx = failureRegEx).asInstanceOf[ProcessRunnerImpl]
 
     f(runner, outputFilePath.toAbsolutePath.toString)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/ScriptProcessRunnerFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/ScriptProcessRunnerFixture.scala
@@ -37,8 +37,20 @@ trait ScriptProcessRunnerFixture {
   def withDummyProcessRunner(includeOutputLines: Int = 10,
                              logStdOut: Boolean = true,
                              logStdErr: Boolean = true,
-                             redirectErrorStream: Boolean = false)(f: ProcessRunnerImpl => Unit): Unit = {
-    val runner = new DummyProcessRunner(includeOutputLines, logStdOut, logStdErr, redirectErrorStream)
+                             redirectErrorStream: Boolean = false,
+                             recordCountRegEx: Option[String] = None,
+                             zeroRecordsSuccessRegEx: Option[String] = None,
+                             failureRegEx: Option[String] = None,
+                             outputFilterRegEx: Seq[String] = Nil
+                            )(f: ProcessRunnerImpl => Unit): Unit = {
+    val runner = new DummyProcessRunner(includeOutputLines,
+      logStdOut,
+      logStdErr,
+      redirectErrorStream,
+      recordCountRegEx,
+      zeroRecordsSuccessRegEx,
+      failureRegEx,
+      outputFilterRegEx)
 
     f(runner)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummyProcessRunner.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummyProcessRunner.scala
@@ -18,16 +18,24 @@ package za.co.absa.pramen.core.mocks
 
 import za.co.absa.pramen.core.process.ProcessRunnerImpl
 
-class DummyProcessRunner(includeOutputLines: Int,
-                         logStdOut: Boolean,
-                         logStdErr: Boolean,
-                         redirectErrorStream: Boolean)
+class DummyProcessRunner(includeOutputLines: Int = 100,
+                         logStdOut: Boolean = true,
+                         logStdErr: Boolean = true,
+                         redirectErrorStream: Boolean = false,
+                         recordCountRegEx: Option[String] = None,
+                         zeroRecordsSuccessRegEx: Option[String] = None,
+                         failureRegEx: Option[String] = None,
+                         outputFilterRegEx: Seq[String] = Nil)
   extends ProcessRunnerImpl(includeOutputLines,
     logStdOut,
     logStdErr,
     "CmdOut",
     "CmdErr",
-    redirectErrorStream) {
+    redirectErrorStream,
+    recordCountRegEx,
+    zeroRecordsSuccessRegEx,
+    failureRegEx,
+    outputFilterRegEx) {
 
   override def run(cmdLine: String): Int = {
     throw new IllegalStateException(s"Cannot run a dummy process.")

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/process/ProcessRunnerSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/process/ProcessRunnerSpy.scala
@@ -24,10 +24,12 @@ class ProcessRunnerSpy(exitCode: Int = 0,
                        stdOutLines: Array[String] = new Array[String](0),
                        stdErrLines: Array[String] = new Array[String](0),
                        runException: Throwable = null,
-                       runFunction: () => Unit = () => {}) extends ProcessRunner {
+                       runFunction: () => Unit = () => {},
+                       recordsCountToReturn: Option[Long] = None) extends ProcessRunner {
   var runCommands = new ListBuffer[String]
   var getLastStdoutLinesCount = 0
   var getLastStderrLinesCount = 0
+  var recordCountCalled = 0
 
   override def run(cmdLine: String): Int = {
     runCommands += cmdLine
@@ -49,5 +51,11 @@ class ProcessRunnerSpy(exitCode: Int = 0,
   override def getLastStderrLines: Array[String] = {
     getLastStderrLinesCount += 1
     stdErrLines
+  }
+
+  override def recordCount: Option[Long] = {
+    recordCountCalled += 1
+
+    recordsCountToReturn
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/process/ProcessRunnerSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/process/ProcessRunnerSpy.scala
@@ -25,7 +25,7 @@ class ProcessRunnerSpy(exitCode: Int = 0,
                        stdErrLines: Array[String] = new Array[String](0),
                        runException: Throwable = null,
                        runFunction: () => Unit = () => {},
-                       recordsCountToReturn: Option[Long] = None) extends ProcessRunner {
+                       recordCountToReturn: Option[Long] = None) extends ProcessRunner {
   var runCommands = new ListBuffer[String]
   var getLastStdoutLinesCount = 0
   var getLastStderrLinesCount = 0
@@ -56,6 +56,6 @@ class ProcessRunnerSpy(exitCode: Int = 0,
   override def recordCount: Option[Long] = {
     recordCountCalled += 1
 
-    recordsCountToReturn
+    recordCountToReturn
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/sink/CmdLineSinkSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/sink/CmdLineSinkSuite.scala
@@ -25,6 +25,7 @@ import za.co.absa.pramen.core.exceptions.CmdFailedException
 import za.co.absa.pramen.core.fixtures.TempDirFixture
 import za.co.absa.pramen.core.mocks.process.ProcessRunnerSpy
 import za.co.absa.pramen.core.sink.CmdLineSink
+import za.co.absa.pramen.core.sink.CmdLineSink.CmdLineDataParams
 
 import java.time.LocalDate
 
@@ -82,7 +83,7 @@ class CmdLineSinkSuite extends AnyWordSpec with SparkTestBase with TempDirFixtur
 
       val cmdTemplate = "--data-path @dataPath --data-uri @dataUri --info-date @infoDate --infoMonth @infoMonth"
 
-      assert(sink.getCmdLine(cmdTemplate, new Path("/dummy/path"), infoDate) ==
+      assert(sink.getCmdLine(cmdTemplate, Some(new Path("/dummy/path")), infoDate) ==
         "--data-path /dummy/path --data-uri /dummy/path --info-date 2021-12-28 --infoMonth 2021-12")
     }
   }
@@ -127,7 +128,13 @@ class CmdLineSinkSuite extends AnyWordSpec with SparkTestBase with TempDirFixtur
                  runFunction: () => Unit = () => {}): (CmdLineSink, ProcessRunnerSpy) = {
     val runner = new ProcessRunnerSpy(exitCode = exitCode, runException = runException, runFunction = runFunction)
 
-    (new CmdLineSink(ConfigFactory.empty(), runner, tempDir, format, options), runner)
+    val dataParams = if (tempDir != null) {
+      Some(CmdLineDataParams(tempDir, format, options))
+    } else {
+      None
+    }
+
+    (new CmdLineSink(ConfigFactory.empty(), runner, dataParams), runner)
   }
 
 }

--- a/pramen/extras/src/test/resources/log4j.properties
+++ b/pramen/extras/src/test/resources/log4j.properties
@@ -21,3 +21,4 @@ log4j.appender.console.Threshold=ERROR
 
 log4j.logger.cmd=ERROR
 log4j.logger.za.co.absa.pramen.DummyProcessRunner=OFF
+log4j.logger.za.co.absa.pramen.extras.sink.EnceladusSink=OFF

--- a/pramen/extras/src/test/resources/log4j2.properties
+++ b/pramen/extras/src/test/resources/log4j2.properties
@@ -21,3 +21,4 @@ log4j.appender.console.Threshold=ERROR
 
 log4j.logger.cmd=ERROR
 log4j.logger.za.co.absa.pramen.DummyProcessRunner=OFF
+log4j.logger.za.co.absa.pramen.extras.sink.EnceladusSink=OFF


### PR DESCRIPTION
Changes:
- `temp.hadoop.path` and `format` are no longer mandatory. If not specified, the data won't be prepared before running the command. The command will just run at the specified scheduled day.
- Added new non-mandatory options:
  - `record.count.regex` - a RegEx expression for extracting the number of records written from the program output.
  - `zero.records.success.regex` -  a RegEx expression for extracting a success of the job with zero records written, if it is different from the one defined at `record.count.regex`.
  - `failure.regex` - a RegEx expression for extracting a success of the job even if the exit code is 0.
  - `output.filter.regex` - a list of RegEx expressions to filter out program's output so logs won't be too big. It can be used to filter out progress lines from the output of legacy tools.