### PR TITLE
Feature/182 add custom query type

### DIFF
--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/Query.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/Query.scala
@@ -20,22 +20,37 @@ package za.co.absa.pramen.api
   * Query is an abstraction that unifies the way data can be retrieved from a source.
   */
 sealed trait Query {
+  def name: String
+
   def query: String
 }
 
 object Query {
   /** A SQL query. */
   case class Sql(sql: String) extends Query {
+    override def name: String = "sql"
+
     override def query: String = sql
   }
 
   /** A database table name. */
   case class Table(dbTable: String) extends Query {
+    override def name: String = "table"
+
     override def query: String = dbTable
   }
 
   /** A path to a directory. */
   case class Path(path: String) extends Query {
+    override def name: String = "path"
+
     override def query: String = path
+  }
+
+  /** A custom way of specifying query options. */
+  case class Custom(options: Map[String, String]) extends Query {
+    override def name: String = "custom"
+
+    override def query: String = options.map { case (k, v) => s"$k=$v" }.mkString("(", ", ", ")")
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceDelta.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceDelta.scala
@@ -49,7 +49,7 @@ class MetastorePersistenceDelta(query: Query,
           .load(path)
       case Query.Table(table) =>
         spark.table(table)
-      case _                  => throw new IllegalArgumentException(s"Arguments of type ${query.getClass} are not supported for Delta format.")
+      case _                  => throw new IllegalArgumentException(s"Arguments of type '${query.name}' are not supported for Delta format. Use either 'path' or 'table'.")
     }
 
     df.filter(getFilter(infoDateFrom, infoDateTo))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -91,7 +91,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
   }
 
   def renderSubject(): String = {
-    val timeCreatedStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+    val timeCreatedStr = ZonedDateTime.now(zoneId).format(timestampFmt)
     val (someTasksSucceeded, someTasksFailed) = getSuccessFlags
 
     val dryRunStr = if (isDryRun) "(DRY RUN) " else ""

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -104,8 +104,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
   private def getTableName(query: Query): String = {
     query match {
       case Query.Table(tableName) => tableName
-      case _: Query.Sql => throw new IllegalArgumentException("'sql' is not supported by the JDBC reader. Use 'table' instead.")
-      case _: Query.Path => throw new IllegalArgumentException("'path' is not supported by the JDBC reader. Use 'table' instead.")
+      case other => throw new IllegalArgumentException(s"'${other.name}' is not supported by the JDBC reader. Use 'table' instead.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{Query, TableReader}
 import za.co.absa.pramen.core.reader.model.JdbcConfig
-import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils, TimeUtils}
+import za.co.absa.pramen.core.utils.{JdbcNativeUtils, TimeUtils}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate}
@@ -57,8 +57,7 @@ class TableReaderJdbcNative(jdbcConfig: JdbcConfig)
   private def getSqlExpression(query: Query): String = {
     query match {
       case Query.Sql(sql) => sql
-      case _: Query.Table           => throw new IllegalArgumentException("'table' is not supported by the JDBC Native reader. Use 'sql' instead.")
-      case _: Query.Path          => throw new IllegalArgumentException("'path' is not supported by the JDBC Native reader. Use 'sql' instead.")
+      case other          => throw new IllegalArgumentException(s"'${other.name}' is not supported by the JDBC Native reader. Use 'sql' instead.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderSpark.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderSpark.scala
@@ -142,6 +142,7 @@ class TableReaderSpark(format: String,
         }
       case Query.Table(table) =>
         spark.table(table)
+      case other            => throw new IllegalArgumentException(s"'${other.name}' is not supported by the Spark reader. Use 'path', 'table' or 'sql' instead.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
@@ -55,6 +55,7 @@ class SparkSource(val format: String,
       case Query.Path(path) =>
         val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, path)
         fsUtils.getHadoopFiles(new Path(path))
+      case other            => throw new IllegalArgumentException(s"'${other.name}' is not supported by the Spark source. Use 'path', 'table' or 'sql' instead.")
     }
 
     SourceResult(df, filesRead)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
@@ -114,12 +114,18 @@ object ConfigUtils {
   }
 
   def getExtraOptions(conf: Config, prefix: String): Map[String, String] = {
-    if (conf.hasPath(prefix)) {
-      ConfigUtils.getFlatConfig(conf.getConfig(prefix))
-        .map { case (k, v) => (k, v.toString) }
+    val optionsConfig = if (prefix.isEmpty) {
+      conf
     } else {
-      Map()
+      if (conf.hasPath(prefix)) {
+        conf.getConfig(prefix)
+      } else {
+        ConfigFactory.empty()
+      }
     }
+
+    ConfigUtils.getFlatConfig(optionsConfig)
+      .map { case (k, v) => (k, v.toString) }
   }
 
   def getExtraOptions(options: Map[String, String],

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/model/QueryBuilderSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/model/QueryBuilderSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.model
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.api.Query
+
+class QueryBuilderSuite extends AnyWordSpec {
+  case class TestCase(prefix: String, configStr: String, expected: Query)
+
+  private val testCases = Seq(
+    TestCase("", """sql = "SELECT * FROM table"""", Query.Sql("SELECT * FROM table")),
+    TestCase("", """table = "table1"""", Query.Table("table1")),
+    TestCase("", """path = "/some/path"""", Query.Path("/some/path")),
+    TestCase("", """data.file.1 = "/some/data/file"""", Query.Custom(Map("data.file.1" -> "/some/data/file"))),
+    TestCase("input", """input.sql = "SELECT * FROM table"""", Query.Sql("SELECT * FROM table")),
+    TestCase("input", """input.table = table1""", Query.Table("table1")),
+    TestCase("input", """input.path = /some/path""", Query.Path("/some/path")),
+    TestCase("input", "input.data.file.1 = /some/data/file1\ninput.data.file.2 = /some/data/file2",
+      Query.Custom(Map("data.file.1" -> "/some/data/file1", "data.file.2" -> "/some/data/file2")))
+  )
+
+  "QueryBuilder" should {
+    testCases.foreach(testCase => {
+      s"build a query from a config for '${testCase.configStr}'" in {
+        val conf = ConfigFactory.parseString(testCase.configStr)
+
+        val query = QueryBuilder.fromConfig(conf, testCase.prefix, "")
+
+        assert(query == testCase.expected)
+      }
+    })
+
+    "throw an exception when no query configuration is specified" in {
+      val conf = ConfigFactory.parseString("")
+
+      val exception = intercept[IllegalArgumentException] {
+        QueryBuilder.fromConfig(conf, "", "")
+      }
+
+      assert(exception.getMessage == "No options are specified for the query. Usually, it is one of: 'sql', 'path', 'table', 'db.table'.")
+    }
+
+    "throw an exception when the prefix is empty" in {
+      val conf = ConfigFactory.parseString("data = /tmp")
+
+      val exception = intercept[IllegalArgumentException] {
+        QueryBuilder.fromConfig(conf, "input", "")
+      }
+
+      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table'.")
+    }
+
+    "throw an exception when the prefix is empty and parent is specified" in {
+      val conf = ConfigFactory.parseString("data = /tmp")
+
+      val exception = intercept[IllegalArgumentException] {
+        QueryBuilder.fromConfig(conf, "input", "my.parent")
+      }
+
+      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table' at my.parent.")
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableSuite.scala
@@ -116,9 +116,8 @@ class SourceTableSuite extends AnyWordSpec {
         SourceTable.fromConfig(conf, "source.tables")
       }
 
-      assert(ex.getMessage.contains("Either 'input.sql', 'input.path', 'input.table', 'input.db.table' is required at source.tables[0]"))
+      assert(ex.getMessage.contains("No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table' at source.tables[0]."))
     }
-
 
     "throw an exception in case of duplicate entries" in {
       val conf = ConfigFactory.parseString(

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ConfigUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ConfigUtilsSuite.scala
@@ -378,6 +378,19 @@ class ConfigUtilsSuite extends AnyWordSpec with TempDirFixture with TextComparis
       assert(map("value2") == "100")
     }
 
+    "return a new config even if the prefix is empty" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |value1 = "value1"
+          |value2 = 100
+          |""".stripMargin)
+      val map = ConfigUtils.getExtraOptions(conf, "")
+
+      assert(map.size == 2)
+      assert(map("value1") == "value1")
+      assert(map("value2") == "100")
+    }
+
     "return a new map if the prefix path exists" in {
       val map = ConfigUtils.getExtraOptions(
         Map[String, String]("mytest.extra.options.value1" -> "value1", "mytest.extra.options.value2" -> "100"),


### PR DESCRIPTION
Add support for custom queries for data sources (#182).

These are queries that cannot fit the standard set of `table`, `sql`, `path`.

I also included a tiny fix in this PR. Notification email subject was reporting date and time in the system timezone. I've noticed it since on AWS the system timezone is UTC. The fix is to honor the timezone configured in Pramen configuration.