### PR TITLE
Make AppRunner recreate AppContext on every run

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -19,7 +19,6 @@ package za.co.absa.pramen.core.runner
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.core.AppContextFactory
 import za.co.absa.pramen.core.app.{AppContext, AppContextImpl}
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.pipeline.{Job, OperationSplitter, PipelineDef}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.AppContextFactory
-import za.co.absa.pramen.core.app.AppContext
+import za.co.absa.pramen.core.app.{AppContext, AppContextImpl}
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.pipeline.{Job, OperationSplitter, PipelineDef}
 import za.co.absa.pramen.core.runner.jobrunner.{ConcurrentJobRunner, ConcurrentJobRunnerImpl}
@@ -93,7 +93,7 @@ object AppRunner {
                                      state: PipelineState,
                                      spark: SparkSession): Try[AppContext] = {
     handleFailure(Try {
-      AppContextFactory.getOrCreate(conf)
+      AppContextImpl(conf)
     }, state, "initialization of the pipeline")
   }
 


### PR DESCRIPTION
We hit some issues on Databricks where, if we run a Pramen job repeatedly on an all-purpose cluster or in a notebook, the `AppContext` gets created only once. In the `AppContext` creation process, metastore config is parsed and configured. Thus, if we change the metastore config between runs on an all-purpose cluster, it has no effect on the pipeline run, since Pramen will be using an already created `AppContext` from the JVM process (with old metastore table definitions).

So far did not remove any dead code (`AppContextFactory` and its tests) in case we would like to use it in the future.   