### PR TITLE
#149 Autodetect Enceladus info version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2038,11 +2038,25 @@ pramen.operations = [
         input.sql = "SELECT * FROM table2 WHERE info_date = date'@infoDate'"
         job.metastore.table = "table2->my_data_lake" # This is needed the input is not a table
         output.path = /datalake/path/raw/table2
-        output.info.version = 1
+        
+        # Autodetect info version based on files in the raw and publish folders
+        # Needs 'output.publish.base.path' or 'output.hive.table' to be set
+        output.info.version = auto
 
         # The rest of the fields are optional
         date.from = "@infoDate"
         date.to = "@infoDate"
+        
+        output {
+           # Optional when running Enceladus from Pramen
+           dataset.name = "my_dataset"
+           dataset.version = 2
+           
+           # Optional publish base path (for detecting version number)
+           publish.base.path = "/bigdata/datalake/publish"
+           # Optional Hive table to repair after Enceladus is executed
+           hive.table = "my_database.my_table"
+        }
 
         transformations = [
           {col = "last_name_u", expr = "upper(last_name)"}

--- a/pramen/examples/enceladus_single_config/daily_ingestion.conf
+++ b/pramen/examples/enceladus_single_config/daily_ingestion.conf
@@ -127,14 +127,23 @@ pramen.operations = [
       {
         input.db.table = my_table1
         output.path = "/bigdata/datalake/raw/my_table1"
-        output.info.version = 1
 
-        # Optional when running Enceladus from Pramen
+        # Autodetect info version based on files in the raw and publish folders
+        # Needs 'output.publish.base.path' or 'output.hive.table' to be set
+        output.info.version = auto
+
         output.dataset.name = "my_dataset"
-        output.dataset.version = 2
 
-        # Optional Hive table to repair after Enceladus is executed
-        hive.table = "my_database.my_table"
+        output {
+           # Optional when running Enceladus from Pramen
+           dataset.name = "my_dataset"
+           dataset.version = 2
+
+           # Optional publish base path (for detecting version number)
+           publish.base.path = "/bigdata/datalake/publish"
+           # Optional Hive table to repair after Enceladus is executed
+           hive.table = "my_database.my_table"
+        }
       },
       {
         input.db.table = my_table2

--- a/pramen/examples/enceladus_single_config/weekly_ingestion.conf
+++ b/pramen/examples/enceladus_single_config/weekly_ingestion.conf
@@ -129,19 +129,27 @@ pramen.operations = [
       {
         input.db.table = my_table1
         output.path = "/bigdata/datalake/raw/my_table1"
-        output.info.version = 1
+
+        # Autodetect info version based on files in the raw and publish folders
+        # Needs 'output.publish.base.path' or 'output.hive.table' to be set
+        output.info.version = auto
+
+        output.dataset.name = "my_dataset"
+
+        output {
+           # Optional when running Enceladus from Pramen
+           dataset.name = "my_dataset"
+           dataset.version = 2
+
+           # Optional publish base path (for detecting version number)
+           publish.base.path = "/bigdata/datalake/publish"
+           # Optional Hive table to repair after Enceladus is executed
+           hive.table = "my_database.my_table"
+        }
 
         # Optionally you can specify expressions for date ranges.
-        # Here we say grab all data from source from Monday to Sunday
-        date.from = "lastMonday(@infoDate)"
-        date.to = "@infoDate + 1"
-
-        # Optional when running Enceladus from Pramen
-        output.dataset.name = "my_dataset"
-        output.dataset.version = 2
-
-        # Optional Hive table to repair after Enceladus is executed
-        hive.table = "my_database.my_table"
+        date.from = "@infoDate"
+        date.to = "@infoDate"
       },
       {
         input.db.table = my_table2

--- a/pramen/examples/enceladus_sourcing/daily_ingestion.conf
+++ b/pramen/examples/enceladus_sourcing/daily_ingestion.conf
@@ -36,17 +36,25 @@ pramen.operations = [
 
     tables = [
       {
-        #input.sql = "SELECT * FROM my_table1 WHERE information_date = date'@infoDate'"
-        input.db.table = db.my_table1
-        output.path = "/bigdata/datalake/my_table1/raw"
-        output.info.version = 1
+        input.db.table = my_table1
+        output.path = "/bigdata/datalake/raw/my_table1"
 
-        # Optional when running Enceladus from Pramen
+        # Autodetect info version based on files in the raw and publish folders
+        # Needs 'output.publish.base.path' or 'output.hive.table' to be set
+        output.info.version = auto
+
         output.dataset.name = "my_dataset"
-        output.dataset.version = 2
 
-        # Optional Hive table to repair after Enceladus is executed
-        hive.table = "my_database.my_table"
+        output {
+           # Optional when running Enceladus from Pramen
+           dataset.name = "my_dataset"
+           dataset.version = 2
+
+           # Optional publish base path (for detecting version number)
+           publish.base.path = "/bigdata/datalake/publish"
+           # Optional Hive table to repair after Enceladus is executed
+           hive.table = "my_database.my_table"
+        }
       }
       {
         #input.sql = "SELECT * FROM my_table2 WHERE information_date = date'@infoDate'"

--- a/pramen/examples/enceladus_sourcing/daily_snapshot.conf
+++ b/pramen/examples/enceladus_sourcing/daily_snapshot.conf
@@ -39,14 +39,17 @@ pramen.operations = [
         #input.sql = "SELECT * FROM my_table1 WHERE information_date = date'@infoDate'"
         input.db.table = db.my_table1
         output.path = "/bigdata/datalake/my_table1/raw"
-        output.info.version = 1
+        output.info.version = auto
 
         # Optional when running Enceladus from Pramen
         output.dataset.name = "my_dataset"
         output.dataset.version = 2
 
+        # Optional publish base path (for detecting version number)
+        output.publish.base.path = "/bigdata/datalake/publish"
+
         # Optional Hive table to repair after Enceladus is executed
-        hive.table = "my_database.my_table"
+        output.hive.table = "my_database.my_table"
       }
       {
         #input.sql = "SELECT * FROM my_table2 WHERE information_date = date'@infoDate'"

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/query/QueryExecutor.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/query/QueryExecutor.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.query
+
+import org.apache.spark.sql.DataFrame
+
+trait QueryExecutor {
+  def execute(sql: String): Unit
+
+  def query(sql: String): DataFrame
+}

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/query/QueryExecutorSpark.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/query/QueryExecutorSpark.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.query
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.slf4j.LoggerFactory
+
+class QueryExecutorSpark(spark: SparkSession) extends QueryExecutor {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override def execute(sql: String): Unit = {
+    log.info(s"Executing SQL: $sql")
+    spark.sql(sql).take(100)
+  }
+  override def query(sql: String): DataFrame = {
+    log.info(s"Executing SQL: $sql")
+    spark.sql(sql)
+  }
+}

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusConfig.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusConfig.scala
@@ -36,7 +36,8 @@ case class EnceladusConfig(
                             generateInfoFile: Boolean,
                             enceladusMainClass: String,
                             enceladusCmdLineTemplate: String,
-                            hiveDatabase: Option[String]
+                            hiveDatabase: Option[String],
+                            publishPartitionTemplate: String
                           )
 
 object EnceladusConfig {
@@ -52,6 +53,7 @@ object EnceladusConfig {
   val ENCELADUS_RUN_MAIN_CLASS_KEY = "enceladus.run.main.class"
   val ENCELADUS_COMMAND_LINE_TEMPLATE_KEY = "enceladus.command.line.template"
   val HIVE_DATABASE_KEY = "hive.database"
+  val PUBLISH_PARTITION_TEMPLATE_KEY = "publish.partition.template"
 
   val DEFAULT_INFO_DATE_COLUMN = "enceladus_info_date"
   val DEFAULT_PARTITION_PATTERN = "{year}/{month}/{day}/v{version}"
@@ -59,6 +61,7 @@ object EnceladusConfig {
   val DEFAULT_MODE = "errorifexists"
   val DEFAULT_ENCELADUS_RUN_MAIN_CLASS = "za.co.absa.enceladus.standardization_conformance.StandardizationAndConformanceJob"
   val DEFAULT_ENCELADUS_COMMAND_LINE_TEMPLATE = "--dataset-name @datasetName --dataset-version @datasetVersion --report-date @infoDate --menas-auth-keytab menas.keytab --raw-format @rawFormat --autoclean-std-folder true"
+  val DEFAULT_PUBLISH_PARTITION_TEMPLATE = "enceladus_info_date={1}/enceladus_info_version={2}"
 
   def fromConfig(conf: Config): EnceladusConfig = {
     val pramenVersion = Try {
@@ -83,7 +86,8 @@ object EnceladusConfig {
       ConfigUtils.getOptionBoolean(conf, GENERATE_INFO_FILE_KEY).getOrElse(true),
       ConfigUtils.getOptionString(conf, ENCELADUS_RUN_MAIN_CLASS_KEY).getOrElse(DEFAULT_ENCELADUS_RUN_MAIN_CLASS),
       ConfigUtils.getOptionString(conf, ENCELADUS_COMMAND_LINE_TEMPLATE_KEY).getOrElse(DEFAULT_ENCELADUS_COMMAND_LINE_TEMPLATE),
-      ConfigUtils.getOptionString(conf, HIVE_DATABASE_KEY)
+      ConfigUtils.getOptionString(conf, HIVE_DATABASE_KEY),
+      ConfigUtils.getOptionString(conf, PUBLISH_PARTITION_TEMPLATE_KEY).getOrElse(DEFAULT_PUBLISH_PARTITION_TEMPLATE)
     )
   }
 }

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusConfig.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusConfig.scala
@@ -37,7 +37,7 @@ case class EnceladusConfig(
                             enceladusMainClass: String,
                             enceladusCmdLineTemplate: String,
                             hiveDatabase: Option[String],
-                            publishPartitionTemplate: String
+                            publishPartitionPattern: String
                           )
 
 object EnceladusConfig {
@@ -61,7 +61,7 @@ object EnceladusConfig {
   val DEFAULT_MODE = "errorifexists"
   val DEFAULT_ENCELADUS_RUN_MAIN_CLASS = "za.co.absa.enceladus.standardization_conformance.StandardizationAndConformanceJob"
   val DEFAULT_ENCELADUS_COMMAND_LINE_TEMPLATE = "--dataset-name @datasetName --dataset-version @datasetVersion --report-date @infoDate --menas-auth-keytab menas.keytab --raw-format @rawFormat --autoclean-std-folder true"
-  val DEFAULT_PUBLISH_PARTITION_TEMPLATE = "enceladus_info_date={1}/enceladus_info_version={2}"
+  val DEFAULT_PUBLISH_PARTITION_TEMPLATE = "enceladus_info_date={year}-{month}-{day}/enceladus_info_version={version}"
 
   def fromConfig(conf: Config): EnceladusConfig = {
     val pramenVersion = Try {

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusSink.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusSink.scala
@@ -345,19 +345,18 @@ class EnceladusSink(sinkConfig: Config,
       enceladusConfig.publishPartitionPattern,
       enceladusConfig.infoDateColumn)
 
-    val versionOpt = enceladusUtils.getNextEnceladusVersion(infoDate,
+    val versionTry = enceladusUtils.getNextEnceladusVersion(infoDate,
       rawBasePath,
       publishBasePath,
       hiveTable
     )
 
-    versionOpt match {
+    versionTry match {
       case Success(version) =>
         log.warn(s"Autodetected next info version for $metaTable: $version.")
         version
       case Failure(ex)      =>
-        log.error(s"Could not autodetect Enceladus version for $metaTable. Defaulting to 1.", ex)
-        1
+        throw new IllegalStateException(s"Could not autodetect Enceladus version for $metaTable.", ex)
     }
   }
 }

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusUtils.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusUtils.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.sink
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.extras.utils.FsUtils
+import za.co.absa.pramen.extras.utils.PartitionUtils.unpackCustomPartitionPattern
+
+import java.time.LocalDate
+import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
+
+object EnceladusUtils {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  def getNextEnceladusVersion(hiveTableOpt: Option[String],
+                              rawBasePath: Path,
+                              rawPartitionPattern: String,
+                              publishBasePathOpt: Option[Path],
+                              publishPartitionPattern: String,
+                              infoDateColumn: String,
+                              infoDate: LocalDate)(implicit spark: SparkSession): Try[Int] = {
+    val rawMaxVersion = getMaxVersionInRaw(rawBasePath, rawPartitionPattern, infoDateColumn, infoDate).getOrElse(0)
+
+    val maxVersionInPublish = publishBasePathOpt match {
+      case Some(publishBasePath) =>
+        log.info(s"Detecting info version from the publish base path: $publishBasePath")
+        getMaxVersionInPublish(publishBasePath, publishPartitionPattern, infoDateColumn, infoDate)
+      case None                  =>
+        hiveTableOpt match {
+          case Some(hiveTable) =>
+            log.info(s"Detecting info version from the hive table: $hiveTable")
+            getMaxVersionInPublish(hiveTable, publishPartitionPattern, infoDateColumn, infoDate)
+          case None            =>
+            Failure(new IllegalArgumentException(s"No publish path or hive table specified for $rawBasePath."))
+        }
+    }
+
+    maxVersionInPublish.map {
+      case Some(versionInPublish) =>
+        versionInPublish + 1
+      case None =>
+        rawMaxVersion + 1
+    }
+  }
+
+  def getMaxVersionInRaw(rawBasePath: Path,
+                         partitionPattern: String,
+                         infoDateColumn: String,
+                         infoDate: LocalDate)(implicit spark: SparkSession): Option[Int] = {
+
+    val rawPath = getParentPartitionPath(rawBasePath, partitionPattern, infoDateColumn, infoDate)
+
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, rawBasePath.toString)
+
+    if (!fsUtils.exists(rawPath)) {
+      log.info(s"Raw path $rawPath does not exist.")
+      return None
+    }
+
+    val versionR = "^v(\\d+)$".r
+
+    getMaxVersionFromDirs(rawPath, versionR, fsUtils).get
+  }
+
+  def getMaxVersionInPublish(publishBasePath: Path,
+                             partitionPattern: String,
+                             infoDateColumn: String,
+                             infoDate: LocalDate)(implicit spark: SparkSession): Try[Option[Int]] = {
+    val rawPath = getParentPartitionPath(publishBasePath, partitionPattern, infoDateColumn, infoDate)
+
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, publishBasePath.toString)
+
+    if (!fsUtils.exists(rawPath)) {
+      log.info(s"Publish path $rawPath does not exist.")
+      return Success(None)
+    }
+
+    val versionR = "^.*=(\\d+)$".r
+
+    getMaxVersionFromDirs(rawPath, versionR, fsUtils)
+  }
+
+  private def getMaxVersionFromDirs(rawPath: Path, versionExtractRegEx: Regex, fsUtils: FsUtils) = {
+    Try {
+      val versions = fsUtils.getDirectories(rawPath)
+        .flatMap(_.getName match {
+          case versionExtractRegEx(version) => Some(version.toInt)
+          case _                 => None
+        })
+      if (versions.isEmpty) {
+        None
+      } else {
+        Option(versions.max)
+      }
+    }
+  }
+
+  def getMaxVersionInPublish(hiveTable: String,
+                             partitionPattern: String,
+                             infoDateColumn: String,
+                             infoDate: LocalDate)(implicit spark: SparkSession): Try[Option[Int]] = {
+    Failure(new NotImplementedError("Not implemented yet"))
+  }
+
+  private[extras] def getParentPartitionPath(basePath: Path,
+                                             pathPattern: String,
+                                             infoDateColumn: String,
+                                             infoDate: LocalDate): Path = {
+    val partitionPath = unpackCustomPartitionPattern(pathPattern, infoDateColumn, infoDate, 1)
+
+    val specificPath = new Path(basePath, partitionPath)
+
+    specificPath.getParent
+  }
+}

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/InfoVersionStatus.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/InfoVersionStatus.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.sink
+
+trait InfoVersionStatus
+
+object InfoVersionStatus {
+  case class Detected(maxVersion: Int) extends InfoVersionStatus
+
+  case object NotPresent extends InfoVersionStatus
+
+  case class DetectionFailure(ex: Throwable) extends InfoVersionStatus
+}

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/utils/FsUtils.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/utils/FsUtils.scala
@@ -136,6 +136,39 @@ class FsUtils(conf: Configuration, pathBase: String) {
   }
 
   /**
+    * Gets the list of directories
+    *
+    * @param path     The base path to search
+    * @return
+    */
+  def getDirectories(path: Path, includeHiddenFiles: Boolean = false): Seq[Path] = {
+    val dirs = new ListBuffer[Path]
+
+    def isHidden(fileName: String): Boolean = {
+      fileName.startsWith("_") || fileName.startsWith(".")
+    }
+
+    def addToListRecursive(searchPath: Path): Unit = {
+      val statuses = fs.globStatus(new Path(searchPath, "*"))
+      statuses.foreach { status =>
+        val p = status.getPath
+        if (status.isDirectory) {
+          if (includeHiddenFiles || !isHidden(p.getName)) {
+            dirs += status.getPath
+          }
+        }
+      }
+    }
+
+    if (isFile(path)) {
+      Nil
+    } else {
+      addToListRecursive(path)
+      dirs.toSeq
+    }
+  }
+
+  /**
     * Appends an UTF-8 string to a file.
     *
     * @param filePath a path to a file.

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/mocks/QueryExecutorSpy.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/mocks/QueryExecutorSpy.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.mocks
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import za.co.absa.pramen.extras.query.QueryExecutor
+
+import scala.collection.mutable.ListBuffer
+
+class QueryExecutorSpy(dfToReturn: Option[DataFrame] = None,
+                       throwException: Option[Throwable] = None)(implicit spark: SparkSession) extends QueryExecutor {
+
+  import spark.implicits._
+
+  val executed = new ListBuffer[String]
+  val queried = new ListBuffer[String]
+
+  override def execute(sql: String): Unit = {
+    executed += sql
+    throwException.foreach(e => throw e)
+  }
+
+  override def query(sql: String): DataFrame = {
+    queried += sql
+    throwException.foreach(e => throw e)
+    dfToReturn match {
+      case Some(df) => df
+      case None     => List(("A", 1), ("B", 2), ("C", 3)).toDF("A", "B")
+    }
+  }
+}

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusConfigSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusConfigSuite.scala
@@ -57,7 +57,7 @@ class EnceladusConfigSuite extends AnyWordSpec with SparkTestBase {
       assert(!enceladusConfig.generateInfoFile)
       assert(enceladusConfig.enceladusMainClass == EnceladusConfig.DEFAULT_ENCELADUS_RUN_MAIN_CLASS)
       assert(enceladusConfig.enceladusCmdLineTemplate == EnceladusConfig.DEFAULT_ENCELADUS_COMMAND_LINE_TEMPLATE)
-      assert(enceladusConfig.publishPartitionTemplate == "enceladus_info_date={1}/enceladus_info_version={2}")
+      assert(enceladusConfig.publishPartitionPattern == "enceladus_info_date={year}-{month}-{day}/enceladus_info_version={version}")
     }
 
     "construct a config with app version and timezone" in {
@@ -99,7 +99,7 @@ class EnceladusConfigSuite extends AnyWordSpec with SparkTestBase {
       assert(!enceladusConfig.generateInfoFile)
       assert(enceladusConfig.enceladusMainClass == "A")
       assert(enceladusConfig.enceladusCmdLineTemplate == "B")
-      assert(enceladusConfig.publishPartitionTemplate == "aaa")
+      assert(enceladusConfig.publishPartitionPattern == "aaa")
     }
   }
 }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusConfigSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusConfigSuite.scala
@@ -57,6 +57,7 @@ class EnceladusConfigSuite extends AnyWordSpec with SparkTestBase {
       assert(!enceladusConfig.generateInfoFile)
       assert(enceladusConfig.enceladusMainClass == EnceladusConfig.DEFAULT_ENCELADUS_RUN_MAIN_CLASS)
       assert(enceladusConfig.enceladusCmdLineTemplate == EnceladusConfig.DEFAULT_ENCELADUS_COMMAND_LINE_TEMPLATE)
+      assert(enceladusConfig.publishPartitionTemplate == "enceladus_info_date={1}/enceladus_info_version={2}")
     }
 
     "construct a config with app version and timezone" in {
@@ -69,6 +70,7 @@ class EnceladusConfigSuite extends AnyWordSpec with SparkTestBase {
            |
            |enceladus.run.main.class = "A"
            |enceladus.command.line.template = "B"
+           |publish.partition.template = "aaa"
            |
            |timezone = "Africa/Johannesburg"
            |
@@ -97,6 +99,7 @@ class EnceladusConfigSuite extends AnyWordSpec with SparkTestBase {
       assert(!enceladusConfig.generateInfoFile)
       assert(enceladusConfig.enceladusMainClass == "A")
       assert(enceladusConfig.enceladusCmdLineTemplate == "B")
+      assert(enceladusConfig.publishPartitionTemplate == "aaa")
     }
   }
 }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusSinkSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusSinkSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.extras.base.SparkTestBase
 import za.co.absa.pramen.extras.sink.EnceladusSink
 import za.co.absa.pramen.extras.fixtures.{TempDirFixture, TextComparisonFixture}
-import za.co.absa.pramen.extras.sink.EnceladusSink.{DATASET_NAME_KEY, DATASET_VERSION_KEY, HIVE_TABLE__KEY}
+import za.co.absa.pramen.extras.sink.EnceladusSink.{DATASET_NAME_KEY, DATASET_VERSION_KEY, HIVE_TABLE_KEY}
 import za.co.absa.pramen.extras.utils.FsUtils
 
 import java.nio.file.{Files, Paths}
@@ -177,7 +177,7 @@ class EnceladusSinkSuite extends AnyWordSpec with SparkTestBase with TextCompari
           Map(
             DATASET_NAME_KEY -> "m_dayaset",
             DATASET_VERSION_KEY -> "22",
-            HIVE_TABLE__KEY -> "test_table"
+            HIVE_TABLE_KEY -> "test_table"
           )
         )
       }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusUtilsSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusUtilsSuite.scala
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.extras.tests.sink
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.DataFrame
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.extras.base.SparkTestBase
+import za.co.absa.pramen.extras.fixtures.{TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.extras.mocks.QueryExecutorSpy
+import za.co.absa.pramen.extras.sink.EnceladusUtils
+import za.co.absa.pramen.extras.utils.FsUtils
+
+import java.nio.file.{Files, Paths}
+import java.time.LocalDate
+
+class EnceladusUtilsSuite extends AnyWordSpec with SparkTestBase with TextComparisonFixture with TempDirFixture {
+
+  import spark.implicits._
+
+  private val infoDate = LocalDate.of(2022, 2, 18)
+  private val rawPathPattern = "{year}/{month}/{day}/v{version}"
+  private val publishPathPattern = "enceladus_info_date={year}-{month}-{day}/enceladus_info_version={version}"
+
+  "getNextEnceladusVersion" should {
+    "return initial versions if only the base folders exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_raw") { tempRaw =>
+        withTempDirectory("enceladus_publish") { tempPublish =>
+          Files.createDirectories(Paths.get(tempRaw, "my_table"))
+          Files.createDirectories(Paths.get(tempPublish, "my_table"))
+
+          val nextVersionTry = utils.getNextEnceladusVersion(infoDate,
+            new Path(tempRaw, "my_table"),
+            Some(new Path(tempPublish, "my_table")),
+            None)
+
+          assert(nextVersionTry.get == 1)
+        }
+      }
+    }
+
+    "return initial versions if only raw folders have versions" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_raw") { tempRaw =>
+        withTempDirectory("enceladus_publish") { tempPublish =>
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v1"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v2"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v3"))
+
+          Files.createDirectories(Paths.get(tempPublish, "my_table"))
+
+          val nextVersionTry = utils.getNextEnceladusVersion(infoDate,
+            new Path(tempRaw, "my_table"),
+            Some(new Path(tempPublish, "my_table")),
+            None)
+
+          assert(nextVersionTry.get == 1)
+        }
+      }
+    }
+
+    "return next version if published versions exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_raw") { tempRaw =>
+        withTempDirectory("enceladus_publish") { tempPublish =>
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v1"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v3"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v4"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v5"))
+
+          Files.createDirectories(Paths.get(tempPublish, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=1"))
+          Files.createDirectories(Paths.get(tempPublish, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=2"))
+          Files.createDirectories(Paths.get(tempPublish, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=3"))
+
+          val nextVersionTry = utils.getNextEnceladusVersion(infoDate,
+            new Path(tempRaw, "my_table"),
+            Some(new Path(tempPublish, "my_table")),
+            None)
+
+          assert(nextVersionTry.get == 4)
+        }
+      }
+    }
+
+    "return next version if hive versions exist" in {
+      val partitiondDf = Seq(
+        "enceladus_info_date=2022-02-18/enceladus_info_version=1",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=3",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=5"
+      ).toDF("partition")
+
+      val (utils, _) = getUseCase(Option(partitiondDf))
+
+      withTempDirectory("enceladus_raw") { tempRaw =>
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v1"))
+          Files.createDirectories(Paths.get(tempRaw, "my_table", "2022", "02", "18", "v3"))
+
+          val nextVersionTry = utils.getNextEnceladusVersion(infoDate,
+            new Path(tempRaw, "my_table"),
+            None,
+            Some("dummy_hive_table"))
+
+          assert(nextVersionTry.get == 6)
+        }
+    }
+
+    "fail if neither publish folder nor hive table is defined" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        Files.createDirectories(Paths.get(tempDir, "my_table"))
+
+        val path = new Path(tempDir, "my_table")
+        val nextVersionTry = utils.getNextEnceladusVersion(infoDate, path, None, None)
+
+        assert(nextVersionTry.isFailure)
+        assert(nextVersionTry.failed.get.getMessage.contains("No publish path or hive table specified"))
+      }
+    }
+
+    "fail if the raw publish folder does not exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_raw") { tempRaw =>
+        withTempDirectory("enceladus_publish") { tempPublish =>
+          Files.createDirectories(Paths.get(tempRaw, "my_table"))
+
+          val nextVersionTry = utils.getNextEnceladusVersion(infoDate,
+            new Path(tempRaw, "my_table"),
+            Some(new Path(tempPublish, "my_table")),
+            None)
+
+          assert(nextVersionTry.isFailure)
+          assert(nextVersionTry.failed.get.getMessage.contains("Publish path does not exist"))
+        }
+      }
+    }
+  }
+
+  "getMaxVersionInRaw" should {
+    "return the maximum version in the publish folder" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v1"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v2"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v3"))
+
+        val maxVersionTry = utils.getMaxVersionInRaw(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.get.contains(3))
+      }
+    }
+
+    "return None for empty publish folder" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        Files.createDirectories(Paths.get(tempDir, "my_table"))
+
+        val maxVersionTry = utils.getMaxVersionInRaw(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.get.isEmpty)
+      }
+    }
+
+    "fail if the base folder does not exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        val maxVersionTry = utils.getMaxVersionInRaw(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.isFailure)
+      }
+    }
+  }
+
+  "getMaxVersionInPublish" should {
+    "return the maximum version in the publish folder" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        Files.createDirectories(Paths.get(tempDir, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=1"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=2"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "enceladus_info_date=2022-02-18", "enceladus_info_version=3"))
+
+        val maxVersionTry = utils.getMaxVersionInPublish(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.get.contains(3))
+      }
+    }
+
+    "return None for empty publish folder" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        Files.createDirectories(Paths.get(tempDir, "my_table"))
+
+        val maxVersionTry = utils.getMaxVersionInPublish(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.get.isEmpty)
+      }
+    }
+
+    "fail if the base folder does not exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        val maxVersionTry = utils.getMaxVersionInPublish(new Path(tempDir, "my_table"), "enceladus_info_date", infoDate)
+
+        assert(maxVersionTry.isFailure)
+      }
+    }
+  }
+
+  "getMaxVersionFromHive" should {
+    "have partitions" when {
+      val partitiondDf = Seq(
+        "enceladus_info_date=2022-02-18/enceladus_info_version=1",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=3",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=5"
+      ).toDF("partition")
+
+      val (utils, qe) = getUseCase(Option(partitiondDf))
+
+      val maxVersion = utils.getMaxVersionFromHive("mydb.mytable1", "enceladus_info_date", infoDate)
+
+      "execute the proper query" in {
+        assert(qe.queried.head == "SHOW PARTITIONS mydb.mytable1")
+      }
+
+      "return the proper result" in {
+        assert(maxVersion.get.contains(5))
+      }
+    }
+
+    "empty partitions" when {
+      val partitiondDf = Seq.empty[String].toDF("partition")
+
+      val (utils, qe) = getUseCase(Option(partitiondDf))
+
+      val maxVersion = utils.getMaxVersionFromHive("mydb.mytable1", "enceladus_info_date", infoDate)
+
+      "execute the proper query" in {
+        assert(qe.queried.head == "SHOW PARTITIONS mydb.mytable1")
+      }
+
+      "return the proper result" in {
+        assert(maxVersion.get.isEmpty)
+      }
+    }
+
+    "rethrow hive exception" when {
+      val partitiondDf = Seq.empty[String].toDF("partition")
+
+      val (utils, qe) = getUseCase(Option(partitiondDf), Option(new IllegalStateException("Dummy")))
+
+      val maxVersion = utils.getMaxVersionFromHive("mydb.mytable2", "enceladus_info_date", infoDate)
+
+      "execute the proper query" in {
+        assert(qe.queried.head == "SHOW PARTITIONS mydb.mytable2")
+      }
+
+      "return the proper result" in {
+        assert(maxVersion.isFailure)
+        assert(maxVersion.failed.get.getMessage == "Dummy")
+      }
+    }
+  }
+
+  "getMaxVersionFromDirs" should {
+    "find the maximum version in a dir" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v1"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v8"))
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18", "v2"))
+
+        val partitionParent = utils.getParentPartitionPath(new Path(tempDir, "my_table"), rawPathPattern, "enceladus_info_date", infoDate)
+
+        val action = utils.getMaxVersionFromDirs(partitionParent, utils.rawVersionRegEx, fsUtils)
+
+        assert(action.get.contains(8))
+      }
+    }
+
+    "return None for an empty dir" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        Files.createDirectories(Paths.get(tempDir, "my_table", "2022", "02", "18"))
+
+        val partitionParent = utils.getParentPartitionPath(new Path(tempDir, "my_table"), rawPathPattern, "enceladus_info_date", infoDate)
+
+        val action = utils.getMaxVersionFromDirs(partitionParent, utils.rawVersionRegEx, fsUtils)
+
+        assert(action.get.isEmpty)
+      }
+    }
+
+    "return Failure if the folder does not exist" in {
+      val (utils, _) = getUseCase()
+
+      withTempDirectory("enceladus_utils") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        val partitionParent = utils.getParentPartitionPath(new Path(tempDir, "my_table"), rawPathPattern, "enceladus_info_date", infoDate)
+
+        val action = utils.getMaxVersionFromDirs(partitionParent, utils.rawVersionRegEx, fsUtils)
+
+        assert(action.isFailure)
+      }
+    }
+  }
+
+  "getMaxVersionFromList" should {
+    "return maximum version in a raw folder" in {
+      val (utils, _) = getUseCase()
+
+      val partitions = Seq(
+        "/bigdata/raw/my_table/2022/02/18/v1",
+        "/bigdata/raw/my_table/2022/02/18/v2",
+        "/bigdata/raw/my_table/2022/02/18/v10"
+      )
+
+      val action = utils.getMaxVersionFromList(partitions, utils.rawVersionRegEx)
+
+      assert(action.get.contains(10))
+    }
+
+    "return maximum version in a raw inner folder" in {
+      val (utils, _) = getUseCase()
+
+      val partitions = Seq(
+        "v1",
+        "v2",
+        "v10"
+      )
+
+      val action = utils.getMaxVersionFromList(partitions, utils.rawVersionRegEx)
+
+      assert(action.get.contains(10))
+    }
+
+
+    "return maximum version in a publish folder" in {
+      val (utils, _) = getUseCase()
+
+      val partitions = Seq(
+        "/bigdata/publish/my_table/enceladus_info_date=2022-02-18/enceladus_info_version=1",
+        "/bigdata/publish/my_table/enceladus_info_date=2022-02-18/enceladus_info_version=2",
+        "/bigdata/publish/my_table/enceladus_info_date=2022-02-18/enceladus_info_version=11"
+      )
+
+      val action = utils.getMaxVersionFromList(partitions, utils.publishVersionRegEx)
+
+      assert(action.get.contains(11))
+    }
+
+    "return maximum version in a Hive table" in {
+      val (utils, _) = getUseCase()
+
+      val partitions = Seq(
+        "enceladus_info_date=2022-02-18/enceladus_info_version=1",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=2",
+        "enceladus_info_date=2022-02-18/enceladus_info_version=11"
+      )
+
+      val action = utils.getMaxVersionFromList(partitions, utils.publishVersionRegEx)
+
+      assert(action.get.contains(11))
+    }
+
+    "return None for the empty folder" in {
+      val (utils, _) = getUseCase()
+
+      val partitions = Seq.empty[String]
+
+      val action = utils.getMaxVersionFromList(partitions, utils.publishVersionRegEx)
+
+      assert(action.get.isEmpty)
+    }
+  }
+
+  "getParentPartitionPath" should {
+    "return raw the parent path" in {
+      val (utils, _) = getUseCase()
+
+      val action = utils.getParentPartitionPath(new Path("/bigdata/raw/my_table"), rawPathPattern, "enceladus_info_date", infoDate)
+
+      assert(action.toString == "/bigdata/raw/my_table/2022/02/18")
+    }
+
+    "return publish the parent path" in {
+      val (utils, _) = getUseCase()
+
+      val action = utils.getParentPartitionPath(new Path("/bigdata/publish/my_table"), publishPathPattern, "enceladus_info_date", infoDate)
+
+      assert(action.toString == "/bigdata/publish/my_table/enceladus_info_date=2022-02-18")
+    }
+  }
+
+  def getUseCase(partitionDf: Option[DataFrame] = None,
+                 throwException: Option[Throwable] = None): (EnceladusUtils, QueryExecutorSpy) = {
+    implicit val qe: QueryExecutorSpy = new QueryExecutorSpy(dfToReturn = partitionDf, throwException = throwException)
+    val utils = new EnceladusUtils("{year}/{month}/{day}/v{version}",
+      "enceladus_info_date={year}-{month}-{day}/enceladus_info_version={version}",
+      "enceladus_info_date"
+     )
+    (utils, qe)
+  }
+}

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
 
   def ExtrasJobsDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
     "org.apache.spark"     %% "spark-sql"                  % sparkVersion(scalaVersion) % Provided,
+    "org.slf4j"            %  "slf4j-log4j12"              % "1.7.16"                   % Provided,
     "net.sourceforge.jtds" %  "jtds"                       % msSqlDriverVersion,
     "org.scalatest"        %% "scalatest"                  % scalatestVersion           % Test
   ) :+ getAbrisDependency(scalaVersion)

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -44,7 +44,6 @@ object Dependencies {
 
   def ExtrasJobsDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
     "org.apache.spark"     %% "spark-sql"                  % sparkVersion(scalaVersion) % Provided,
-    "org.slf4j"            %  "slf4j-log4j12"              % "1.7.16"                   % Provided,
     "net.sourceforge.jtds" %  "jtds"                       % msSqlDriverVersion,
     "org.scalatest"        %% "scalatest"                  % scalatestVersion           % Test
   ) :+ getAbrisDependency(scalaVersion)

--- a/pramen/project/plugins.sbt
+++ b/pramen/project/plugins.sbt
@@ -15,7 +15,7 @@
  */
 
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.12")
+addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.1.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.7.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")
 addSbtPlugin("com.github.sbt"    % "sbt-jacoco"    % "3.4.0")

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-SNAPSHOT"
+ThisBuild / version := "1.2.2-SNAPSHOT"


### PR DESCRIPTION
- The autodetection is used when `output.info.version = auto` or not specified
- Either `output.publish.base.path` or `output.hive.table` should be specified
- The publish base path should exist if specified
- If no partitions found the version number will be 1
- Otherwise, `maximum info version published + 1`
