### PR TITLE
#203 Add spark catalog support

### DIFF
--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -51,7 +51,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.3
         with:
           paths: >
-            ${{ github.workspace }}/pramen/runner/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/pramen/core/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
             ${{ github.workspace }}/pramen/extras/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: ${{ matrix.overall }}

--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -51,8 +51,8 @@ jobs:
         uses: madrapps/jacoco-report@v1.3
         with:
           paths: >
-            ${{ github.workspace }}/pramen/pramen/runner/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
-            ${{ github.workspace }}/pramen/pramen/extras/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml
+            ${{ github.workspace }}/pramen/runner/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/pramen/extras/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: ${{ matrix.overall }}
           min-coverage-changed-files: ${{ matrix.changed }}

--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -51,8 +51,8 @@ jobs:
         uses: madrapps/jacoco-report@v1.3
         with:
           paths: >
-            ${{ github.workspace }}/pramen/runner/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
-            ${{ github.workspace }}/pramen/extras/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml
+            ${{ github.workspace }}/pramen/pramen/runner/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml,
+            ${{ github.workspace }}/pramen/pramen/extras/target/scala-${{ matrix.scala_short }}/jacoco/report/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: ${{ matrix.overall }}
           min-coverage-changed-files: ${{ matrix.changed }}

--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,14 @@ Here is an example configuration of a sink:
     timestamp.format = "dd-MM-yyyy HH:mm:ss Z"
     date.format = "yyyy-MM-dd"
   }
+
+  # Hive properties
+  hive = {
+    # The API to use to query Hive. Valid values are: "sql" (default), "spark_catalog"
+    api = "sql"
+    database = "my_hive_db"
+    ignore.failures = false
+  }
 }
 ```
 </details>
@@ -2248,6 +2256,9 @@ pramen {
   }
   
   hive {
+    # The API to use to query Hive. Valid values are: "sql" (default), "spark_catalog"
+    hive.api = "sql"
+
     database = "my_db"
 
     # Optional, use only if you want to use JDBC rather than Spark metastore to query Hive
@@ -2281,11 +2292,18 @@ pramen.metastore {
         name = my_table
         format = parquet
         path = /a/b/c
-        hive.table = my_hive_table
+       
+        ## [Optional]  Hive oprions (if they are different from global defaults)
+        # The API to use to query Hive. Valid values are: "sql", "spark_catalog"
+        hive.api = "sql"
         hive.database = my_hive_db
-        # Override the table creation query for this table
+       
+        # [Optional] Hive table to create/repair after writes to this metastore table
+        hive.table = my_hive_table
+        
+        # [Optional] Override the table creation query for this table
         hive.conf.create.table.template = "..."
-        # Override Hive JDBC for this table
+        # [Optional] Override Hive JDBC for this table
         hive.jdbc {
         }
      }

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -48,6 +48,9 @@ pramen {
   # Enables Hive (requires Hive JARs to be in the classpath)
   enable.hive = true
 
+  # The API to use to query Hive. Valid values are: "sql", "spark_catalog"
+  hive.api = "sql"
+
   # If enabled, the job will wait for the output table to become available before running a job
   # If the number of seconds <=0 the waiting will be infinite
   wait.for.output.table.enabled = false

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -128,7 +128,7 @@ class MetastoreImpl(tableDefs: Seq[MetaTable],
     } else {
       if (hiveHelper.doesTableExist(mt.hiveConfig.database, hiveTable)) {
         log.info(s"The table '$fullTableName' exists. Repairing it.")
-        hiveHelper.repairHiveTable(mt.hiveConfig.database, hiveTable)
+        hiveHelper.repairHiveTable(mt.hiveConfig.database, hiveTable, format)
       } else {
         log.info(s"The table '$fullTableName' does not exist. Creating it.")
         hiveHelper.createOrUpdateHiveTable(path, format, effectiveSchema, Seq(mt.infoDateColumn), mt.hiveConfig.database, hiveTable)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveApi.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveApi.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.model
+
+sealed trait HiveApi
+
+object HiveApi {
+  case object Sql extends HiveApi
+  case object SparkCatalog extends HiveApi
+
+  def fromString(s: String): HiveApi = s match {
+    case "sql" => Sql
+    case "spark_catalog" => SparkCatalog
+    case _ => throw new IllegalArgumentException(s"Unknown Hive API config: '$s'. Only 'sql' and 'spark_catalog' are supported.")
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
@@ -19,10 +19,12 @@ package za.co.absa.pramen.core.utils
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DataType, StructType, TimestampType}
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.notify.pipeline.FieldChange
 import za.co.absa.pramen.core.pipeline.TransformExpression
@@ -223,6 +225,26 @@ object SparkUtils {
       df.show(numRows, truncate = false)
     }
     new String(outCapture.toByteArray).replace("\r\n", "\n")
+  }
+
+  def createExternalTable(tableName: String,
+                          location: String,
+                          schema: StructType,
+                          partitionCols: Seq[String], source: String)
+                         (implicit spark: SparkSession): Unit = {
+    val tableIdent = spark.sessionState.sqlParser.parseTableIdentifier(tableName)
+    val storage = DataSource.buildStorageFormatFromOptions(Map("path" -> location))
+    val tableDesc = CatalogTable(
+      identifier = tableIdent,
+      tableType = CatalogTableType.EXTERNAL,
+      storage = storage,
+      schema = schema,
+      partitionColumnNames = partitionCols,
+      provider = Some(source)
+    )
+
+    val plan = CreateTable(tableDesc, SaveMode.ErrorIfExists, None)
+    spark.sessionState.executePlan(plan).toRdd
   }
 
   private def getActualProcessingTimeUdf: UserDefinedFunction = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveFormat.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveFormat.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.hive
+
+trait HiveFormat {
+  def name: String
+}
+
+object HiveFormat {
+  case object Parquet extends HiveFormat {
+    override def name: String = "parquet"
+  }
+
+  case object Delta extends HiveFormat {
+    override def name: String = "delta"
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveFormat.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveFormat.scala
@@ -18,14 +18,20 @@ package za.co.absa.pramen.core.utils.hive
 
 trait HiveFormat {
   def name: String
+
+  def repairPartitionsRequired: Boolean
 }
 
 object HiveFormat {
   case object Parquet extends HiveFormat {
     override def name: String = "parquet"
+
+    override def repairPartitionsRequired: Boolean = true
   }
 
   case object Delta extends HiveFormat {
     override def name: String = "delta"
+
+    override def repairPartitionsRequired: Boolean = false
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
@@ -57,7 +57,7 @@ object HiveHelper {
                    tableName: String): String = {
 
     databaseName match {
-      case Some(dbName) => s"$dbName.$tableName"
+      case Some(dbName) => s"`$dbName`.`$tableName`"
       case None         => tableName
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
@@ -23,7 +23,8 @@ import za.co.absa.pramen.core.metastore.model.HiveConfig
 import za.co.absa.pramen.core.reader.JdbcUrlSelector
 
 abstract class HiveHelper {
-  def createOrUpdateHiveTable(parquetPath: String,
+  def createOrUpdateHiveTable(path: String,
+                              format: HiveFormat,
                               schema: StructType,
                               partitionBy: Seq[String],
                               databaseName: Option[String],
@@ -40,7 +41,7 @@ object HiveHelper {
   def apply(conf: Config)(implicit spark: SparkSession): HiveHelper = {
     val queryExecutor = new QueryExecutorSpark()
     val hiveTemplates = HiveQueryTemplates.fromConfig(conf)
-    new HiveHelperImpl(queryExecutor, hiveTemplates)
+    new HiveHelperSql(queryExecutor, hiveTemplates)
   }
 
   def fromHiveConfig(hiveConfig: HiveConfig)
@@ -49,7 +50,7 @@ object HiveHelper {
       case Some(jdbcConfig) => new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig))
       case None             => new QueryExecutorSpark()
     }
-    new HiveHelperImpl(queryExecutor, hiveConfig.templates)
+    new HiveHelperSql(queryExecutor, hiveConfig.templates)
   }
 
   def getFullTable(databaseName: Option[String],

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSparkCatalog.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSparkCatalog.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.hive
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
+import org.slf4j.LoggerFactory
+
+import scala.util.control.NonFatal
+
+class HiveHelperSparkCatalog(spark: SparkSession) extends HiveHelper {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override def createOrUpdateHiveTable(path: String,
+                                       format: HiveFormat,
+                                       schema: StructType,
+                                       partitionBy: Seq[String],
+                                       databaseName: Option[String],
+                                       tableName: String): Unit = {
+    val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
+
+    if (spark.catalog.tableExists(fullTableName)) {
+      log.info(s"Table $fullTableName already exists. Dropping it...")
+      dropCatalogTable(fullTableName)
+    }
+
+    createCatalogTable(fullTableName, path, format)
+
+    if (partitionBy.nonEmpty) {
+      repairCatalogTable(fullTableName)
+    }
+  }
+
+  override def repairHiveTable(databaseName: Option[String],
+                               tableName: String): Unit = {
+    val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
+
+    repairCatalogTable(fullTableName)
+  }
+
+  private def dropCatalogTable(fullTableName: String): Unit = {
+    spark.sql(s"DROP TABLE $fullTableName").collect()
+  }
+
+  override def doesTableExist(databaseName: Option[String], tableName: String): Boolean = spark.catalog.tableExists(HiveHelper.getFullTable(databaseName, tableName))
+
+  private def createCatalogTable(fullTableName: String,
+                              path: String,
+                              format: HiveFormat
+                             ): Unit = {
+
+    log.info(s"Creating Spark Catalog table: $fullTableName...")
+
+    spark.catalog.createTable(fullTableName, path, format.name).collect()
+  }
+
+
+  private def repairCatalogTable(fullTableName: String): Unit = {
+    try {
+      spark.catalog.recoverPartitions(fullTableName)
+    } catch {
+      case NonFatal(ex) =>
+        log.warn(s"Failed to repair table $fullTableName", ex)
+    }
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
@@ -39,10 +39,13 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
   }
 
   override def repairHiveTable(databaseName: Option[String],
-                               tableName: String): Unit = {
-    val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
+                               tableName: String,
+                               format: HiveFormat): Unit = {
+    if (format.repairPartitionsRequired) {
+      val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
 
-    repairHiveTable(fullTableName)
+      repairHiveTable(fullTableName)
+    }
   }
 
   private def dropHiveTable(fullTableName: String): Unit = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -251,10 +251,19 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
         val qe = new QueryExecutorMock(tableExists = true)
         val hh = new HiveHelperSql(qe, defaultTemplates)
 
-        m.repairOrCreateHiveTable("table_hive_delta", infoDate, Option(schema), hh, recreate = false)
+        m.repairOrCreateHiveTable("table_hive_parquet", infoDate, Option(schema), hh, recreate = false)
 
         assert(qe.queries.length == 1)
         assert(qe.queries.exists(_.contains("REPAIR")))
+      }
+
+      "do nothing for a delta since it does not need repairing" in {
+        val qe = new QueryExecutorMock(tableExists = true)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
+
+        m.repairOrCreateHiveTable("table_hive_delta", infoDate, Option(schema), hh, recreate = false)
+
+        assert(qe.queries.isEmpty)
       }
 
       "re-create if not exist" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -26,7 +26,7 @@ import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
 import za.co.absa.pramen.core.utils.SparkUtils
-import za.co.absa.pramen.core.utils.hive.{HiveHelperImpl, HiveQueryTemplates, QueryExecutorSpark}
+import za.co.absa.pramen.core.utils.hive.{HiveHelperSql, HiveQueryTemplates, QueryExecutorSpark}
 
 import java.time.LocalDate
 
@@ -224,9 +224,9 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         val hiveHelper = m.getHiveHelper("table1")
 
-        assert(hiveHelper.isInstanceOf[HiveHelperImpl])
+        assert(hiveHelper.isInstanceOf[HiveHelperSql])
 
-        assert(hiveHelper.asInstanceOf[HiveHelperImpl].queryExecutor.isInstanceOf[QueryExecutorSpark])
+        assert(hiveHelper.asInstanceOf[HiveHelperSql].queryExecutor.isInstanceOf[QueryExecutorSpark])
       }
     }
   }
@@ -240,7 +240,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
       "do nothing if hive table is not defined" in {
         val qe = new QueryExecutorMock(tableExists = true)
-        val hh = new HiveHelperImpl(qe, defaultTemplates)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
 
         m.repairOrCreateHiveTable("table1", infoDate, Option(schema), hh, recreate = false)
 
@@ -249,7 +249,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
       "repair existing table" in {
         val qe = new QueryExecutorMock(tableExists = true)
-        val hh = new HiveHelperImpl(qe, defaultTemplates)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
 
         m.repairOrCreateHiveTable("table_hive_delta", infoDate, Option(schema), hh, recreate = false)
 
@@ -259,7 +259,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
       "re-create if not exist" in {
         val qe = new QueryExecutorMock(tableExists = false)
-        val hh = new HiveHelperImpl(qe, defaultTemplates)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
 
         m.repairOrCreateHiveTable("table_hive_parquet", infoDate, Option(schema), hh, recreate = false)
 
@@ -271,7 +271,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
       "re-create if requested" in {
         val qe = new QueryExecutorMock(tableExists = true)
-        val hh = new HiveHelperImpl(qe, defaultTemplates)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
 
         m.repairOrCreateHiveTable("table_hive_parquet", infoDate, Option(schema), hh, recreate = true)
 
@@ -283,7 +283,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
       "throw an exception if query is not supported" in {
         val qe = new QueryExecutorMock(tableExists = true)
-        val hh = new HiveHelperImpl(qe, defaultTemplates)
+        val hh = new HiveHelperSql(qe, defaultTemplates)
 
         val ex = intercept[IllegalArgumentException] {
           m.repairOrCreateHiveTable("table_hive_not_supported", infoDate, Option(schema), hh, recreate = false)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
@@ -25,13 +25,16 @@ class HiveConfigSuite extends AnyWordSpec {
     "return the default config if not overridden" in {
       val conf = ConfigFactory.empty()
 
-      val defaultConfig = HiveDefaultConfig(Some("mydb1"),
+      val defaultConfig = HiveDefaultConfig(
+        HiveApi.SparkCatalog,
+        Some("mydb1"),
         Map("parquet" -> HiveQueryTemplates("create1", "repair1", "drop1")),
         None,
         ignoreFailures = true)
 
       val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, defaultConfig, DataFormat.Parquet("dummy", None))
 
+      assert(hiveConfig.hiveApi == HiveApi.SparkCatalog)
       assert(hiveConfig.database.contains("mydb1"))
       assert(hiveConfig.jdbcConfig.isEmpty)
       assert(hiveConfig.ignoreFailures)
@@ -42,7 +45,8 @@ class HiveConfigSuite extends AnyWordSpec {
 
     "return the overridden config" in {
       val conf = ConfigFactory.parseString(
-        """database = mydb2
+        """api = spark_catalog
+          |database = mydb2
           |
           |ignore.failures = true
           |
@@ -60,13 +64,16 @@ class HiveConfigSuite extends AnyWordSpec {
           |}
           |""".stripMargin)
 
-      val defaultConfig = HiveDefaultConfig(Some("mydb1"),
+      val defaultConfig = HiveDefaultConfig(
+        HiveApi.Sql,
+        Some("mydb1"),
         Map("parquet" -> HiveQueryTemplates("create1", "repair1", "drop1")),
         None,
         ignoreFailures = false)
 
       val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, defaultConfig, DataFormat.Parquet("dummy", None))
 
+      assert(hiveConfig.hiveApi == HiveApi.SparkCatalog)
       assert(hiveConfig.database.contains("mydb2"))
       assert(hiveConfig.jdbcConfig.nonEmpty)
       assert(hiveConfig.jdbcConfig.map(_.driver).contains("driver2"))
@@ -79,13 +86,16 @@ class HiveConfigSuite extends AnyWordSpec {
 
   "fromDefaults()" should {
     "return the default config" in {
-      val defaultConfig = HiveDefaultConfig(Some("mydb"),
+      val defaultConfig = HiveDefaultConfig(
+        HiveApi.Sql,
+        Some("mydb"),
         Map("parquet" -> HiveQueryTemplates("create", "repair", "drop")),
         None,
         ignoreFailures = true)
 
       val hiveConfig = HiveConfig.fromDefaults(defaultConfig, DataFormat.Parquet("dummy", None))
 
+      assert(hiveConfig.hiveApi == HiveApi.Sql)
       assert(hiveConfig.database.contains("mydb"))
       assert(hiveConfig.jdbcConfig.isEmpty)
       assert(hiveConfig.ignoreFailures)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveDefaultConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveDefaultConfigSuite.scala
@@ -26,6 +26,7 @@ class HiveDefaultConfigSuite extends AnyWordSpec {
 
       val hiveDefaultConfig = HiveDefaultConfig.fromConfig(conf)
 
+      assert(hiveDefaultConfig.hiveApi == HiveApi.Sql)
       assert(hiveDefaultConfig.database.isEmpty)
       assert(hiveDefaultConfig.jdbcConfig.isEmpty)
       assert(!hiveDefaultConfig.ignoreFailures)
@@ -37,6 +38,7 @@ class HiveDefaultConfigSuite extends AnyWordSpec {
     "return overridden config" in {
       val conf = ConfigFactory.parseString(
         """pramen.hive {
+          |  api = spark_catalog
           |  database = mydb
           |
           |  table = my_hive_table
@@ -62,6 +64,7 @@ class HiveDefaultConfigSuite extends AnyWordSpec {
 
       val hiveDefaultConfig = HiveDefaultConfig.fromConfig(conf.getConfig("pramen.hive"))
 
+      assert(hiveDefaultConfig.hiveApi == HiveApi.SparkCatalog)
       assert(hiveDefaultConfig.database.contains("mydb"))
       assert(hiveDefaultConfig.jdbcConfig.map(_.driver).contains("driver"))
       assert(hiveDefaultConfig.ignoreFailures)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -23,7 +23,7 @@ import za.co.absa.pramen.core.metastore.model.MetaTable
 import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, TableNotConfigured}
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
-import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperImpl, HiveQueryTemplates}
+import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperSql, HiveQueryTemplates}
 
 import java.time.LocalDate
 import scala.collection.mutable.ListBuffer
@@ -75,7 +75,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
   def getHiveHelper(tableName: String): HiveHelper = {
     val defaultQueryTemplates = HiveQueryTemplates.getDefaultQueryTemplates
 
-    new HiveHelperImpl(new QueryExecutorMock(isTableAvailable), defaultQueryTemplates)
+    new HiveHelperSql(new QueryExecutorMock(isTableAvailable), defaultQueryTemplates)
   }
 
   override def repairOrCreateHiveTable(tableName: String, infoDate: LocalDate, schema: Option[StructType], hiveHelper: HiveHelper, recreate: Boolean): Unit = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/pipeline/PipelineNotificationBuilderHtmlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/pipeline/PipelineNotificationBuilderHtmlSuite.scala
@@ -102,8 +102,6 @@ class PipelineNotificationBuilderHtmlSuite extends AnyWordSpec with TextComparis
 
       val actual = builder.renderBody()
 
-      println(actual)
-
       // Can't test the full body since stack trace depends on the runner of the unit test
       assert(actual.contains("<pre>java.lang.IllegalArgumentException: MyTest exception"))
       assert(actual.contains("Cause 1"))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveApiSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveApiSuite.scala
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.core.metastore.model
+package za.co.absa.pramen.core.tests.utils.hive
 
-sealed trait HiveApi
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.metastore.model.HiveApi
 
-object HiveApi {
-  case object Sql extends HiveApi
-  case object SparkCatalog extends HiveApi
+class HiveApiSuite extends AnyWordSpec {
+  "fromString()" should {
+    "properly parse 'sql'" in {
+      assert(HiveApi.fromString("SqL") == HiveApi.Sql)
+    }
 
-  def fromString(s: String): HiveApi = s.toLowerCase() match {
-    case "sql" => Sql
-    case "spark_catalog" => SparkCatalog
-    case _ => throw new IllegalArgumentException(s"Unknown Hive API config: '$s'. Only 'sql' and 'spark_catalog' are supported.")
+    "properly parse 'spark_catalog'" in {
+      assert(HiveApi.fromString("spark_catalog") == HiveApi.SparkCatalog)
+    }
+
+    "throw on an invalid value" in {
+      assertThrows[IllegalArgumentException](HiveApi.fromString("dummy"))
+    }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSparkCatalogSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSparkCatalogSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.utils.hive
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.functions.lit
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.utils.FsUtils
+import za.co.absa.pramen.core.utils.hive.{HiveFormat, HiveHelperSparkCatalog}
+
+class HiveHelperSparkCatalogSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
+
+  import spark.implicits._
+
+  "createOrUpdateHiveTable()" should {
+    "create a non-partitioned Parquet table" in {
+      withTempDirectory("hive_test") { tempDir =>
+        val path = getParquetPath(tempDir)
+
+        val hiveHelper = new HiveHelperSparkCatalog(spark)
+        val schema = spark.read.parquet(path).schema
+
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, Nil, Some("default"), "tbl1")
+        assert(spark.catalog.tableExists("default.tbl1"))
+
+        // If the table exists it should be re-created
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, Nil, Some("default"), "tbl1")
+        assert(spark.catalog.tableExists("default.tbl1"))
+      }
+    }
+
+    "create a partitioned Parquet table" in {
+      withTempDirectory("hive_test") { tempDir =>
+        val path = getParquetPath(tempDir)
+
+        val hiveHelper = new HiveHelperSparkCatalog(spark)
+        val schema = spark.read.parquet(path).withColumn("b", lit(1)).schema
+
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, "a" :: "b" :: Nil, Some("default"), "tbl2")
+        assert(hiveHelper.doesTableExist(Some("default"),"tbl2"))
+
+        spark.sql(s"DROP TABLE default.tbl2").collect()
+        assert(!hiveHelper.doesTableExist(Some("default"),"tbl2"))
+
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, "a" :: "b" :: Nil, Some("default"), "tbl2")
+        assert(hiveHelper.doesTableExist(Some("default"),"tbl2"))
+      }
+    }
+
+    "create a partitioned Delta table" in {
+      withTempDirectory("hive_test") { tempDir =>
+        val path = getDeltaPath(tempDir, Seq("b"))
+
+        val hiveHelper = new HiveHelperSparkCatalog(spark)
+        val schema = spark.read.format("delta").load(path).withColumn("b", lit(1)).schema
+
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Delta, schema, "b" :: Nil, Some("default"), "tbl3")
+        assert(hiveHelper.doesTableExist(Some("default"), "tbl3"))
+
+        assert(spark.table("default.tbl3").count() == 3)
+      }
+    }
+  }
+
+  private def getParquetPath(tempBaseDir: String, partitionBy: Seq[String] = Nil): String = {
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, "file:///")
+
+    val tempDir = fsUtils.getTempPath(new Path(tempBaseDir)).toString
+
+    val df = List(("A", 1, 10), ("B", 2, 20), ("C", 3, 30)).toDF("a", "b", "c")
+
+    if (partitionBy.isEmpty) {
+      df.repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .parquet(tempDir)
+    } else {
+      df.repartition(1)
+        .write
+        .mode(SaveMode.Overwrite)
+        .partitionBy(partitionBy: _*)
+        .parquet(tempDir)
+    }
+
+    tempDir
+  }
+
+  private def getDeltaPath(tempBaseDir: String, partitionBy: Seq[String]): String = {
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, "file:///")
+
+    val tempDir = fsUtils.getTempPath(new Path(tempBaseDir)).toString
+
+    val df = List(("A", 1, 10), ("B", 2, 20), ("C", 3, 30)).toDF("a", "b", "c")
+
+    df.repartition(1)
+      .write
+      .mode(SaveMode.Overwrite)
+      .partitionBy(partitionBy: _*)
+      .format("delta")
+      .save(tempDir)
+
+    tempDir
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
@@ -100,7 +100,7 @@ class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixt
       val qe = new QueryExecutorMock(tableExists = true)
       val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
 
-      hiveHelper.repairHiveTable(Some("db"), "tbl")
+      hiveHelper.repairHiveTable(Some("db"), "tbl", HiveFormat.Parquet)
 
       val actual = qe.queries.mkString("\n")
 
@@ -113,11 +113,20 @@ class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixt
       val qe = new QueryExecutorMock(tableExists = true)
       val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
 
-      hiveHelper.repairHiveTable(None, "tbl")
+      hiveHelper.repairHiveTable(None, "tbl", HiveFormat.Parquet)
 
       val actual = qe.queries.mkString("\n")
 
       compareText(actual, expected)
+    }
+
+    "not repair table for Delta" in {
+      val qe = new QueryExecutorMock(tableExists = true)
+      val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
+
+      hiveHelper.repairHiveTable(Some("db"), "tbl", HiveFormat.Delta)
+
+      assert(qe.queries.isEmpty)
     }
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
@@ -95,7 +95,7 @@ class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixt
     }
 
     "repair table with database" in {
-      val expected = "MSCK REPAIR TABLE db.tbl"
+      val expected = "MSCK REPAIR TABLE `db`.`tbl`"
 
       val qe = new QueryExecutorMock(tableExists = true)
       val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
@@ -25,9 +25,9 @@ import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
 import za.co.absa.pramen.core.utils.FsUtils
-import za.co.absa.pramen.core.utils.hive.{HiveHelperImpl, HiveQueryTemplates}
+import za.co.absa.pramen.core.utils.hive.{HiveFormat, HiveHelperSql, HiveQueryTemplates}
 
-class HiveHelperImplSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
+class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
 
   import spark.implicits._
 
@@ -51,10 +51,10 @@ class HiveHelperImplSuite extends AnyWordSpec with SparkTestBase with TempDirFix
 
 
         val qe = new QueryExecutorMock(tableExists = false)
-        val hiveHelper = new HiveHelperImpl(qe, defaultHiveConfig)
+        val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
         val schema = spark.read.parquet(path).schema
 
-        hiveHelper.createOrUpdateHiveTable(path, schema, Nil, Some("db"), "tbl")
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, Nil, Some("db"), "tbl")
 
         qe.close()
 
@@ -83,10 +83,10 @@ class HiveHelperImplSuite extends AnyWordSpec with SparkTestBase with TempDirFix
 
 
         val qe = new QueryExecutorMock(tableExists = false)
-        val hiveHelper = new HiveHelperImpl(qe, defaultHiveConfig)
+        val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
         val schema = spark.read.parquet(path).withColumn("b", lit(1)).schema
 
-        hiveHelper.createOrUpdateHiveTable(path, schema, "a" :: "b" :: Nil, Some("db"), "tbl")
+        hiveHelper.createOrUpdateHiveTable(path, HiveFormat.Parquet, schema, "a" :: "b" :: Nil, Some("db"), "tbl")
 
         val actual = qe.queries.mkString("\n").replaceAll("`", "")
 
@@ -98,7 +98,7 @@ class HiveHelperImplSuite extends AnyWordSpec with SparkTestBase with TempDirFix
       val expected = "MSCK REPAIR TABLE db.tbl"
 
       val qe = new QueryExecutorMock(tableExists = true)
-      val hiveHelper = new HiveHelperImpl(qe, defaultHiveConfig)
+      val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
 
       hiveHelper.repairHiveTable(Some("db"), "tbl")
 
@@ -111,7 +111,7 @@ class HiveHelperImplSuite extends AnyWordSpec with SparkTestBase with TempDirFix
       val expected = "MSCK REPAIR TABLE tbl"
 
       val qe = new QueryExecutorMock(tableExists = true)
-      val hiveHelper = new HiveHelperImpl(qe, defaultHiveConfig)
+      val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig)
 
       hiveHelper.repairHiveTable(None, "tbl")
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSuite.scala
@@ -19,26 +19,29 @@ package za.co.absa.pramen.core.tests.utils.hive
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
-import za.co.absa.pramen.core.metastore.model.{DataFormat, HiveConfig, HiveDefaultConfig}
-import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperSql, QueryExecutorJdbc, QueryExecutorSpark}
+import za.co.absa.pramen.core.metastore.model.{DataFormat, HiveApi, HiveConfig, HiveDefaultConfig}
+import za.co.absa.pramen.core.utils.hive._
 
 class HiveHelperSuite extends AnyWordSpec with SparkTestBase {
-  "HiveHelper" should {
-    "create a default instance of HiveHelper" in {
-      val hiveHelper = HiveHelper(ConfigFactory.empty())(spark)
-
-      assert(hiveHelper != null)
-      assert(hiveHelper.isInstanceOf[HiveHelperSql])
-    }
-  }
-
   "fromHiveConfig()" should {
     "return the helper backed by Spark metastore" in {
       val hiveConfig = HiveConfig.getNullConfig
 
-      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig).asInstanceOf[HiveHelperSql]
+      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig)
 
-      assert(hiveHelper.queryExecutor.isInstanceOf[QueryExecutorSpark])
+      assert(hiveHelper.isInstanceOf[HiveHelperSql])
+
+      val hiveHelperSql = hiveHelper.asInstanceOf[HiveHelperSql]
+
+      assert(hiveHelperSql.queryExecutor.isInstanceOf[QueryExecutorSpark])
+    }
+
+    "return the helper backed by Spark Catalog" in {
+      val hiveConfig = HiveConfig.getNullConfig.copy(hiveApi = HiveApi.SparkCatalog)
+
+      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig)
+
+      assert(hiveHelper.isInstanceOf[HiveHelperSparkCatalog])
     }
 
     "return the helper backed by a JDBC connection" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSuite.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.metastore.model.{DataFormat, HiveConfig, HiveDefaultConfig}
-import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperImpl, QueryExecutorJdbc, QueryExecutorSpark}
+import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperSql, QueryExecutorJdbc, QueryExecutorSpark}
 
 class HiveHelperSuite extends AnyWordSpec with SparkTestBase {
   "HiveHelper" should {
@@ -28,7 +28,7 @@ class HiveHelperSuite extends AnyWordSpec with SparkTestBase {
       val hiveHelper = HiveHelper(ConfigFactory.empty())(spark)
 
       assert(hiveHelper != null)
-      assert(hiveHelper.isInstanceOf[HiveHelperImpl])
+      assert(hiveHelper.isInstanceOf[HiveHelperSql])
     }
   }
 
@@ -36,7 +36,7 @@ class HiveHelperSuite extends AnyWordSpec with SparkTestBase {
     "return the helper backed by Spark metastore" in {
       val hiveConfig = HiveConfig.getNullConfig
 
-      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig).asInstanceOf[HiveHelperImpl]
+      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig).asInstanceOf[HiveHelperSql]
 
       assert(hiveHelper.queryExecutor.isInstanceOf[QueryExecutorSpark])
     }
@@ -55,7 +55,7 @@ class HiveHelperSuite extends AnyWordSpec with SparkTestBase {
 
       val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, hiveDefaultConfig, DataFormat.Parquet("Dummy", None))
 
-      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig).asInstanceOf[HiveHelperImpl]
+      val hiveHelper = HiveHelper.fromHiveConfig(hiveConfig).asInstanceOf[HiveHelperSql]
 
       assert(hiveHelper.queryExecutor.isInstanceOf[QueryExecutorJdbc])
     }

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/StandardizationSink.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/StandardizationSink.scala
@@ -199,6 +199,7 @@ class StandardizationSink(sinkConfig: Config,
       log.info(s"Updating Hive table '$fullTableName'...")
       try {
         hiveHelper.createOrUpdateHiveTable(publishBasePath.toUri.toString,
+          HiveFormat.Parquet,
           fullSchema,
           paritionBy,
           standardizationConfig.hiveDatabase,
@@ -342,7 +343,7 @@ object StandardizationSink extends ExternalChannelFactory[StandardizationSink] {
         log.info("Using Spark to connect to Hive")
         QueryExecutorSpark(spark)
     }
-    val hiveHelper = new HiveHelperImpl(queryExecutor, hiveConfig)
+    val hiveHelper = new HiveHelperSql(queryExecutor, hiveConfig)
 
     new StandardizationSink(conf, standardizationConfig, hiveHelper)
   }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/StandardizationSinkSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/StandardizationSinkSuite.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.core.utils.hive.{HiveHelperImpl, HiveQueryTemplates}
+import za.co.absa.pramen.core.utils.hive.{HiveHelperSql, HiveQueryTemplates}
 import za.co.absa.pramen.extras.base.SparkTestBase
 import za.co.absa.pramen.extras.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.extras.mocks.QueryExecutorMock
@@ -177,7 +177,7 @@ class StandardizationSinkSuite extends AnyWordSpec with SparkTestBase with TextC
       val stdConfig = StandardizationConfig.fromConfig(conf)
       val hiveConfig = HiveQueryTemplates.fromConfig(conf)
       val qe = new QueryExecutorMock(tableExists = true)
-      val hiveHelper = new HiveHelperImpl(qe, hiveConfig)
+      val hiveHelper = new HiveHelperSql(qe, hiveConfig)
       val sink = new StandardizationSink(conf, stdConfig, hiveHelper)
 
       withTempDirectory("std_sink") { tempDir =>
@@ -206,7 +206,7 @@ class StandardizationSinkSuite extends AnyWordSpec with SparkTestBase with TextC
       val stdConfig = StandardizationConfig.fromConfig(updatedConf)
       val hiveConfig = HiveQueryTemplates.fromConfig(conf)
       val qe = new QueryExecutorMock(tableExists = true, () => throw new RuntimeException("Hive exception"))
-      val hiveHelper = new HiveHelperImpl(qe, hiveConfig)
+      val hiveHelper = new HiveHelperSql(qe, hiveConfig)
       val sink = new StandardizationSink(conf, stdConfig, hiveHelper)
 
       withTempDirectory("std_sink") { tempDir =>


### PR DESCRIPTION
This adds another HiveHelper implementation that is based on Spark Catalog, rather than running explicit SQL query against Hive metastore.

Spark Catalog allows natural management of Glue Catalog tables in Delta format, provided that prerequisites for the Glue job are met: https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-format-delta-lake.html.

Global Hive implementation selection:
```hocon
pramen {
  # ...

  # The API to use to query Hive. Valid values are: "sql", "spark_catalog"
  hive.api = "sql"
}
```

Per-metastore table Hive implementation selection:
```hocon
pramen.metastore {
  tables = [
    {
      # ...

      # The API to use to query Hive. Valid values are: "sql", "spark_catalog"
      hive.api = "spark_catalog"
      hive.table = "table"
    }
  ]
}
```

Standardization Sink Hive implementation selection:
```hocon
pramen.sinks = [
  {
    name = "mysink"
    factory.class = "za.co.absa.pramen.extras.sink.StandardizationSink"

    # ...

    hive = {
      # The API to use to query Hive. Valid values are: "sql", "spark_catalog"
      api = "sql"
    }
  }
]
```