### PR TITLE
EnceladusSink - several new features

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{Query, TableReader}
 import za.co.absa.pramen.core.config.Keys
+import za.co.absa.pramen.core.config.Keys.KEYS_TO_REDACT
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
 import za.co.absa.pramen.core.sql.{SqlColumnType, SqlConfig, SqlGenerator}
 import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
@@ -191,7 +192,13 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
   private def getOptions(optionName: String, optionValue: Option[Any]): Map[String, String] = {
     optionValue match {
       case Some(value) =>
-        log.info(s"JDBC reader $optionName = $value")
+        val keyLowercase = optionName
+        val redactedValue = if (KEYS_TO_REDACT.exists(k => keyLowercase.contains(k))) {
+          "[redacted]"
+        } else {
+          value.toString
+        }
+        log.info(s"JDBC reader $optionName = $redactedValue")
         Map[String, String](optionName -> value.toString)
       case None =>
         Map[String, String]()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JvmUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JvmUtils.scala
@@ -26,7 +26,12 @@ object JvmUtils {
     if (ex.getCause == null) {
       ex.getMessage
     } else {
-      s"${ex.getMessage} (${ex.getCause.getMessage})"
+      val cause = ex.getCause
+      if (cause.getCause == null) {
+        s"${ex.getMessage} (${ex.getCause.getMessage})"
+      } else {
+        s"${ex.getMessage} (${cause.getMessage} caused by ${cause.getCause.getMessage})"
+      }
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JvmUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JvmUtilsSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.utils
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.utils.JvmUtils
+
+class JvmUtilsSuite extends AnyWordSpec {
+  "getShortExceptionDescription()" should {
+    "work with an exception that does not have a cause" in {
+      val actual = JvmUtils.getShortExceptionDescription(new RuntimeException("Dummy1"))
+
+      assert(actual == "Dummy1")
+    }
+
+    "work with an exception that has a cause" in {
+      val actual = JvmUtils.getShortExceptionDescription(new RuntimeException("Dummy1", new RuntimeException("Dummy2")))
+
+      assert(actual == "Dummy1 (Dummy2)")
+    }
+
+    "work with an exception that has a cause of a cause" in {
+      val actual = JvmUtils.getShortExceptionDescription(new RuntimeException("Dummy1", new RuntimeException("Dummy2", new RuntimeException("Dummy3"))))
+
+      assert(actual == "Dummy1 (Dummy2 caused by Dummy3)")
+    }
+  }
+}

--- a/pramen/examples/enceladus_single_config/daily_ingestion.conf
+++ b/pramen/examples/enceladus_single_config/daily_ingestion.conf
@@ -12,17 +12,16 @@
 # limitations under the License.
 
 pramen {
-  run.type = "(Prod)"
-  environment.name = "MyEnv "${pramen.run.type}
+  environment.name = "(Prod) MyEnvName"
   pipeline.name = "My DCE pipeline"
-
-  parallel.tasks = 1
 
   bookkeeping.enabled = false
 
   email.if.no.changes = false
 
   temporary.directory = "/tmp/pramen"
+
+  parallel.tasks = 1
 }
 
 mail {
@@ -48,7 +47,7 @@ pramen.metastore {
 
 pramen.sources = [
   {
-    name = "postgre"
+    name = "my_source"
     factory.class = "za.co.absa.pramen.core.source.JdbcSource"
 
     jdbc = {
@@ -82,19 +81,38 @@ pramen.sinks = [
     name = "dce"
     factory.class = "za.co.absa.pramen.extras.sink.EnceladusSink"
 
-    format = "csv"
-
-    option {
-      sep = "|"
-      quoteAll = "false"
-      header = "false"
-    }
+    format = "parquet"
 
     mode = "overwrite"
 
+    records.per.partition = 1000000
+
+    # Information date column, default: enceladus_info_date
+    info.date.column = "enceladus_info_date"
+
+    # Partition pattern. Default: {year}/{month}/{day}/v{version}
     partition.pattern = "{year}/{month}/{day}/v{version}"
 
-    records.per.partition = 1000000
+    # If true (default), the data will be saved even if it does not contain any records. If false, the saving will be skipped
+    save.empty = true
+
+    # Setup Enceladus main class and command line template if you want to run it from Pramen
+    enceladus.run.main.class = "za.co.absa.enceladus.standardization_conformance.StandardizationAndConformanceJob"
+
+    # Command line template for Enceladus
+    # You can use the following variables: @datasetName, @datasetName, @datasetVersion, @infoDate, @infoVersion, @rawPath, @rawFormat.
+    enceladus.command.line.template = "--autoclean-std-folder true --dataset-name @datasetName --dataset-version @datasetVersion --report-date @infoDate --report-version @infoVersion --menas-auth-keytab menas.keytab --raw-format @rawFormat"
+
+    hive.conf {
+      # You can specify Hive table creation template if it is different from the default one.
+      create.table.template = """CREATE EXTERNAL TABLE IF NOT EXISTS
+@fullTableName ( @schema )
+ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
+STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
+@partitionedBy
+LOCATION '@path'"""
+    }
 
     info.file {
       generate = true
@@ -105,18 +123,6 @@ pramen.sinks = [
       timestamp.format = "dd-MM-yyyy HH:mm:ss Z"
       date.format = "yyyy-MM-dd"
     }
-
-    hive.conf  {
-      create.table.template = """CREATE EXTERNAL TABLE IF NOT EXISTS
-@fullTableName ( @schema )
-@partitionedBy
-ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'
-OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
-LOCATION '@path';"""
-      repair.table.template = "MSCK REPAIR TABLE @fullTableName"
-      drop.table.template = "DROP TABLE IF EXISTS @fullTableName"
-    }
   }
 ]
 
@@ -126,44 +132,28 @@ pramen.operations = [
     type = "transfer"
     #disabled = "true"
 
-    schedule.type = "daily"
-
     # Get data from the source and write it to the sink
-    source = "postgre"
+    source = "my_source"
     sink = "dce"
 
-    # We are getting yesterday's data each day
-    info.date.expr = "@runDate - 1"
+    schedule.type = "daily"
+
+    # The data will be loaded for the same date as it is ran
+    info.date.expr = "@runDate"
 
     tables = [
       {
+        # The table in the database
         input.db.table = my_table1
-        output.path = "/bigdata/datalake/raw/my_table1"
+        # The path to the raw folder in HDFS
+        output.path = "/mydatalake/raw/my_table1"
+        # The path to the publish folder in HDFS
+        output.publish.base.path = "/mydatalake/publish/my_table1"
 
-        # Autodetect info version based on files in the raw and publish folders
-        # Needs 'output.publish.base.path' or 'output.hive.table' to be set
-        output.info.version = auto
-
-        output.dataset.name = "my_dataset"
-
-        output {
-           # Optional when running Enceladus from Pramen
-           dataset.name = "my_dataset"
-           dataset.version = 2
-
-           # Optional publish base path (for detecting version number)
-           publish.base.path = "/bigdata/datalake/publish"
-           # Optional Hive table to repair after Enceladus is executed
-           hive.table = "my_database.my_table"
-        }
-      },
-      {
-        # This needs to be set of the input and output are both paths
-        job.metastore.table = "my_table2"
-
-        input.path = "s3://mybucket/myprefix/source/my_table2"
-        output.path = "s3://mybucket/myprefix/destination/my_table2"
-
+        # These parameters should point to the info in Menas
+        output.dataset.name="my_dataset"
+        output.dataset.version = 1
+        output.hive.table = "my_hive_database.my_hive_table"
         output.info.version = 1
 
         # Optionally you can specify expressions for date ranges.

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusSink.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/EnceladusSink.scala
@@ -329,7 +329,7 @@ class EnceladusSink(sinkConfig: Config,
           case Success(_)  =>
             log.info(s"Hive table '${options(HIVE_TABLE_KEY)}' was repaired successfully.")
           case Failure(ex) =>
-            throw new IllegalStateException(s"Failed to repair Hive table '${options(HIVE_TABLE_KEY)}'.", ex)
+            throw new IllegalStateException(s"Failed to create or repair Hive table '${options(HIVE_TABLE_KEY)}'.", ex)
         }
       }
     } else {

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/utils/FsUtils.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/utils/FsUtils.scala
@@ -253,4 +253,18 @@ class FsUtils(conf: Configuration, pathBase: String) {
       fs.rename(pathSrc, pathTrg)
     }
   }
+
+  /**
+    * Deletes a directory and all its contents recursively.
+    *
+    * @param path path to a file.
+    */
+  def deleteDirectoryRecursively(path: Path): Boolean = {
+    if (fs.exists(path)) {
+      log.info(s"Deleting recursively '$path'...")
+      fs.delete(path, true)
+    } else {
+      false
+    }
+  }
 }

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusSinkSuite.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/tests/sink/EnceladusSinkSuite.scala
@@ -16,14 +16,14 @@
 
 package za.co.absa.pramen.extras.tests.sink
 
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.ConfigFactory
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.DataFrame
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.extras.base.SparkTestBase
-import za.co.absa.pramen.extras.sink.EnceladusSink
 import za.co.absa.pramen.extras.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.extras.mocks.QueryExecutorSpy
+import za.co.absa.pramen.extras.sink.EnceladusSink
 import za.co.absa.pramen.extras.sink.EnceladusSink.{DATASET_NAME_KEY, DATASET_VERSION_KEY, HIVE_TABLE_KEY}
 import za.co.absa.pramen.extras.utils.FsUtils
 
@@ -100,35 +100,6 @@ class EnceladusSinkSuite extends AnyWordSpec with SparkTestBase with TextCompari
 
       "close does nothing" in {
         sink.close()
-      }
-    }
-
-    "getHiveRepairEnceladusQuery()" should {
-      "return a valid query when a db is setup" in {
-        val updatedConf = conf.
-           withValue("hive.database", ConfigValueFactory.fromAnyRef("mydb"))
-
-        val sink = EnceladusSink.apply(updatedConf, "", spark)
-
-        val query = sink.getHiveRepairEnceladusQuery("my_table")
-
-        assert(query == "MSCK REPAIR TABLE mydb.my_table")
-      }
-
-      "return a valid query when a db is not setup" in {
-        val sink = EnceladusSink.apply(conf, "", spark)
-
-        val query = sink.getHiveRepairEnceladusQuery("my_table")
-
-        assert(query == "MSCK REPAIR TABLE my_table")
-      }
-    }
-
-    "getHiveRepairQuery()" should {
-      "return the repair query" in {
-        val sink = EnceladusSink.apply(conf, "", spark)
-
-        assert(sink.getHiveRepairQuery("db1.table1") == "MSCK REPAIR TABLE db1.table1")
       }
     }
 
@@ -212,9 +183,7 @@ class EnceladusSinkSuite extends AnyWordSpec with SparkTestBase with TextCompari
         )
       }
 
-      val actual = qe.executed.head
-
-      assert(actual == "MSCK REPAIR TABLE test_table")
+      assert(qe.executed.isEmpty)
     }
 
     "forward the exception if something goes wrong" in {


### PR DESCRIPTION
These features were in the separate branch for a while. But now I think they can be merged. 

The new features are very Enceladus-specific.

- Autodelete standardization and publish partitions on re-runs to simplify operation of ingestion pipelines.
- Allow Hive table creation at the end of Enceladus job (it was only repairing existing tables before)
- Fix JDBC password leakage in certain circumstances

P.S.
I'm going to fix the next coverage in some other PRs.

Closes #207 