### PR TITLE
#146 Fix failing tests from extras module on Windows.

### DIFF
--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JsonUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JsonUtilsSuite.scala
@@ -30,7 +30,7 @@ class JsonUtilsSuite extends AnyWordSpec {
       |  "longValue" : 10000000000,
       |  "dateValue" : "2020-08-10",
       |  "listStr" : [ "Str1", "Str2" ]
-      |}""".stripMargin
+      |}""".replace("\r", "").stripMargin
 
   "asJson" should {
     "return a JSON representation of a case class" in {
@@ -43,9 +43,9 @@ class JsonUtilsSuite extends AnyWordSpec {
   }
 
   "asJsonPretty" should {
-    "return the number of milliseconds for values less than 1 second" in {
+    "prettify a JSON" in {
       val sample = SampleCaseClass.getDummy
-      val actualJson = JsonUtils.asJsonPretty(sample)
+      val actualJson = JsonUtils.asJsonPretty(sample).replace("\r", "")
 
       assert(actualJson == sampleJson)
     }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/fixtures/TempDirFixture.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/fixtures/TempDirFixture.scala
@@ -71,6 +71,7 @@ trait TempDirFixture {
     val fullPathToTheFile = Paths.get(path, fileName).toString
     val f = new RandomAccessFile(fullPathToTheFile, "rw")
     f.setLength(size)
+    f.close()
   }
 
 }

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/tests/CmdLineLineConfigSuite.scala
@@ -249,7 +249,7 @@ class CmdLineLineConfigSuite extends AnyWordSpec {
       assert(!config.getBoolean(USE_LOCK))
     }
 
-    "return the origina config if undercover is not specified" in {
+    "return the original config if undercover is not specified" in {
       val cmd = CmdLineConfig.parseCmdLine(Array("--workflow", "dummy.config"))
       val config = CmdLineConfig.applyCmdLineToConfig(populatedConfig, cmd.get)
 


### PR DESCRIPTION
In the end, this was a very simple fix (just closing a file in `TempDirFixture`). Although there are some complexities in tests which compare two strings (I will describe them in comments). 