### PR TITLE
#153 Fix pipeline does not publish task completion events to the journal table.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -24,6 +24,7 @@ import za.co.absa.pramen.core.notify.pipeline.PipelineNotificationBuilderHtml.MI
 import za.co.absa.pramen.core.pipeline.{DependencyFailure, TaskRunReason}
 import za.co.absa.pramen.core.runner.task.RunStatus._
 import za.co.absa.pramen.core.runner.task.{NotificationFailure, TaskResult}
+import za.co.absa.pramen.core.utils.JvmUtils.getShortExceptionDescription
 import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ConfigUtils, StringUtils, TimeUtils}
 
 import java.time._
@@ -341,7 +342,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
       row.append(TextElement(error.notificationTarget))
       row.append(TextElement(error.table))
       row.append(TextElement(error.infoDate.toString))
-      row.append(TextElement(getErrorMessageFromException(error.ex), Style.Error))
+      row.append(TextElement(getShortExceptionDescription(error.ex), Style.Error))
 
       tableBuilder.withRow(row)
     })
@@ -351,14 +352,6 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
 
     builder.withParagraph(notificationErrorsParagraph)
     builder.withTable(tableBuilder)
-  }
-
-  private def getErrorMessageFromException(ex: Throwable): String = {
-    if (ex.getCause == null) {
-      ex.getMessage
-    } else {
-      s"${ex.getMessage} (${ex.getCause.getMessage})"
-    }
   }
 
   private def getThroughputRps(task: TaskResult): TextElement = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -101,7 +101,7 @@ object AppRunner {
                                           state: PipelineState,
                                           appContext: AppContext): Try[TaskRunner] = {
     handleFailure(Try {
-      new TaskRunnerMultithreaded(conf, appContext.bookkeeper, state, appContext.appConfig.runtimeConfig)
+      new TaskRunnerMultithreaded(conf, appContext.bookkeeper, appContext.journal, state, appContext.appConfig.runtimeConfig)
     }, state, "initialization of the task runner")
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
@@ -50,17 +50,16 @@ object RunStatus {
   }
 
   case class MissingDependencies(isFailure: Boolean, tables: Seq[String]) extends RunStatus {
-    override def toString: String = "Missing dependencies"
+    override def toString: String = "Dependent job failed"
 
-    override def getReason(): Option[String] = Option(s"Missing dependencies: ${tables.mkString(", ")}")
+    override def getReason(): Option[String] = Option(s"Dependent job failures: ${tables.mkString(", ")}")
   }
 
   case class FailedDependencies(isFailure: Boolean, failures: Seq[DependencyFailure]) extends RunStatus {
-    override def toString: String = "Failed dependencies"
+    override def toString: String = "Dependency check failed"
 
     override def getReason(): Option[String] = {
-      val failedTables = failures.flatMap(d => d.failedTables ++ d.emptyTables).distinct.sorted
-      Option(s"Failed dependencies for: ${failedTables.mkString(", ")}")
+      Option(s"Dependency check failures: ${failures.map(_.renderText).mkString("; ")}")
     }
   }
 
@@ -75,7 +74,7 @@ object RunStatus {
 
     val isFailure: Boolean = true
 
-    override def getReason(): Option[String] = Option(s"Expected $expected records, but got $actual records")
+    override def getReason(): Option[String] = Option(s"Got $actual, expected at least $expected records")
   }
 
   case object NotRan extends RunStatus {
@@ -91,6 +90,6 @@ object RunStatus {
 
     override def toString: String = "Skipped"
 
-    override def getReason(): Option[String] = Option(msg)
+    override def getReason(): Option[String] = if (msg.isEmpty) None else Option(msg)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerMultithreaded.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerMultithreaded.scala
@@ -19,6 +19,7 @@ package za.co.absa.pramen.core.runner.task
 import com.typesafe.config.Config
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
+import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.pipeline.Task
 import za.co.absa.pramen.core.state.PipelineState
 
@@ -34,8 +35,9 @@ import scala.concurrent.{ExecutionContextExecutorService, Future}
   */
 class TaskRunnerMultithreaded(conf: Config,
                               bookkeeper: Bookkeeper,
+                              journal: Journal,
                               pipelineState: PipelineState,
-                              runtimeConfig: RuntimeConfig) extends TaskRunnerBase(conf, bookkeeper, runtimeConfig, pipelineState) {
+                              runtimeConfig: RuntimeConfig) extends TaskRunnerBase(conf, bookkeeper, journal, runtimeConfig, pipelineState) {
   private val executor: ExecutorService = newFixedThreadPool(runtimeConfig.parallelTasks)
   implicit private val executionContext: ExecutionContextExecutorService = fromExecutorService(executor)
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JvmUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JvmUtils.scala
@@ -21,4 +21,12 @@ import java.lang.management.ManagementFactory
 object JvmUtils {
   // Caching JVM name. In some cases this method can take some time to complete.
   lazy val jvmName: String = ManagementFactory.getRuntimeMXBean.getName
+
+  def getShortExceptionDescription(ex: Throwable): String = {
+    if (ex.getCause == null) {
+      ex.getMessage
+    } else {
+      s"${ex.getMessage} (${ex.getCause.getMessage})"
+    }
+  }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/journal/JournalMock.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/journal/JournalMock.scala
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.core.pipeline
+package za.co.absa.pramen.core.mocks.journal
 
-sealed trait TaskRunReason
+import za.co.absa.pramen.core.journal.Journal
+import za.co.absa.pramen.core.journal.model.TaskCompleted
 
-object TaskRunReason {
-  case object New extends TaskRunReason {
-    override def toString: String = "New"
-  }
+import java.time.Instant
+import scala.collection.mutable.ListBuffer
 
-  case object Update extends TaskRunReason {
-    override def toString: String = "Update"
-  }
+class JournalMock extends Journal {
+  val entries: ListBuffer[TaskCompleted] = new ListBuffer[TaskCompleted]
 
-  case object Rerun extends TaskRunReason {
-    override def toString: String = "Rerun"
-  }
+  override def addEntry(entry: TaskCompleted): Unit = entries += entry
 
-  case object Late extends TaskRunReason {
-    override def toString: String = "Late"
-  }
+  override def getEntries(from: Instant, to: Instant): Seq[TaskCompleted] =
+    entries.filter(e => e.finishedAt >= from.getEpochSecond && e.finishedAt <= to.getEpochSecond).toSeq
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TaskRunReasonSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TaskRunReasonSuite.scala
@@ -16,22 +16,23 @@
 
 package za.co.absa.pramen.core.pipeline
 
-sealed trait TaskRunReason
+import org.scalatest.wordspec.AnyWordSpec
 
-object TaskRunReason {
-  case object New extends TaskRunReason {
-    override def toString: String = "New"
-  }
-
-  case object Update extends TaskRunReason {
-    override def toString: String = "Update"
-  }
-
-  case object Rerun extends TaskRunReason {
-    override def toString: String = "Rerun"
-  }
-
-  case object Late extends TaskRunReason {
-    override def toString: String = "Late"
+class TaskRunReasonSuite extends AnyWordSpec {
+  "TaskRunReason" should {
+    "be able to be rendered as a string" when {
+      "new" in {
+        assert(TaskRunReason.New.toString == "New")
+      }
+      "update" in {
+        assert(TaskRunReason.Update.toString == "Update")
+      }
+      "rerun" in {
+        assert(TaskRunReason.Rerun.toString == "Rerun")
+      }
+      "late" in {
+        assert(TaskRunReason.Late.toString == "Late")
+      }
+    }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.journal
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.journal.model.TaskCompleted
+import za.co.absa.pramen.core.mocks.job.JobSpy
+import za.co.absa.pramen.core.pipeline.{Task, TaskRunReason}
+import za.co.absa.pramen.core.runner.task.{RunInfo, RunStatus, TaskResult}
+
+import java.time.{Instant, LocalDate}
+
+class TaskCompletedSuite extends AnyWordSpec {
+  private val infoDate = LocalDate.of(2022, 1, 18)
+
+  "fromTaskResult" should {
+    "create a TaskCompleted from a TaskResult for a successful task" in {
+      val now = Instant.now()
+      val job = new JobSpy()
+      val runReason = TaskRunReason.Update
+      val task = Task(job, infoDate, runReason)
+      val taskResult = TaskResult(
+        job,
+        RunStatus.Succeeded(Some(1000), 2000, Some(3000), runReason),
+        Some(RunInfo(infoDate, now.minusSeconds(10), now)),
+        Nil,
+        Nil,
+        Nil)
+
+      val taskCompleted = TaskCompleted.fromTaskResult(task, taskResult)
+
+      assert(taskCompleted.jobName == job.name)
+      assert(taskCompleted.tableName == job.outputTable.name)
+      assert(taskCompleted.periodBegin == infoDate)
+      assert(taskCompleted.periodEnd == infoDate)
+      assert(taskCompleted.informationDate == infoDate)
+      assert(taskCompleted.inputRecordCount == 2000)
+      assert(taskCompleted.inputRecordCountOld == 1000)
+      assert(taskCompleted.outputRecordCount.contains(2000))
+      assert(taskCompleted.outputRecordCountOld.contains(1000))
+      assert(taskCompleted.outputSize.contains(3000))
+      assert(taskCompleted.startedAt == now.minusSeconds(10).getEpochSecond)
+      assert(taskCompleted.finishedAt == now.getEpochSecond)
+      assert(taskCompleted.status == "Update")
+      assert(taskCompleted.failureReason.isEmpty)
+    }
+
+    "create a TaskCompleted from a TaskResult for a failed task" in {
+      val now = Instant.now()
+      val job = new JobSpy()
+      val runReason = TaskRunReason.Update
+      val task = Task(job, infoDate, runReason)
+      val taskResult = TaskResult(
+        job,
+        RunStatus.Failed(new IllegalStateException("Dummy Exception")),
+        None,
+        Nil,
+        Nil,
+        Nil)
+
+      val taskCompleted = TaskCompleted.fromTaskResult(task, taskResult)
+
+      assert(taskCompleted.jobName == job.name)
+      assert(taskCompleted.tableName == job.outputTable.name)
+      assert(taskCompleted.periodBegin == infoDate)
+      assert(taskCompleted.periodEnd == infoDate)
+      assert(taskCompleted.informationDate == infoDate)
+      assert(taskCompleted.inputRecordCount == 0)
+      assert(taskCompleted.inputRecordCountOld == 0)
+      assert(taskCompleted.outputRecordCount.isEmpty)
+      assert(taskCompleted.outputRecordCountOld.isEmpty)
+      assert(taskCompleted.outputSize.isEmpty)
+      assert(now.getEpochSecond - taskCompleted.startedAt < 1000)
+      assert(now.getEpochSecond - taskCompleted.finishedAt < 1000)
+      assert(taskCompleted.status == "Failed")
+      assert(taskCompleted.failureReason.exists(_.contains("Dummy Exception")))
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
@@ -27,6 +27,7 @@ import za.co.absa.pramen.core.metastore.MetaTableStats
 import za.co.absa.pramen.core.pipeline.Job
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.mocks.job.JobSpy
+import za.co.absa.pramen.core.mocks.journal.JournalMock
 import za.co.absa.pramen.core.mocks.state.PipelineStateSpy
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunnerImpl
 import za.co.absa.pramen.core.runner.task.RunStatus.{Failed, Succeeded}
@@ -146,6 +147,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
     val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(isRerun = isRerun, runDate = runDateIn)
 
     val bookkeeper = new SyncBookkeeperMock
+    val journal = new JournalMock
 
     val state = new PipelineStateSpy
 
@@ -155,7 +157,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
 
     val job = new JobSpy(runFunction = runFunction, saveStats = stats, allowParallel = allowParallel)
 
-    val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, state, runtimeConfig)
+    val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, journal, state, runtimeConfig)
 
     val jobRunner = new ConcurrentJobRunnerImpl(runtimeConfig, bookkeeper, taskRunner)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/RunStatusSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/RunStatusSuite.scala
@@ -51,13 +51,13 @@ class RunStatusSuite extends AnyWordSpec {
     "MissingDependencies" in {
       val status = RunStatus.MissingDependencies(isFailure = false, null)
 
-      assert(status.toString == "Missing dependencies")
+      assert(status.toString == "Dependent job failed")
     }
 
     "FailedDependencies" in {
       val status = RunStatus.FailedDependencies(isFailure = false, null)
 
-      assert(status.toString == "Failed dependencies")
+      assert(status.toString == "Dependency check failed")
     }
 
     "NoData" in {
@@ -187,7 +187,7 @@ class RunStatusSuite extends AnyWordSpec {
     "MissingDependencies" in {
       val status = RunStatus.MissingDependencies(isFailure = false, Seq("table2", "table1"))
 
-      assert(status.getReason().contains("Missing dependencies: table2, table1"))
+      assert(status.getReason().contains("Dependent job failures: table2, table1"))
     }
 
     "FailedDependencies" in {
@@ -196,10 +196,10 @@ class RunStatusSuite extends AnyWordSpec {
           MetastoreDependency(Seq("table2", "table1", "table3"), "", None, triggerUpdates = false, isOptional = false, isPassive = false),
           Seq("table3"),
           Seq("table1"),
-          Nil
+          Seq("2022-01-01")
         )))
 
-      assert(status.getReason().contains("Failed dependencies for: table1, table3"))
+      assert(status.getReason().contains("Dependency check failures: table3 (Empty or wrong name), table1 (2022-01-01)"))
     }
 
     "NoData" in {
@@ -211,7 +211,7 @@ class RunStatusSuite extends AnyWordSpec {
     "InsufficientData" in {
       val status = RunStatus.InsufficientData(100, 200, None)
 
-      assert(status.getReason().contains("Expected 200 records, but got 100 records"))
+      assert(status.getReason().contains("Got 100, expected at least 200 records"))
     }
 
     "NotRan" in {
@@ -220,10 +220,17 @@ class RunStatusSuite extends AnyWordSpec {
       assert(status.getReason().isEmpty)
     }
 
-    "Skipped" in {
-      val status = RunStatus.Skipped("My reason")
+    "Skipped" when {
+      "empty reason" in {
+        val status = RunStatus.Skipped("")
 
-      assert(status.getReason().contains("My reason"))
+        assert(status.getReason().isEmpty)
+      }
+      "non-empty reason" in {
+        val status = RunStatus.Skipped("My reason")
+
+        assert(status.getReason().contains("My reason"))
+      }
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/RunStatusSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/RunStatusSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.runner.task
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.metastore.model.MetastoreDependency
+import za.co.absa.pramen.core.pipeline.{DependencyFailure, TaskRunReason}
+import za.co.absa.pramen.core.runner.task.RunStatus
+
+class RunStatusSuite extends AnyWordSpec {
+  "toString" should {
+    "Succeeded" when {
+      "New" in {
+        val status = RunStatus.Succeeded(None, 0, None, TaskRunReason.New)
+
+        assert(status.toString == "New")
+      }
+      "Update" in {
+        val status = RunStatus.Succeeded(None, 0, None, TaskRunReason.Update)
+
+        assert(status.toString == "Update")
+      }
+    }
+
+    "Validation Failed" in {
+      val status = RunStatus.ValidationFailed(null)
+
+      assert(status.toString == "Validation failed")
+    }
+
+    "Failed" in {
+      val status = RunStatus.Failed(null)
+
+      assert(status.toString == "Failed")
+    }
+
+    "MissingDependencies" in {
+      val status = RunStatus.MissingDependencies(isFailure = false, null)
+
+      assert(status.toString == "Missing dependencies")
+    }
+
+    "FailedDependencies" in {
+      val status = RunStatus.FailedDependencies(isFailure = false, null)
+
+      assert(status.toString == "Failed dependencies")
+    }
+
+    "NoData" in {
+      val status = RunStatus.NoData(false)
+
+      assert(status.toString == "No data")
+    }
+
+    "InsufficientData" in {
+      val status = RunStatus.InsufficientData(0, 0, None)
+
+      assert(status.toString == "Insufficient data")
+    }
+
+    "NotRan" in {
+      val status = RunStatus.NotRan
+
+      assert(status.toString == "Not ran")
+    }
+
+    "Skipped" in {
+      val status = RunStatus.Skipped(null)
+
+      assert(status.toString == "Skipped")
+    }
+  }
+
+  "isFailure" should {
+    "Succeeded" in {
+       val status = RunStatus.Succeeded(None, 0, None, TaskRunReason.New)
+
+       assert(!status.isFailure)
+    }
+
+    "Validation Failed" in {
+      val status = RunStatus.ValidationFailed(null)
+
+      assert(status.isFailure)
+    }
+
+    "Failed" in {
+      val status = RunStatus.Failed(null)
+
+      assert(status.isFailure)
+    }
+
+    "MissingDependencies" when {
+      "failure" in {
+        val status = RunStatus.MissingDependencies(isFailure = true, null)
+
+        assert(status.isFailure)
+      }
+
+      "not a failure" in {
+        val status = RunStatus.MissingDependencies(isFailure = false, null)
+
+        assert(!status.isFailure)
+      }
+    }
+
+    "FailedDependencies" when {
+      "failure" in {
+        val status = RunStatus.FailedDependencies(isFailure = true, null)
+
+        assert(status.isFailure)
+      }
+
+      "not a failure" in {
+        val status = RunStatus.FailedDependencies(isFailure = false, null)
+
+        assert(!status.isFailure)
+      }
+    }
+
+    "NoData" when {
+      "failure" in {
+        val status = RunStatus.NoData(isFailure = true)
+
+        assert(status.isFailure)
+      }
+
+      "not a failure" in {
+        val status = RunStatus.NoData(isFailure = false)
+
+        assert(!status.isFailure)
+      }
+    }
+
+    "InsufficientData" in {
+      val status = RunStatus.InsufficientData(0, 0, None)
+
+      assert(status.isFailure)
+    }
+
+    "NotRan" in {
+      val status = RunStatus.NotRan
+
+      assert(!status.isFailure)
+    }
+
+    "Skipped" in {
+      val status = RunStatus.Skipped(null)
+
+      assert(!status.isFailure)
+    }
+  }
+
+  "getReason" should {
+    "Succeeded" in {
+      val status = RunStatus.Succeeded(None, 0, None, TaskRunReason.New)
+
+      assert(status.getReason().isEmpty)
+    }
+
+    "Validation Failed" in {
+      val status = RunStatus.ValidationFailed(new RuntimeException("test1", new RuntimeException("test2")))
+
+      assert(status.getReason().contains("test1 (test2)"))
+    }
+
+    "Failed" in {
+      val status = RunStatus.Failed(new RuntimeException("test1", new RuntimeException("test2")))
+
+      assert(status.getReason().contains("test1 (test2)"))
+    }
+
+    "MissingDependencies" in {
+      val status = RunStatus.MissingDependencies(isFailure = false, Seq("table2", "table1"))
+
+      assert(status.getReason().contains("Missing dependencies: table2, table1"))
+    }
+
+    "FailedDependencies" in {
+      val status = RunStatus.FailedDependencies(isFailure = false, Seq(
+        DependencyFailure(
+          MetastoreDependency(Seq("table2", "table1", "table3"), "", None, triggerUpdates = false, isOptional = false, isPassive = false),
+          Seq("table3"),
+          Seq("table1"),
+          Nil
+        )))
+
+      assert(status.getReason().contains("Failed dependencies for: table1, table3"))
+    }
+
+    "NoData" in {
+      val status = RunStatus.NoData(false)
+
+      assert(status.getReason().contains("No data at the source"))
+    }
+
+    "InsufficientData" in {
+      val status = RunStatus.InsufficientData(100, 200, None)
+
+      assert(status.getReason().contains("Expected 200 records, but got 100 records"))
+    }
+
+    "NotRan" in {
+      val status = RunStatus.NotRan
+
+      assert(status.getReason().isEmpty)
+    }
+
+    "Skipped" in {
+      val status = RunStatus.Skipped("My reason")
+
+      assert(status.getReason().contains("My reason"))
+    }
+  }
+}


### PR DESCRIPTION
- The journal table has quite a legacy format for compatibility with SyncWatcher. Maybe the journal can be deprecated in the future, or made optional
- Extended RunStatus with additional methods since these reasons are pattern matched and rendered for different reasons. New methods unify the way these status messages are rendered.
- Tested end to end