### PR TITLE
Release Pramen v.1.2.2

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -35,14 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         scala: [2.11.12, 2.12.17, 2.13.10]
-        spark: [2.4.8, 3.1.3, 3.2.2, 3.3.1]
+        spark: [2.4.8, 3.1.3, 3.2.3, 3.3.2]
         exclude:
           - scala: 2.11.12
             spark: 3.1.3
           - scala: 2.11.12
-            spark: 3.2.2
+            spark: 3.2.3
           - scala: 2.11.12
-            spark: 3.3.1
+            spark: 3.3.2
           - scala: 2.13.10
             spark: 2.4.8
           - scala: 2.13.10

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -18,8 +18,8 @@ import sbt._
 
 object Versions {
   val defaultSparkVersionForScala211 = "2.4.8"
-  val defaultSparkVersionForScala212 = "3.2.2"
-  val defaultSparkVersionForScala213 = "3.2.2"
+  val defaultSparkVersionForScala212 = "3.2.3"
+  val defaultSparkVersionForScala213 = "3.2.3"
 
   val typesafeConfigVersion = "1.4.0"
   val postgreSqlDriverVersion = "42.3.8"

--- a/pramen/project/plugins.sbt
+++ b/pramen/project/plugins.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
+addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.2.1")
 addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.1.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.7.0")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.2-SNAPSHOT"
+ThisBuild / version := "1.2.2"

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.2"
+ThisBuild / version := "1.2.3-SNAPSHOT"

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.2.3-SNAPSHOT"
+ThisBuild / version := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
## What's Changed

https://github.com/AbsaOSS/pramen/releases/tag/v1.2.2

* #132 Make command line sink more generic by @yruslan in https://github.com/AbsaOSS/pramen/pull/142
* #146 Fix failing tests from extras module on Windows. by @jirifilip in https://github.com/AbsaOSS/pramen/pull/147
* #145 Add an option for failing the pipeline if no data is available at the source by @yruslan in https://github.com/AbsaOSS/pramen/pull/148
* #150 Updated Spark Application Name (Syncwatcher -> Pramen) by @dwfchu in https://github.com/AbsaOSS/pramen/pull/150
* #153 Fix pipeline does not publish task completion events to the journal table. by @yruslan in https://github.com/AbsaOSS/pramen/pull/154
* #151 Specify number of threads to consume by a task. by @jirifilip in https://github.com/AbsaOSS/pramen/pull/156
* #149 Autodetect Enceladus info version by @yruslan in https://github.com/AbsaOSS/pramen/pull/155
* #162 Standardization sink by @yruslan in https://github.com/AbsaOSS/pramen/pull/163
* #167 Make checking of the workflow configuration file existence smarter. by @yruslan in https://github.com/AbsaOSS/pramen/pull/168
* #170 Delete empty folder on write error so readers won't be confused that the partition exists. by @yruslan in https://github.com/AbsaOSS/pramen/pull/172
* #164 Allow creation of Hive tables from StandardizationSink by @yruslan in https://github.com/AbsaOSS/pramen/pull/171
* #173 Unify JDBC retries config by @yruslan in https://github.com/AbsaOSS/pramen/pull/174


**Full Changelog**: https://github.com/AbsaOSS/pramen/compare/v1.2.1...v1.2.2