### PR TITLE
Hotfix: make sure fields that have empty names are not part of Hive DDL.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -247,7 +247,7 @@ abstract class TaskRunnerBase(conf: Config,
         case None => runResult.data
       }
 
-      val dfWithInfoDate = if (dfWithTimestamp.schema.exists(f => f.name.equals(task.job.outputTable.infoDateColumn))) {
+      val dfWithInfoDate = if (dfWithTimestamp.schema.exists(f => f.name.equals(task.job.outputTable.infoDateColumn)) || task.job.outputTable.infoDateColumn.isEmpty) {
         dfWithTimestamp
       } else {
         dfWithTimestamp.withColumn(task.job.outputTable.infoDateColumn, lit(Date.valueOf(task.infoDate)))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
@@ -93,7 +93,12 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
   private def getTableDDL(schema: StructType, partitionBy: Seq[String]): String = {
     val partitionColsLower = partitionBy.map(_.toLowerCase())
 
-    StructType(schema.filter(field => !partitionColsLower.contains(field.name.toLowerCase()))).toDDL
+    val nonPartitionFields = schema
+      .filter(field => !partitionColsLower.contains(field.name.toLowerCase()))
+      .filter(field => field.name.trim.nonEmpty)
+
+    StructType(nonPartitionFields).toDDL
+      .replace(" NOT NULL", "")
   }
 
   private def getPartitionDDL(schema: StructType, partitionBy: Seq[String]): String = {


### PR DESCRIPTION
This fixes an issue of Hive table creation that we encountered in AWS. This affects only 'transfer' jobs that sends data from source directly to a sink (without the metastore).

Will release a new version of Pramen after this is merged.