### PR TITLE
#151 Specify number of threads to consume by a task.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
@@ -19,6 +19,7 @@ package za.co.absa.pramen.core.app.config
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.app.config.BookkeeperConfig.BOOKKEEPING_ENABLED
+import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.model.Constants.DATE_FORMAT_INTERNAL
 import za.co.absa.pramen.core.runner.splitter.RunMode
 import za.co.absa.pramen.core.utils.ConfigUtils
@@ -61,7 +62,6 @@ object RuntimeConfig {
   val CURRENT_DATE = "pramen.current.date"
   val LOAD_DATE_FROM = "pramen.load.date.from"
   val LOAD_DATE_TO = "pramen.load.date.to"
-  val PARALLEL_TASKS = "pramen.parallel.tasks"
   val STOP_SPARK_SESSION = "pramen.stop.spark.session"
   val VERBOSE = "pramen.verbose"
 
@@ -131,7 +131,7 @@ object RuntimeConfig {
       runDate = dateFrom,
       runDateTo = dateTo,
       isInverseOrder = ConfigUtils.getOptionBoolean(conf, IS_INVERSE_ORDER).getOrElse(false),
-      parallelTasks = conf.getInt(PARALLEL_TASKS),
+      parallelTasks = conf.getInt(Keys.PARALLEL_TASKS),
       stopSparkSession = conf.getBoolean(STOP_SPARK_SESSION),
       runMode
     )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
@@ -21,6 +21,8 @@ object Keys {
   val INFORMATION_DATE_FORMAT_APP = "pramen.information.date.format"
   val TEMPORARY_DIRECTORY = "pramen.temporary.directory"
 
+  val PARALLEL_TASKS = "pramen.parallel.tasks"
+
   val WARN_THROUGHPUT_RPS = "pramen.warn.throughput.rps"
   val GOOD_THROUGHPUT_RPS = "pramen.good.throughput.rps"
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
@@ -23,7 +23,6 @@ import za.co.absa.pramen.core.expr.DateExprEvaluator
 import za.co.absa.pramen.core.metastore.Metastore
 import za.co.absa.pramen.core.metastore.model.{MetaTable, MetastoreDependency}
 import za.co.absa.pramen.core.pipeline
-import za.co.absa.pramen.core.utils.ConfigUtils
 import za.co.absa.pramen.core.utils.Emoji._
 
 import java.time.LocalDate

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -168,7 +168,7 @@ abstract class TaskRunnerBase(conf: Config,
   }
 
   /**
-    * Does pre-run checks and vask validations.
+    * Does pre-run checks and task validations.
     *
     * If validation is successful, in instance of JobPreRunResult is returned.
     * If validation failed an instance of TaskResult is returned.

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerMultithreaded.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerMultithreaded.scala
@@ -17,17 +17,18 @@
 package za.co.absa.pramen.core.runner.task
 
 import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.pipeline.Task
 import za.co.absa.pramen.core.state.PipelineState
 
-import java.time.{Instant, LocalDate}
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.{ExecutorService, Semaphore}
 import java.util.concurrent.Executors.newFixedThreadPool
 import scala.concurrent.ExecutionContext.fromExecutorService
 import scala.concurrent.{ExecutionContextExecutorService, Future}
+import scala.util.Try
 
 /**
   * The responsibility of this class is to handle the execution method.
@@ -38,22 +39,57 @@ class TaskRunnerMultithreaded(conf: Config,
                               journal: Journal,
                               pipelineState: PipelineState,
                               runtimeConfig: RuntimeConfig) extends TaskRunnerBase(conf, bookkeeper, journal, runtimeConfig, pipelineState) {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
   private val executor: ExecutorService = newFixedThreadPool(runtimeConfig.parallelTasks)
   implicit private val executionContext: ExecutionContextExecutorService = fromExecutorService(executor)
 
+  private val maxResources = runtimeConfig.parallelTasks
+  private val availableResources: Semaphore = new Semaphore(maxResources, true)
+
+  /**
+    * We want to prevent a case when a lot of resource-intensive actions are running at the same time.
+    * We have a finite number of resources. Before executing, the *action* asks for the required resources and only when
+    * there is enough of them available, the action will be executed.
+    */
+  private[task] def whenEnoughResourcesAreAvailable[T](requestedCount: Int)(action: => T): T = {
+    val resourceCount = getTruncatedResourceCount(requestedCount)
+
+    availableResources.acquire(resourceCount)
+    val result = Try { action }
+    availableResources.release(resourceCount)
+
+    result.get
+  }
+
+  private[task] def getTruncatedResourceCount(requestedCount: Int): Int = {
+    if (requestedCount > maxResources) {
+      log.warn(s"Asked for $requestedCount resources but maximum allowed is $maxResources. Truncating to $maxResources")
+      maxResources
+    } else {
+      requestedCount
+    }
+  }
+
   override def runParallel(tasks: Seq[Task]): Seq[Future[RunStatus]] = {
     tasks.map(task => Future {
-      runTask(task)
+      whenEnoughResourcesAreAvailable(task.job.operation.consumeThreads) {
+        runTask(task)
+      }
     })
   }
 
   override def runSequential(tasks: Seq[Task]): Future[Seq[RunStatus]] = {
     Future {
-      runDependentTasks(tasks)
+      val requiredResources = tasks.map(_.job.operation.consumeThreads).max
+      whenEnoughResourcesAreAvailable(requiredResources) {
+        runDependentTasks(tasks)
+      }
     }
   }
 
   override def shutdown(): Unit = {
     executionContext.shutdown()
   }
+
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/OperationDefFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/OperationDefFactory.scala
@@ -17,7 +17,6 @@
 package za.co.absa.pramen.core
 
 import com.typesafe.config.{Config, ConfigFactory}
-import za.co.absa.pramen.api.NotificationTarget
 import za.co.absa.pramen.core.metastore.model.MetastoreDependency
 import za.co.absa.pramen.core.pipeline.{OperationDef, OperationType, TransformExpression}
 import za.co.absa.pramen.core.schedule.Schedule
@@ -30,6 +29,7 @@ object OperationDefFactory {
                            schedule: Schedule = Schedule.EveryDay(),
                            expectedDelayDays: Int = 0,
                            allowParallel: Boolean = true,
+                           consumeThreads: Int = 1,
                            dependencies: Seq[MetastoreDependency] = Nil,
                            outputInfoDateExpression: String = "@date",
                            initialSourcingDateExpression: String = "@runDate",
@@ -46,6 +46,7 @@ object OperationDefFactory {
       schedule,
       expectedDelayDays,
       allowParallel,
+      consumeThreads,
       dependencies,
       outputInfoDateExpression,
       initialSourcingDateExpression,


### PR DESCRIPTION
Add an option to specify how many "threads" should a certain task consume with regards to the total number of threads set by `pramen.parallel.tasks`. 

An example:

```
pramen {
  pipeline.name = "A testing pipeline"

  parallel.tasks = 4
}

pramen.operations = [
  {
    name = "easy job"
    ...
   # default is 1
    consume.threads = 1 # not a resource intensive job, so Pramen can run 4 of these at one time (if nothing else is running of course)
  },
  {
    name = "hard job"
    ...
    consume.threads = 4 # run only one instance of this operation at a time
  },
]

```

These are not real threads, it is more akin to an indication to pramen saying: "This is a resource-intenstive operation, so you don't want to have many of these running at once".  

I tried thinking of a better name to not be as confusing but did not come up with anything useful. I was thinking about `pramen.parallelism.available.slots` and `uses.slots`  but these do not sound very good 😄 

# Some notes

- I tested this end-to-end. Was also thinking about how to unit test this better but did not come up with anything other than is in the PR.
- the `Try` in the `whenEnoughResourcesAreAvailable` is there to ensure than the permits get released but I call `.get()` after to let the exception "bubble up". I was going through the code and it seems that the task run failure is already handled by the `runTask()` function and the Future failure is also handled. But still not sure if I had done this correctly.
- It still spawns all of the threads. The ones that don't have enough "slots" are blocking on the semaphore until there are enough "threads" so that they can run.   