### PR TITLE
Release hotfix with the version 1.4.3

### DIFF
--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.4.3"
+ThisBuild / version := "1.4.4-SNAPSHOT"

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.4.3-SNAPSHOT"
+ThisBuild / version := "1.4.3"


### PR DESCRIPTION
The released version contains the following hotfix:
#213 Hotfix: make sure fields that have empty names are not part of Hive DDL