### PR TITLE
#166 - Fix get_latest_available_date for delta format

### DIFF
--- a/pramen-py/.env.local
+++ b/pramen-py/.env.local
@@ -35,4 +35,5 @@ export PRAMENPY_SPARK_CONFIG='spark.master=local,
                               spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension,
                               spark.sql.session.timeZone=Africa/Johannesburg,
                               spark.jars.packages=io.delta:delta-core_2.12:1.0.1,
-                              spark.jars.repositories=https://maven-central.storage-download.googleapis.com/maven2/'
+                              spark.jars.repositories=https://maven-central.storage-download.googleapis.com/maven2/,
+                              spark.sql.shuffle.partitions=1'

--- a/pramen-py/src/pramen_py/metastore/reader.py
+++ b/pramen-py/src/pramen_py/metastore/reader.py
@@ -227,12 +227,6 @@ class MetastoreReader(MetastoreReaderBase):
                     metastore_table.path,
                     metastore_table.reader_options,
                 )
-                .withColumn(
-                    info_date_settings.column,
-                    F.to_date(
-                        info_date_settings.column, info_date_settings.format
-                    ),
-                )
                 .select(info_date_settings.column)
                 .distinct()
             )

--- a/pramen-py/src/pramen_py/metastore/writer.py
+++ b/pramen-py/src/pramen_py/metastore/writer.py
@@ -82,10 +82,13 @@ class MetastoreWriter(MetastoreWriterBase):
     def _write_delta_format_table(
         self, df: DataFrame, metastore_table: MetastoreTable
     ) -> Tuple[str, int]:
-        info_date_str = convert_date_to_str(self.info_date, fmt=metastore_table.info_date_settings.format)
+        info_date_str = convert_date_to_str(
+            self.info_date, fmt=metastore_table.info_date_settings.format
+        )
 
         df_with_info_date = df.withColumn(
-            metastore_table.info_date_settings.column, lit(info_date_str).cast(DateType())
+            metastore_table.info_date_settings.column,
+            lit(info_date_str).cast(DateType()),
         )
         df_repartitioned, count_df_items = self._apply_repartitioning(
             df_with_info_date, metastore_table.records_per_partition

--- a/pramen-py/tests/conftest.py
+++ b/pramen-py/tests/conftest.py
@@ -34,7 +34,7 @@ def repo_root() -> pathlib.Path:
 
 
 @pytest.fixture
-def get_data_stub(
+def test_dataframe(
     spark: SparkSession,
 ) -> DataFrame:
     """
@@ -74,7 +74,7 @@ def get_data_stub(
 
 @pytest.fixture
 def generate_test_tables(
-    get_data_stub: DataFrame,
+    test_dataframe,
     tmp_path: pathlib.Path,
 ):
     """Create different format data stubs partitioned by info_date.
@@ -90,7 +90,7 @@ def generate_test_tables(
     for format_ in TableFormat:
         read_table_path = (table_path / f"read_{format_.value}").as_posix()
         write_table_path = (table_path / f"write_{format_.value}").as_posix()
-        get_data_stub.write.partitionBy("info_date").format(
+        test_dataframe.write.partitionBy("info_date").format(
             format_.value
         ).mode("overwrite").save(read_table_path)
         paths["read_table"][f"{format_.value}"] = read_table_path
@@ -114,7 +114,7 @@ def config() -> TransformationConfig:
 def load_and_patch_config(
     mocker,
     config,
-    get_data_stub: DataFrame,
+    test_dataframe,
     tmp_path: pathlib.Path,
 ):
     """Load config and patch tables pathes to use tmp_path from pytest.
@@ -140,7 +140,7 @@ def load_and_patch_config(
     output_table_path = (
         (tmp_path / "data_lake" / "example_output_table").resolve().as_posix()
     )
-    get_data_stub.write.partitionBy("info_date").format("parquet").mode(
+    test_dataframe.write.partitionBy("info_date").format("parquet").mode(
         "overwrite"
     ).save(dependency_table_path)
     object.__setattr__(

--- a/pramen-py/tests/test_metastore/test_reader/test_get_latest_available_date.py
+++ b/pramen-py/tests/test_metastore/test_reader/test_get_latest_available_date.py
@@ -135,7 +135,7 @@ def test_returns_date_type(spark, tmp_path, test_dataframe, table_format):
         "test_table"
     )
 
-    assert latest_available_date == d(2022, 3, 23)
+    assert latest_available_date == d(2023, 3, 23)
 
 
 @pytest.mark.parametrize(

--- a/pramen-py/tests/test_metastore/test_reader/test_get_table.py
+++ b/pramen-py/tests/test_metastore/test_reader/test_get_table.py
@@ -85,7 +85,7 @@ def test_get_table(
 
 def test_with_reader_options(
     spark,
-    get_data_stub,
+    test_dataframe,
     tmp_path,
 ):
     def get_metastore_writer(
@@ -106,10 +106,10 @@ def test_with_reader_options(
         reader_options=reader_options,
     )
     get_metastore_writer(metastore_table, d(2022, 3, 23)).write(
-        "test_table", get_data_stub.withColumn("C", F.lit(1))
+        "test_table", test_dataframe.withColumn("C", F.lit(1))
     )
     get_metastore_writer(metastore_table, d(2022, 3, 24)).write(
-        "test_table", get_data_stub.withColumn("D", F.lit("1"))
+        "test_table", test_dataframe.withColumn("D", F.lit("1"))
     )
 
     metastore_reader = MetastoreReader(spark=spark, tables=[metastore_table])

--- a/pramen-py/tests/test_metastore/test_writer/test_writer.py
+++ b/pramen-py/tests/test_metastore/test_writer/test_writer.py
@@ -27,7 +27,9 @@ from pramen_py import MetastoreWriter
 from pramen_py.models import InfoDateSettings, MetastoreTable, TableFormat
 
 
-@pytest.mark.parametrize("table_format", (TableFormat.parquet, TableFormat.delta))
+@pytest.mark.parametrize(
+    "table_format", (TableFormat.parquet, TableFormat.delta)
+)
 def test_write(spark, test_dataframe, tmp_path_builder, table_format):
     table_path = tmp_path_builder().as_posix()
     metastore_table_config = MetastoreTable(

--- a/pramen-py/tests/test_metastore/test_writer/test_writer.py
+++ b/pramen-py/tests/test_metastore/test_writer/test_writer.py
@@ -72,7 +72,7 @@ def test_write(spark: SparkSession, generate_test_tables):
             raise
 
 
-def test_write_delta_with_options(spark, get_data_stub, tmp_path):
+def test_write_delta_with_options(spark, test_dataframe, tmp_path):
     writer_options = {"mergeSchema": "false"}
     metastore_table = MetastoreTable(
         name="test_table",
@@ -92,14 +92,14 @@ def test_write_delta_with_options(spark, get_data_stub, tmp_path):
         match="A schema mismatch detected when writing to the Delta table",
     ):
         metastore_writer.write(
-            "test_table", get_data_stub.withColumn("C", F.lit(1))
+            "test_table", test_dataframe.withColumn("C", F.lit(1))
         )
         metastore_writer.write(
-            "test_table", get_data_stub.withColumn("D", F.lit("1"))
+            "test_table", test_dataframe.withColumn("D", F.lit("1"))
         )
 
 
-def test_write_parquet_with_options(spark, get_data_stub, tmp_path):
+def test_write_parquet_with_options(spark, test_dataframe, tmp_path):
     """
     Testing additional parquet writer options for MetastoreTable.
 
@@ -120,7 +120,7 @@ def test_write_parquet_with_options(spark, get_data_stub, tmp_path):
         info_date=d(2022, 3, 24),
     )
 
-    metastore_writer.write("test_table", get_data_stub)
+    metastore_writer.write("test_table", test_dataframe)
 
     snappy_parquets = pathlib.Path(metastore_table.path).rglob(
         "*.snappy.parquet"


### PR DESCRIPTION
Closes #166 

- Fix `get_latest_available_date` for delta format so that it returns `datetime.date` type instead of string (same as parquet behaviour) 
- renamed `get_data_stub` fixture to `test_dataframe` for better readability

This is a really simple fix but I think better approach would be to extract behaviour for manipulating/persisting delta and parquet formats from `MetastoreReader` because right now, we have branches for delta/parquet in almost every metastore reader method. I plan to tackle this when fixing #165 (we need some layer of abstraction for paths/tables and parquets/deltas)