### PR TITLE
Updated Spark Application Name (Syncwatcher -> Pramen)

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
@@ -101,6 +101,6 @@ object PipelineSparkSessionBuilder {
     } else {
       ""
     }
-    s"SyncWatcher$ingestionSuffix"
+    s"Pramen$ingestionSuffix"
   }
 }


### PR DESCRIPTION
Aliaksei noticed that Pramen still registered as "Syncwatcher - <Pipeline name>", simple change to update to Pramen