### PR TITLE
Add a test suite that checks the runner exit code.

### DIFF
--- a/pramen/runner/src/test/resources/log4j.properties
+++ b/pramen/runner/src/test/resources/log4j.properties
@@ -4,3 +4,5 @@ log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 log4j.appender.console.Threshold=ERROR
+
+log4j.logger.za.co.absa.pramen.core.runner.AppRunner$=OFF

--- a/pramen/runner/src/test/resources/log4j2.properties
+++ b/pramen/runner/src/test/resources/log4j2.properties
@@ -4,3 +4,5 @@ log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 log4j.appender.console.Threshold=ERROR
+
+log4j.logger.za.co.absa.pramen.core.runner.AppRunner$=OFF

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/base/ExitException.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/base/ExitException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.base
+
+case class ExitException(status: Int) extends SecurityException("System.exit() is not allowed")

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/base/NoExitSecurityManager.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/base/NoExitSecurityManager.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.base
+
+import java.security.Permission
+
+sealed class NoExitSecurityManager extends SecurityManager {
+  override def checkPermission(perm: Permission): Unit = {}
+
+  override def checkPermission(perm: Permission, context: Object): Unit = {}
+
+  override def checkExit(status: Int): Unit = {
+    super.checkExit(status)
+    throw ExitException(status)
+  }
+}

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/runner/CmdLineConfigSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/runner/CmdLineConfigSuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.tests
+package za.co.absa.pramen.runner
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/runner/PipelineRunnerSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/runner/PipelineRunnerSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.runner
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.base.{ExitException, NoExitSecurityManager, SparkTestBase, TempDirFixture}
+
+class PipelineRunnerSuite extends AnyWordSpec with BeforeAndAfterAll with TempDirFixture with SparkTestBase {
+  override def beforeAll(): Unit = System.setSecurityManager(new NoExitSecurityManager())
+
+  override def afterAll(): Unit = System.setSecurityManager(null)
+
+  "system.exit" should {
+    "not exit" in {
+      try {
+        System.exit(1)
+        fail("shouldn't read this code")
+      } catch {
+        case e: ExitException =>
+          assert(e.status == 1)
+      }
+    }
+  }
+
+  "PipelineRunner.main" should {
+    "exit with non-zero exit code on error" in {
+      try {
+        PipelineRunner.main(Array.empty[String])
+        fail("shouldn't read this code")
+      } catch {
+        case e: ExitException =>
+          assert(e.status != 0)
+      }
+    }
+  }
+}

--- a/pramen/runner/src/test/scala/za/co/absa/pramen/runner/RunnerCommonsSuite.scala
+++ b/pramen/runner/src/test/scala/za/co/absa/pramen/runner/RunnerCommonsSuite.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.tests
+package za.co.absa.pramen.runner
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.base.{SparkTestBase, TempDirFixture}
-import za.co.absa.pramen.runner.RunnerCommons
 
 import java.nio.file.{Files, Paths}
 import scala.util.control.NonFatal


### PR DESCRIPTION
I thought that methods that contain `System.exit()` can't be tested. But after reading about JVM internals, started searching and found how a `SecurityManager` manager could be used to prevent `System.exit()` from exiting the test app,