### PR TITLE
#239 Add support for column comments in inilne transformations.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformExpression.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformExpression.scala
@@ -23,22 +23,27 @@ import scala.collection.JavaConverters._
 
 case class TransformExpression(
                               column: String,
-                              expression: String,
+                              expression: Option[String],
                               comment: Option[String]
                               )
 
 object TransformExpression {
+  val COLUMN_KEY = "col"
+  val EXPRESSION_KEY = "expr"
+  val COMMENT_KEY = "comment"
+
   def fromConfigSingleEntry(conf: Config, parentPath: String): TransformExpression = {
-    if (!conf.hasPath("col")) {
-      throw new IllegalArgumentException(s"'col' not set for the transformation in $parentPath' in the configuration.")
+    if (!conf.hasPath(COLUMN_KEY)) {
+      throw new IllegalArgumentException(s"'$COLUMN_KEY' not set for the transformation in $parentPath' in the configuration.")
     }
-    if (!conf.hasPath("expr")) {
-      throw new IllegalArgumentException(s"'expr' not set for the transformation in $parentPath' in the configuration.")
+    val col = conf.getString(COLUMN_KEY)
+
+    if (!conf.hasPath(EXPRESSION_KEY) && !conf.hasPath(COMMENT_KEY)) {
+      throw new IllegalArgumentException(s"Either '$EXPRESSION_KEY' or '$COMMENT_KEY' should be defined for for the transformation of '$col' in $parentPath' in the configuration.")
     }
 
-    val col = conf.getString("col")
-    val expr = conf.getString("expr")
-    val comment = ConfigUtils.getOptionString(conf, "comment")
+    val expr = ConfigUtils.getOptionString(conf, EXPRESSION_KEY)
+    val comment = ConfigUtils.getOptionString(conf, COMMENT_KEY)
 
     TransformExpression(col, expr, comment)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformExpression.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformExpression.scala
@@ -17,12 +17,14 @@
 package za.co.absa.pramen.core.pipeline
 
 import com.typesafe.config.Config
+import za.co.absa.pramen.core.utils.ConfigUtils
 
 import scala.collection.JavaConverters._
 
 case class TransformExpression(
                               column: String,
-                              expression: String
+                              expression: String,
+                              comment: Option[String]
                               )
 
 object TransformExpression {
@@ -36,9 +38,11 @@ object TransformExpression {
 
     val col = conf.getString("col")
     val expr = conf.getString("expr")
+    val comment = ConfigUtils.getOptionString(conf, "comment")
 
-    TransformExpression(col, expr)
+    TransformExpression(col, expr, comment)
   }
+
   def fromConfig(conf: Config, arrayPath: String, parentPath: String): Seq[TransformExpression] = {
     if (conf.hasPath(arrayPath)) {
       val transformationConfigs = conf.getConfigList(arrayPath).asScala

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
@@ -166,19 +166,19 @@ object SparkUtils {
   def applyTransformations(df: DataFrame, transformations: Seq[TransformExpression]): DataFrame = {
     transformations.foldLeft(df)((accDf, tf) => {
       (tf.expression, tf.comment) match {
+        case (Some(expression), _) if expression.isEmpty || expression.trim.equalsIgnoreCase("drop") =>
+          log.info(s"Dropping: ${tf.column}")
+          accDf.drop(tf.column)
         case (Some(expression), Some(comment)) =>
           log.info(s"Applying: ${tf.column} <- $expression ($comment)")
           val metadata = new MetadataBuilder()
           metadata.putString("comment", comment)
           accDf.withColumn(tf.column, expr(expression).as(tf.column, metadata.build()))
-        case (Some(expression), None) if expression.isEmpty || expression.trim.equalsIgnoreCase("drop") =>
-          log.info(s"Dropping: ${tf.column}")
-          accDf.drop(tf.column)
         case (Some(expression), None) =>
           log.info(s"Applying: ${tf.column} <- $expression")
           accDf.withColumn(tf.column, expr(expression))
         case (None, Some(comment)) =>
-          log.info(s"Adding comment '$comment' to ${tf.column}")
+          log.debug(s"Adding comment '$comment' to ${tf.column}")
           val metadata = new MetadataBuilder()
           metadata.putString("comment", comment)
           accDf.withColumn(tf.column, col(tf.column).as(tf.column, metadata.build()))

--- a/pramen/core/src/test/resources/log4j.properties
+++ b/pramen/core/src/test/resources/log4j.properties
@@ -30,3 +30,4 @@ log4j.logger.za.co.absa.pramen.core.state.NotificationBuilderImpl=OFF
 log4j.logger.za.co.absa.pramen.core.state.PipelineStateImpl=OFF
 log4j.logger.za.co.absa.pramen.core.utils.ConfigUtils$=OFF
 log4j.logger.za.co.absa.pramen.core.utils.JdbcNativeUtils$=OFF
+log4j.logger.za.co.absa.pramen.core.utils.SparkUtils$=OFF

--- a/pramen/core/src/test/resources/log4j2.properties
+++ b/pramen/core/src/test/resources/log4j2.properties
@@ -49,5 +49,8 @@ logger.jdbcnativeutils.level = OFF
 logger.taskrunnermultithreaded.name = za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded
 logger.taskrunnermultithreaded.level = OFF
 
-logger.notificationbuilderimpl.name = log4j.logger.za.co.absa.pramen.core.state.NotificationBuilderImpl
+logger.notificationbuilderimpl.name = za.co.absa.pramen.core.state.NotificationBuilderImpl
 logger.notificationbuilderimpl.level = OFF
+
+logger.sparkutils.name = za.co.absa.pramen.core.utils.SparkUtils$
+logger.sparkutils.level = OFF

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -338,7 +338,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
       Nil,
       source,
       SourceTable("table1", Query.Table(sourceTable), tableConf, rangeFromExpr, rangeToExpr, Seq(
-        TransformExpression("NAME_U", "upper(NAME)")
+        TransformExpression("NAME_U", "upper(NAME)", None)
       ), Seq("ID > 1"), Seq("ID", "NAME", "NAME_U", "EMAIL"), configOverride),
       outputTable,
       specialCharacters)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -338,7 +338,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
       Nil,
       source,
       SourceTable("table1", Query.Table(sourceTable), tableConf, rangeFromExpr, rangeToExpr, Seq(
-        TransformExpression("NAME_U", "upper(NAME)", None)
+        TransformExpression("NAME_U", Some("upper(NAME)"), None)
       ), Seq("ID > 1"), Seq("ID", "NAME", "NAME_U", "EMAIL"), configOverride),
       outputTable,
       specialCharacters)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationDefSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationDefSuite.scala
@@ -122,7 +122,9 @@ class OperationDefSuite extends AnyWordSpec with TempDirFixture {
            |
            |transformations = [
            |    {col = "A", expr = "cast(A as decimal(15,5))"},
-           |    {col = "D", expr = "cast(A as decimal(14,4))", comment = "Test"},
+           |    {col = "D", expr = "cast(A as decimal(14,4))", comment = "Test1"},
+           |    {col = "C", expr = "drop", comment = "Test2"},
+           |    {col = "A", comment = "Test3"},
            |]
            |
            |filters = [ "A > 0", "B < 2" ]
@@ -143,13 +145,19 @@ class OperationDefSuite extends AnyWordSpec with TempDirFixture {
       assert(op.dependencies.head.triggerUpdates)
       assert(op.dependencies(1).tables.contains("table2"))
       assert(!op.dependencies(1).triggerUpdates)
-      assert(op.schemaTransformations.length == 2)
+      assert(op.schemaTransformations.length == 4)
       assert(op.schemaTransformations.head.column == "A")
-      assert(op.schemaTransformations.head.expression == "cast(A as decimal(15,5))")
+      assert(op.schemaTransformations.head.expression.contains("cast(A as decimal(15,5))"))
       assert(op.schemaTransformations.head.comment.isEmpty)
       assert(op.schemaTransformations(1).column == "D")
-      assert(op.schemaTransformations(1).expression == "cast(A as decimal(14,4))")
-      assert(op.schemaTransformations(1).comment.contains("Test"))
+      assert(op.schemaTransformations(1).expression.contains("cast(A as decimal(14,4))"))
+      assert(op.schemaTransformations(1).comment.contains("Test1"))
+      assert(op.schemaTransformations(2).column == "C")
+      assert(op.schemaTransformations(2).expression.contains("drop"))
+      assert(op.schemaTransformations(2).comment.contains("Test2"))
+      assert(op.schemaTransformations(3).column == "A")
+      assert(op.schemaTransformations(3).expression.isEmpty)
+      assert(op.schemaTransformations(3).comment.contains("Test3"))
       assert(op.filters.length == 2)
       assert(op.filters.head == "A > 0")
       assert(op.consumeThreads == 1)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationDefSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationDefSuite.scala
@@ -121,7 +121,8 @@ class OperationDefSuite extends AnyWordSpec with TempDirFixture {
            |]
            |
            |transformations = [
-           |    {col = "A", expr = "cast(A as decimal(15,5))"}
+           |    {col = "A", expr = "cast(A as decimal(15,5))"},
+           |    {col = "D", expr = "cast(A as decimal(14,4))", comment = "Test"},
            |]
            |
            |filters = [ "A > 0", "B < 2" ]
@@ -142,9 +143,13 @@ class OperationDefSuite extends AnyWordSpec with TempDirFixture {
       assert(op.dependencies.head.triggerUpdates)
       assert(op.dependencies(1).tables.contains("table2"))
       assert(!op.dependencies(1).triggerUpdates)
-      assert(op.schemaTransformations.length == 1)
+      assert(op.schemaTransformations.length == 2)
       assert(op.schemaTransformations.head.column == "A")
       assert(op.schemaTransformations.head.expression == "cast(A as decimal(15,5))")
+      assert(op.schemaTransformations.head.comment.isEmpty)
+      assert(op.schemaTransformations(1).column == "D")
+      assert(op.schemaTransformations(1).expression == "cast(A as decimal(14,4))")
+      assert(op.schemaTransformations(1).comment.contains("Test"))
       assert(op.filters.length == 2)
       assert(op.filters.head == "A > 0")
       assert(op.consumeThreads == 1)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PipelineDefSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PipelineDefSuite.scala
@@ -71,7 +71,7 @@ class PipelineDefSuite extends AnyWordSpec with SparkTestBase with TempDirFixtur
         assert(op2.expectedDelayDays == 0)
         assert(op2.schemaTransformations.length == 1)
         assert(op2.schemaTransformations.head.column == "B")
-        assert(op2.schemaTransformations.head.expression == "cast(B as double)")
+        assert(op2.schemaTransformations.head.expression.contains("cast(B as double)"))
 
         val ingestion = op1.operationType.asInstanceOf[Ingestion]
 
@@ -114,7 +114,7 @@ class PipelineDefSuite extends AnyWordSpec with SparkTestBase with TempDirFixtur
         assert(op2.expectedDelayDays == 0)
         assert(op2.schemaTransformations.length == 1)
         assert(op2.schemaTransformations.head.column == "B")
-        assert(op2.schemaTransformations.head.expression == "cast(B as double)")
+        assert(op2.schemaTransformations.head.expression.contains("cast(B as double)"))
 
         val ingestion = op1.operationType.asInstanceOf[Ingestion]
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkJobSuite.scala
@@ -143,7 +143,7 @@ class SinkJobSuite extends AnyWordSpec with SparkTestBase with TextComparisonFix
           |} ]""".stripMargin
 
       val sinkTable = SinkTableFactory.getDummySinkTable(
-        transformations = Seq(TransformExpression("b1", "cast(b as string)", None)),
+        transformations = Seq(TransformExpression("b1", Some("cast(b as string)"), None)),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
       )
@@ -161,7 +161,7 @@ class SinkJobSuite extends AnyWordSpec with SparkTestBase with TextComparisonFix
 
     "throw an exception when preprocessing throws" in {
       val sinkTable = SinkTableFactory.getDummySinkTable(
-        transformations = Seq(TransformExpression("b1", "cast(b2 as string)", None)),
+        transformations = Seq(TransformExpression("b1", Some("cast(b2 as string)"), None)),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
       )

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkJobSuite.scala
@@ -143,7 +143,7 @@ class SinkJobSuite extends AnyWordSpec with SparkTestBase with TextComparisonFix
           |} ]""".stripMargin
 
       val sinkTable = SinkTableFactory.getDummySinkTable(
-        transformations = Seq(TransformExpression("b1", "cast(b as string)")),
+        transformations = Seq(TransformExpression("b1", "cast(b as string)", None)),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
       )
@@ -161,7 +161,7 @@ class SinkJobSuite extends AnyWordSpec with SparkTestBase with TextComparisonFix
 
     "throw an exception when preprocessing throws" in {
       val sinkTable = SinkTableFactory.getDummySinkTable(
-        transformations = Seq(TransformExpression("b1", "cast(b2 as string)")),
+        transformations = Seq(TransformExpression("b1", "cast(b2 as string)", None)),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
       )

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SinkTableSuite.scala
@@ -84,9 +84,9 @@ class SinkTableSuite extends AnyWordSpec {
       assert(tbl4.metaTableName == "table44")
       assert(tbl4.transformations.length == 2)
       assert(tbl4.transformations.head.column == "a")
-      assert(tbl4.transformations.head.expression == "2+2")
+      assert(tbl4.transformations.head.expression.contains("2+2"))
       assert(tbl4.transformations(1).column == "b")
-      assert(tbl4.transformations(1).expression == "cast(a) as string")
+      assert(tbl4.transformations(1).expression.contains("cast(a) as string"))
       assert(tbl4.filters.length == 1)
       assert(tbl4.filters.head == "A > 1")
       assert(tbl4.columns.length == 2)
@@ -156,7 +156,7 @@ class SinkTableSuite extends AnyWordSpec {
         SinkTable.fromConfig(conf, "sink.tables")
       }
 
-      assert(ex.getMessage.contains("'expr' not set for the transformation"))
+      assert(ex.getMessage.contains("Either 'expr' or 'comment' should be defined for for the transformation of '2.2' in sink.tables[0].transformations[0]"))
     }
 
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableSuite.scala
@@ -91,9 +91,9 @@ class SourceTableSuite extends AnyWordSpec {
       assert(tbl4.query.asInstanceOf[Query.Table].dbTable == "table14")
       assert(tbl4.transformations.length == 2)
       assert(tbl4.transformations.head.column == "a")
-      assert(tbl4.transformations.head.expression == "2+2")
+      assert(tbl4.transformations.head.expression.contains("2+2"))
       assert(tbl4.transformations(1).column == "b")
-      assert(tbl4.transformations(1).expression == "cast(a) as string")
+      assert(tbl4.transformations(1).expression.contains("cast(a) as string"))
       assert(tbl4.columns == Seq.empty[String])
       assert(tbl4.filters == Seq("A > 1"))
       assert(tbl4.rangeFromExpr.contains("@infoDate - 1"))
@@ -183,7 +183,7 @@ class SourceTableSuite extends AnyWordSpec {
         SourceTable.fromConfig(conf, "source.tables")
       }
 
-      assert(ex.getMessage.contains("'expr' not set for the transformation"))
+      assert(ex.getMessage.contains("Either 'expr' or 'comment' should be defined for for the transformation"))
     }
 
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
@@ -157,9 +157,9 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
 
       val transferTable = TransferTableFactory.getDummyTransferTable(
         transformations = Seq(
-          TransformExpression("b1", "cast(v as string)", None),
-          TransformExpression("b", "v", None),
-          TransformExpression("a", "concat('a', b)", None)
+          TransformExpression("b1", Some("cast(v as string)"), None),
+          TransformExpression("b", Some("v"), None),
+          TransformExpression("a", Some("concat('a', b)"), None)
         ),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
@@ -179,7 +179,7 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
     "throw an exception when preprocessing throws" in {
       val transferTable = TransferTableFactory.getDummyTransferTable(
         transformations = Seq(
-          TransformExpression("b1", "cast(x as string)", None)
+          TransformExpression("b1", Some("cast(x as string)"), None)
         )
       )
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
@@ -157,9 +157,9 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
 
       val transferTable = TransferTableFactory.getDummyTransferTable(
         transformations = Seq(
-          TransformExpression("b1", "cast(v as string)"),
-          TransformExpression("b", "v"),
-          TransformExpression("a", "concat('a', b)")
+          TransformExpression("b1", "cast(v as string)", None),
+          TransformExpression("b", "v", None),
+          TransformExpression("a", "concat('a', b)", None)
         ),
         filters = Seq("b > 1"),
         columns = Seq("a", "b1")
@@ -179,7 +179,7 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
     "throw an exception when preprocessing throws" in {
       val transferTable = TransferTableFactory.getDummyTransferTable(
         transformations = Seq(
-          TransformExpression("b1", "cast(x as string)")
+          TransformExpression("b1", "cast(x as string)", None)
         )
       )
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferTableSuite.scala
@@ -128,9 +128,9 @@ class TransferTableSuite extends AnyWordSpec {
 
       assert(tbl4.transformations.length == 2)
       assert(tbl4.transformations.head.column == "a")
-      assert(tbl4.transformations.head.expression == "2+2")
+      assert(tbl4.transformations.head.expression.contains("2+2"))
       assert(tbl4.transformations(1).column == "b")
-      assert(tbl4.transformations(1).expression == "cast(a) as string")
+      assert(tbl4.transformations(1).expression.contains("cast(a) as string"))
       assert(tbl4.filters.length == 1)
       assert(tbl4.filters.head == "A > 1")
       assert(tbl4.columns.length == 2)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
@@ -569,7 +569,7 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
     val state = new PipelineStateSpy
 
     val operationDef = OperationDefFactory.getDummyOperationDef(
-      schemaTransformations = List(TransformExpression("c", "cast(b as string)", None)),
+      schemaTransformations = List(TransformExpression("c", Some("cast(b as string)"), None)),
       filters = List("b > 1")
     )
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
@@ -569,7 +569,7 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
     val state = new PipelineStateSpy
 
     val operationDef = OperationDefFactory.getDummyOperationDef(
-      schemaTransformations = List(TransformExpression("c", "cast(b as string)")),
+      schemaTransformations = List(TransformExpression("c", "cast(b as string)", None)),
       filters = List("b > 1")
     )
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
@@ -137,12 +137,25 @@ class SparkUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture
     }
 
     "apply specified transformations" in {
-      val schemaTransformations = List(TransformExpression("c", "cast(b as string)"))
+      val schemaTransformations = List(TransformExpression("c", "cast(b as string)", None))
 
       val dfOut = applyTransformations(exampleDf, schemaTransformations)
 
       assert(dfOut.schema.fields.length == 3)
       assert(dfOut.schema.fields(2).name == "c")
+      assert(dfOut.count() == 3)
+      assert(!dfOut.schema.fields(2).metadata.contains("comment"))
+    }
+
+    "support comment metadata" in {
+      val schemaTransformations = List(TransformExpression("c", "cast(b as string)", Some("dummy")))
+
+      val dfOut = applyTransformations(exampleDf, schemaTransformations)
+
+      assert(dfOut.schema.fields.length == 3)
+      assert(dfOut.schema.fields(2).name == "c")
+      assert(dfOut.schema.fields(2).metadata.contains("comment"))
+      assert(dfOut.schema.fields(2).metadata.getString("comment") == "dummy")
       assert(dfOut.count() == 3)
     }
   }


### PR DESCRIPTION
Adds the capability:
```hocon
transformations = [
  { col = "col1", comment = "A comment for existing col1" }
  { col = "col2", expr = "lower(col1)", comment = "A comment for new col2" }
],
```