### PR TITLE
#205 Allows spreading object array elements among multiple config files.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/ExternalChannelFactoryReflect.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/ExternalChannelFactoryReflect.scala
@@ -19,9 +19,8 @@ package za.co.absa.pramen.core
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import za.co.absa.pramen.api.{ExternalChannel, ExternalChannelFactory}
-import za.co.absa.pramen.core.utils.ClassLoaderUtils
+import za.co.absa.pramen.core.utils.{ClassLoaderUtils, ConfigUtils}
 
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
@@ -54,7 +53,7 @@ object ExternalChannelFactoryReflect {
                                                                           (implicit spark: SparkSession): T = {
     validateConfig(conf, arrayPath, channelType)
 
-    val srcConfig = conf.getConfigList(arrayPath).asScala
+    val srcConfig = ConfigUtils.getOptionConfigList(conf, arrayPath)
     val src1Config = srcConfig.zipWithIndex
       .find { case (cfg, _) => cfg.hasPath(NAME_KEY) && cfg.getString(NAME_KEY).equalsIgnoreCase(name) }
 
@@ -73,7 +72,7 @@ object ExternalChannelFactoryReflect {
   def validateConfig(conf: Config,
                      arrayPath: String,
                      channelType: String): Unit = {
-    val channelConfigs = conf.getConfigList(arrayPath).asScala
+    val channelConfigs = ConfigUtils.getOptionConfigList(conf, arrayPath)
 
     val emptyNameChannelsCnt = channelConfigs.filterNot(cfg => cfg.hasPath(NAME_KEY)).size
     val emptyFactoryClassesCnt = channelConfigs.filterNot(cfg => cfg.hasPath(FACTORY_CLASS_KEY)).size

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
@@ -25,7 +25,6 @@ import za.co.absa.pramen.core.utils.DateUtils.convertStrToDate
 import za.co.absa.pramen.core.utils.{AlgorithmicUtils, ConfigUtils}
 
 import java.time.LocalDate
-import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 import scala.util.{Failure, Success, Try}
 
 case class MetaTable(
@@ -62,11 +61,10 @@ object MetaTable {
     val defaultTrackDays = conf.getInt(InfoDateConfig.TRACK_DAYS)
     val defaultHiveConfig = HiveDefaultConfig.fromConfig(ConfigUtils.getOptionConfig(conf, DEFAULT_HIVE_CONFIG_PREFIX))
 
-    val tableConfigs = if (conf.hasPath(key)) {
-      conf.getConfigList(key).asScala
-    } else {
+    val tableConfigs = ConfigUtils.getOptionConfigList(conf, key)
+
+    if (tableConfigs.isEmpty) {
       log.warn(s"Config key '$key' not found. The metastore has no tables. The pipeline can run only if it consists of only transfer operations.")
-      Seq.empty[Config]
     }
 
     val metatables = tableConfigs

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PipelineDef.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PipelineDef.scala
@@ -19,8 +19,7 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.Config
 import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.app.config.InfoDateConfig.EXPECTED_DELAY_DAYS
-
-import scala.collection.JavaConverters._
+import za.co.absa.pramen.core.utils.ConfigUtils
 
 case class PipelineDef(
                         name: String,
@@ -37,8 +36,7 @@ object PipelineDef {
     val defaultDelayDays = conf.getInt(EXPECTED_DELAY_DAYS)
     val name = conf.getString(PIPELINE_NAME_KEY)
     val environment = conf.getString(ENVIRONMENT_NAME)
-    val operations = conf.getConfigList(OPERATIONS_KEY)
-      .asScala
+    val operations = ConfigUtils.getOptionConfigList(conf, OPERATIONS_KEY)
       .zipWithIndex
       .flatMap{ case (c, i) => OperationDef.fromConfig(c, conf, infoDateConfig, s"$OPERATIONS_KEY[$i]", defaultDelayDays) }
       .toSeq

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
@@ -71,6 +71,24 @@ object ConfigUtils {
     }
   }
 
+  def getOptionConfigList(conf: Config, path: String): Seq[Config] = {
+    if (conf.hasPath(path)) {
+      try {
+        val subArrays = conf.getObject(path).keySet().toArray
+
+        subArrays.flatMap(key => {
+          val subPath = s"$path.$key"
+          conf.getConfigList(subPath).asScala.toSeq
+        }).toSeq
+      } catch {
+        case _: Throwable =>
+          conf.getConfigList(path).asScala.toSeq
+      }
+    } else {
+      Seq.empty[Config]
+    }
+  }
+
   def getDate(conf: Config, path: String, format: String): LocalDate = {
     val dateString = conf.getString(path)
     val fmt = DateTimeFormatter.ofPattern(format)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ConfigUtils.scala
@@ -71,8 +71,54 @@ object ConfigUtils {
     }
   }
 
+  /**
+    * Parses an array of objects and returns a sequence of Config objects.
+    * If the path does not exist, returns an empty Seq.
+    * {{{
+    *   my.path = [
+    *     { ... },
+    *     { ... }
+    *   ]
+    * }}}
+    *
+    * The above example is similar to the behavior of `Config.getConfigList(path)`
+    *
+    * If the path contains named subkeys, they get merged into a single list, e.g.:
+    * {{{
+    *   my.path.abc = [
+    *     { ... },
+    *     { ... }
+    *   ]
+    *   my.path.def = [
+    *     { ... },
+    *     { ... }
+    *   ]
+    * }}}
+    *
+    * In the above example the result will be 4 objects by mergins 'abc' and 'def' nodes.
+    *
+    * @param conf The configuration object.
+    * @param path The path to the array in the configuration tree.
+    * @return The sequence of Config objects corresponding to elements on the array.
+    */
   def getOptionConfigList(conf: Config, path: String): Seq[Config] = {
     if (conf.hasPath(path)) {
+      // The path should contain either
+      // my.path = [
+      //   { ... },
+      //   { ... }
+      // ]
+      // or
+      // my.path.abc = = [
+      //   { ... },
+      //   { ... }
+      // ]
+      // my.path.def = = [
+      //   { ... },
+      //   { ... }
+      // ]
+      // e.g - either an array of Object or an object that has subkeys of 'abc' and 'def'.
+      // There is no way to check it in advance, so the exception handling is used in this case.
       try {
         val subArrays = conf.getObject(path).keySet().toArray
 

--- a/pramen/core/src/test/resources/test/config/pipeline_v3.conf
+++ b/pramen/core/src/test/resources/test/config/pipeline_v3.conf
@@ -1,0 +1,218 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variable is expected to be set up by the test suite
+#base.path = "/tmp"
+
+pramen.pipeline {
+  name = "pipeline_v3"
+}
+
+pramen.metastore {
+  tables.abc = [
+    {
+      name = "table1_sync"
+      description = "Table 1 description"
+      format = "parquet"
+      path = ${base.path}/table1
+      records.per.partition = 1000000
+
+      information.date.column = "INFORMATION_DATE"
+      information.date.format = "yyyy-MM-dd"
+      information.date.expression = "@runDate - 1"
+      information.date.start = "2017-01-31"
+    },
+    {
+      name = "table2_sync"
+      description = "Table 2 description"
+      format = "delta"
+      path = ${base.path}/table2
+    }
+  ]
+}
+
+pramen.metastore {
+  tables.def = [
+    {
+      name = "table3"
+      description = "Table 2 description"
+      format = "delta"
+      path = ${base.path}/table2
+    },
+    {
+      name = "table4"
+      description = "Output table"
+      format = "delta"
+      path = ${base.path}/table_out
+    }
+  ]
+}
+
+pramen.notification.targets.1 = [
+  {
+    name = "custom1"
+    factory.class = "za.co.absa.pramen.core.mocks.notify.NotificationTargetSpy"
+
+    my.config1 = "mykey1"
+    my.config2 = "mykey2"
+  }
+]
+
+pramen.notification.targets.2 = [
+  {
+    name = "custom2"
+    factory.class = "za.co.absa.pramen.core.mocks.notify.NotificationTargetSpy"
+
+    my.config1 = "mykey3"
+    my.config2 = "mykey4"
+  }
+]
+
+pramen.sources.1 = [
+  {
+    name = "jdbc"
+    factory.class = "za.co.absa.pramen.core.source.JdbcSource"
+    jdbc {
+      driver = "a"
+      connection.string = "b"
+      user = "c"
+      password = "d"
+    }
+
+    has.information.date.column = false
+  }
+]
+
+pramen.sources.2 = [
+  {
+    name = "jdbc_info_date"
+    factory.class = "za.co.absa.pramen.core.source.JdbcSource"
+    jdbc {
+      driver = "$driver"
+      connection.string = "$url"
+      user = "$user"
+      password = "$password"
+    }
+
+    has.information.date.column = true
+    information.date.column = "info_date"
+    information.date.type = "string"
+    information.date.app.format = "yyyy-MM-dd"
+    information.date.sql.format = "YYYY-MM-DD"
+  },
+]
+
+pramen.sinks.1 = [
+  {
+    name = "spark1"
+    factory.class = "za.co.absa.pramen.core.sink.SparkSink"
+
+    format = "csv"
+    mode = "overwrite"
+    records.per.partition = 1
+    partition.by = [ info_date ]
+    save.empty = false
+  },
+  {
+    name = "spark2"
+    factory.class = "za.co.absa.pramen.core.sink.SparkSink"
+
+    format = "csv"
+    mode = "overwrite"
+    records.per.partition = 1
+    partition.by = [ info_date ]
+    save.empty = false
+  }
+]
+
+pramen.sinks.2 = [
+  {
+    name = "spark3"
+    factory.class = "za.co.absa.pramen.core.sink.SparkSink"
+
+    format = "csv"
+    mode = "overwrite"
+    records.per.partition = 1
+    partition.by = [ info_date ]
+    save.empty = false
+  }
+]
+
+pramen.operations.1 = [
+  {
+    # Mandatory
+    name = "op1"
+    type = "ingestion" # or "transformation" or "sink"
+    schedule.type = "daily"
+
+    source = "myjdbc"
+
+    expected.delay.days = 5
+
+    # Determines information date by the run date
+    expected.delay.days = 1
+    info.date.expr = "beginOfMonth(@runDate)"
+    processing.timestamp.column = "SYNC_TIMESTAMP"
+
+    notification.targets = ["custom1", "custom2"]
+
+    tables = [
+      {
+        input.db.table = table1_db
+        output.metastore.table = table1_sync
+        transformations = [
+          {col = "A", expr = "cast(A as decimal(15,5))"}
+        ],
+        filters = [
+          "A > 2.0"
+        ]
+        notification.token = "A1"
+      },
+      {
+        input.sql = "SELECT * FROM table2_db WHERE information_date = date'@infoDate'"
+        output.metastore.table = table2_sync
+        notification.token = "A2"
+      }
+    ]
+  }
+]
+
+pramen.operations.2 = [
+  {
+    name = "op2"
+    type = "transformation"
+    class = "some.class"
+    schedule.type = "daily"
+
+    output.table = "table_out"
+    track.days = 3
+
+    notification.targets = [custom1]
+    notification.token = "A2"
+
+    dependencies = [
+      {
+        tables = [table1_sync, table4]
+        date.from = "@infoDate - 1"
+      }
+    ]
+
+    transformations = [
+      {col = "B", expr = "cast(B as double)"}
+    ]
+
+    filters = [
+      "B > 2.0"
+    ]
+  }
+]

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -390,12 +390,16 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
          |pramen.track.days = 4
          |pramen.undercover = $undercover
          |pramen.metastore {
-         |  tables = [
+         |  tables.1 = [
          |   {
          |     name = "table1"
          |     format = "parquet"
          |     path = "$tempDirEscaped/table1"
-         |   },
+         |   }
+         | ]
+         |}
+         |pramen.metastore {
+         |  tables.2 = [
          |   {
          |     name = "table2"
          |     format = "parquet"

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PipelineDefSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PipelineDefSuite.scala
@@ -19,14 +19,17 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.app.config.InfoDateConfig
+import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.TempDirFixture
 import za.co.absa.pramen.core.pipeline.OperationType.{Ingestion, Transformation}
 import za.co.absa.pramen.core.schedule.Schedule
+import za.co.absa.pramen.core.sink.{SinkManager, SparkSink}
+import za.co.absa.pramen.core.source.{JdbcSource, SourceManager}
 import za.co.absa.pramen.core.utils.ResourceUtils
 
 import java.time.LocalDate
 
-class PipelineDefSuite extends AnyWordSpec with TempDirFixture {
+class PipelineDefSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
   private val defaults = InfoDateConfig("INFO_DATE",
     "yyyy-MM-dd",
     LocalDate.of(2022, 1, 1),
@@ -81,10 +84,58 @@ class PipelineDefSuite extends AnyWordSpec with TempDirFixture {
         assert(transformation.clazz == "some.class")
       }
     }
+
+    "be able to be read from merged config" in {
+      withTempDirectory("pipeline_v3") { tempDir =>
+        val conf = getConfig(tempDir, "pipeline_v3.conf")
+
+        val pipeline = PipelineDef.fromConfig(conf, defaults)
+
+        assert(pipeline.name == "pipeline_v3")
+        assert(pipeline.operations.length == 2)
+
+        val op1 = pipeline.operations.head
+        val op2 = pipeline.operations(1)
+
+        assert(op1.name == "op1")
+        assert(op2.name == "op2")
+
+        assert(op1.schedule.isInstanceOf[Schedule.EveryDay])
+        assert(op1.expectedDelayDays == 1)
+        assert(op1.dependencies.isEmpty)
+        assert(op1.outputInfoDateExpression.contains("beginOfMonth(@runDate)"))
+        assert(op1.processingTimestampColumn.contains("SYNC_TIMESTAMP"))
+
+        assert(op1.schemaTransformations.isEmpty)
+        assert(op1.notificationTargets.length == 2)
+        assert(op1.notificationTargets.head == "custom1")
+        assert(op1.notificationTargets(1) == "custom2")
+
+        assert(op2.expectedDelayDays == 0)
+        assert(op2.schemaTransformations.length == 1)
+        assert(op2.schemaTransformations.head.column == "B")
+        assert(op2.schemaTransformations.head.expression == "cast(B as double)")
+
+        val ingestion = op1.operationType.asInstanceOf[Ingestion]
+
+        assert(ingestion.sourceName == "myjdbc")
+        assert(ingestion.sourceTables.length == 2)
+        assert(ingestion.sourceTables.head.metaTableName == "table1_sync")
+        assert(ingestion.sourceTables(1).metaTableName == "table2_sync")
+
+        val transformation = op2.operationType.asInstanceOf[Transformation]
+        assert(transformation.clazz == "some.class")
+
+        assert(SourceManager.getSourceByName("jdbc", conf, None).isInstanceOf[JdbcSource])
+        assert(SourceManager.getSourceByName("jdbc_info_date", conf, None).isInstanceOf[JdbcSource])
+        assert(SinkManager.getSinkByName("spark1", conf, None).isInstanceOf[SparkSink])
+        assert(SinkManager.getSinkByName("spark2", conf, None).isInstanceOf[SparkSink])
+      }
+    }
   }
 
-  def getConfig(basePath: String): Config = {
-    val configContents = ResourceUtils.getResourceString("/test/config/pipeline_v2.conf")
+  def getConfig(basePath: String, fileName: String = "pipeline_v2.conf"): Config = {
+    val configContents = ResourceUtils.getResourceString(s"/test/config/$fileName")
     val basePathEscaped = basePath.replace("\\", "\\\\")
 
     val conf = ConfigFactory.parseString(


### PR DESCRIPTION
I was trying several attempts and didn't like all of them.
1. Reading configs separately as a TypeSafe `Config` and them combining them into a single `Config` object didn't work since it is not possible to add an array of objects to a config in runtime.
2. Making multiple-configs-aware Sources/Sinks/Operations deserializer complicates Pramen code a lot, and requires enormous change across the project.

So I came with a compromise solution. See #205
