### PR TITLE
#196 Make Hive enablement an explicit parameter.

### DIFF
--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -45,6 +45,9 @@ pramen {
   # If non-zero, specifies how many tasks can be ran in parallel
   parallel.tasks = 1
 
+  # Enables Hive (requires Hive JARs to be in the classpath)
+  enable.hive = true
+
   # If enabled, the job will wait for the output table to become available before running a job
   # If the number of seconds <=0 the waiting will be infinite
   wait.for.output.table.enabled = false

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
@@ -50,6 +50,8 @@ object Keys {
 
   val EXTRA_OPTIONS_PREFIX = "pramen.spark.conf.option"
 
+  val ENABLE_HIVE_SUPPORT = "pramen.enable.hive"
+
   val STOP_SPARK_SESSION = "pramen.stop.spark.session"
 
   val EXIT_CODE_ENABLED = "pramen.exit.code.enabled"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
@@ -45,8 +45,10 @@ object PipelineSparkSessionBuilder {
     * }}}
     */
   def buildSparkSession(conf: Config): SparkSession = {
-    val extraOptions = ConfigUtils.getExtraOptions(conf, EXTRA_OPTIONS_PREFIX)
+    val isHiveEnabled = conf.getBoolean(ENABLE_HIVE_SUPPORT)
+    log.info(s"Hive support enabled = $isHiveEnabled")
 
+    val extraOptions = ConfigUtils.getExtraOptions(conf, EXTRA_OPTIONS_PREFIX)
     log.info("Extra Spark Config:")
     ConfigUtils.renderExtraOptions(extraOptions, KEYS_TO_REDACT)(s => log.info(s))
 
@@ -64,9 +66,7 @@ object PipelineSparkSessionBuilder {
       case (builder, (key, value)) => builder.config(key, value)
     }
 
-    val isHiveSupportRequired = extraOptions.exists(_._1.contains("hive"))
-
-    val spark = if (isHiveSupportRequired) {
+    val spark = if (isHiveEnabled) {
       sparkSessionBuilderWithExtraOptApplied
         .enableHiveSupport()
         .getOrCreate()

--- a/pramen/core/src/test/resources/reference.conf
+++ b/pramen/core/src/test/resources/reference.conf
@@ -1,0 +1,17 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pramen {
+  # Disable Hive support in tests to avoid adding Hive dependencies to the project if not necessary.
+  enable.hive = false
+}


### PR DESCRIPTION
This is so that Pramen jobs can use cluster defaults for Hive configuration. The old logic didn't enable Hive support if no Hive-related options were configured.