### PR TITLE
#221 Add support for transient metastore tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1397,6 +1397,10 @@ pramen.operations = [
         date.to = "@infoDate" // optional
       }
     ]
+   
+    option {
+      input.table = "table1"
+    }
   },
   {
     name = "A Kafka sink"

--- a/README.md
+++ b/README.md
@@ -2173,6 +2173,7 @@ The cache policy can be:
 - `cache` - the table is cached using Spark cache
 - `persist` - the table is persisted in the temporary directory for the duration of the pipeline run.
 
+This feature is experimental. Please, let know if there are any issues when using transient metastore table format.
 
 ### File-based sourcing
 Let's consider a use case when your data lake has 'landing' area where data is loaded from external sources, in addition

--- a/README.md
+++ b/README.md
@@ -2145,6 +2145,31 @@ You can use any source/sink combination in transfer jobs.
 
 We describe here a more complicated use cases.
 
+### Transient tables in the metastore
+Transformers are useful as reusable components and for persisting intermediate reusable results. However, when splitting
+up the pipeline into small reusable components, it is not always desirable to persist intermediate results. This is
+solved by transient tables. You can define a table as transient in the metastore and it won't be persisted to a storage.
+You can use transient tables in transformers and sinks, but only for the same pipeline and the same information date.
+
+You can define a transient table in the metastore like this:
+```hocon
+pramen.metastore {
+  tables = [
+    {
+      name = "table1"
+      format = "transient"
+      cache.policy = "no_cache"
+    }
+  ]
+}
+```
+
+The cache policy can be:
+- `no_cache` - the table is not cached
+- `cache` - the table is cached using Spark cache
+- `persist` - the table is persisted in the temporary directory for the duration of the pipeline run.
+
+
 ### File-based sourcing
 Let's consider a use case when your data lake has 'landing' area where data is loaded from external sources, in addition
 to the classic 'raw' area. The 'landing' area is owned by the data producer and source systems can write files there.

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/CachePolicy.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/CachePolicy.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.api
+
+sealed trait CachePolicy {
+  val name: String
+}
+
+object CachePolicy {
+  case object Cache extends CachePolicy {
+    override val name: String = "cache"
+  }
+
+  case object NoCache extends CachePolicy {
+    override val name: String = "no_cache"
+  }
+
+  case object Persist extends CachePolicy {
+    override val name: String = "persist"
+  }
+}

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/DataFormat.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/DataFormat.scala
@@ -35,7 +35,12 @@ object DataFormat {
     override def name: String = "raw"
   }
 
-  // This format is used for metatables which do not support persistence, e.g. for sink or tramsfer jobs
+  // This format is used for tables that exist only for the duration of the process, and is not persisted
+  case class Transient(cachePolicy: CachePolicy) extends DataFormat {
+    override def name: String = "transient"
+  }
+
+  // This format is used for metatables which do not support persistence, e.g. for sink or transfer jobs
   case class Null() extends DataFormat {
     override def name: String = "null"
   }

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/Reason.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/Reason.scala
@@ -26,9 +26,12 @@ object Reason {
   /** The transformation is ready to run, but has some warnings to be displayed in notifications. */
   case class Warning(warnings: Seq[String]) extends Reason
 
-  /** Data required to run the job is absent or not up to date. */
+  /** Data required to run the job is absent or not up to date. This will result in dependent jobs not run. */
   case class NotReady(message: String) extends Reason
 
-  /** It is too late to calculate data for the specified information date. */
+  /** Skip the task for the current information date, but allow dependent jobs to run. */
   case class Skip(message: String) extends Reason
+
+  /** Skip the task only for this run, but allow dependent jobs to run. */
+  case class SkipOnce(message: String) extends Reason
 }

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -65,7 +65,8 @@ pramen {
   # 1 - Mon, 7 - Sun
   schedule.weekly.days.of.week = [ 7 ]
 
-  temporary.directory = ""
+  # This needs to be specified. The path should be accessible by Hadoop (HDFS, S3, etc)
+  # temporary.directory = ""
 
   warn.throughput.rps = 2000
   good.throughput.rps = 40000

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
@@ -24,7 +24,7 @@ import java.time.ZoneId
 case class GeneralConfig(
                           timezoneId: ZoneId,
                           environmentName: String,
-                          temporaryDirectory: String
+                          temporaryDirectory: Option[String]
                         )
 object GeneralConfig {
   val TIMEZONE_ID_KEY = "pramen.timezone"
@@ -36,7 +36,7 @@ object GeneralConfig {
       .map(tz => ZoneId.of(tz))
       .getOrElse(ZoneId.systemDefault())
     val environmentName = conf.getString(ENVIRONMENT_NAME_KEY)
-    val temporaryDirectory = conf.getString(TEMPORARY_DIRECTORY_KEY)
+    val temporaryDirectory = ConfigUtils.getOptionString(conf, TEMPORARY_DIRECTORY_KEY)
 
     GeneralConfig(timezoneId, environmentName, temporaryDirectory)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/Bookkeeper.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/Bookkeeper.scala
@@ -43,13 +43,14 @@ trait Bookkeeper {
   def getDataChunksCount(table: String, dateBeginOpt: Option[LocalDate], dateEndOpt: Option[LocalDate]): Long
 
   private[pramen] def setRecordCount(table: String,
-                                      infoDate: LocalDate,
-                                      infoDateBegin: LocalDate,
-                                      infoDateEnd: LocalDate,
-                                      inputRecordCount: Long,
-                                      outputRecordCount: Long,
-                                      jobStarted: Long,
-                                      jobFinished: Long): Unit
+                                     infoDate: LocalDate,
+                                     infoDateBegin: LocalDate,
+                                     infoDateEnd: LocalDate,
+                                     inputRecordCount: Long,
+                                     outputRecordCount: Long,
+                                     jobStarted: Long,
+                                     jobFinished: Long,
+                                     isTableTransient: Boolean): Unit
 
   def getLatestSchema(table: String, until: LocalDate): Option[(StructType, LocalDate)]
 
@@ -83,7 +84,7 @@ object Bookkeeper {
           case Some(connection) =>
             log.info(s"Using MongoDB for lock management.")
             new TokenLockFactoryMongoDb(connection)
-          case None             =>
+          case None =>
             log.info(s"Using HadoopFS for lock management.")
             new TokenLockFactoryHadoop(spark.sparkContext.hadoopConfiguration, bookkeepingConfig.bookkeepingLocation.get + "/locks")
         }
@@ -103,9 +104,9 @@ object Bookkeeper {
         case Some(connection) =>
           log.info(s"Using MongoDB for bookkeeping.")
           new BookkeeperMongoDb(connection)
-        case None             =>
+        case None =>
           bookkeepingConfig.bookkeepingHadoopFormat match {
-            case HadoopFormat.Text  =>
+            case HadoopFormat.Text =>
               log.info(s"Using Hadoop (CSV for records, JSON for schemas) for bookkeeping.")
               new BookkeeperText(bookkeepingConfig.bookkeepingLocation.get)
           }
@@ -123,7 +124,7 @@ object Bookkeeper {
         case Some(connection) =>
           log.info(s"Using MongoDB to keep journal of executed jobs.")
           new JournalMongoDb(connection)
-        case None             =>
+        case None =>
           log.info(s"Using HadoopFS to keep journal of executed jobs.")
           new JournalHadoop(bookkeepingConfig.bookkeepingLocation.get + "/journal")
       }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperBase.scala
@@ -22,8 +22,6 @@ import java.time.LocalDate
 import scala.collection.mutable
 
 abstract class BookkeeperBase(isBookkeepingEnabled: Boolean) extends Bookkeeper {
-  protected def getDateStr(date: LocalDate): String = DataChunk.dateFormatter.format(date)
-
   private val transientDataChunks = new mutable.HashMap[String, Array[DataChunk]]()
 
   def getLatestProcessedDateFromStorage(table: String, until: Option[LocalDate] = None): Option[LocalDate]
@@ -72,7 +70,6 @@ abstract class BookkeeperBase(isBookkeepingEnabled: Boolean) extends Bookkeeper 
 
     if (isTransient || !isBookkeepingEnabled) {
       getLatestTransientDate(table, None, until)
-      getLatestTransientChunk(table, None, until).map(chunk => LocalDate.parse(chunk.infoDate))
     } else {
       getLatestProcessedDateFromStorage(table, until)
     }
@@ -143,4 +140,6 @@ abstract class BookkeeperBase(isBookkeepingEnabled: Boolean) extends Bookkeeper 
 
     allChunks.filter(chunk => chunk.infoDate >= minDate && chunk.infoDate <= maxDate)
   }
+
+  protected def getDateStr(date: LocalDate): String = DataChunk.dateFormatter.format(date)
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperBase.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.bookkeeper
+
+import za.co.absa.pramen.core.model.DataChunk
+
+import java.time.LocalDate
+import scala.collection.mutable
+
+abstract class BookkeeperBase(isBookkeepingEnabled: Boolean) extends Bookkeeper {
+  protected def getDateStr(date: LocalDate): String = DataChunk.dateFormatter.format(date)
+
+  private val transientDataChunks = new mutable.HashMap[String, Array[DataChunk]]()
+
+  def getLatestProcessedDateFromStorage(table: String, until: Option[LocalDate] = None): Option[LocalDate]
+
+  def getLatestDataChunkFromStorage(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk]
+
+  def getDataChunksFromStorage(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Seq[DataChunk]
+
+  def getDataChunksCountFromStorage(table: String, dateBeginOpt: Option[LocalDate], dateEndOpt: Option[LocalDate]): Long
+
+  private[pramen] def saveRecordCountToStorage(table: String,
+                                               infoDate: LocalDate,
+                                               infoDateBegin: LocalDate,
+                                               infoDateEnd: LocalDate,
+                                               inputRecordCount: Long,
+                                               outputRecordCount: Long,
+                                               jobStarted: Long,
+                                               jobFinished: Long): Unit
+
+  private[pramen] final def setRecordCount(table: String,
+                                           infoDate: LocalDate,
+                                           infoDateBegin: LocalDate,
+                                           infoDateEnd: LocalDate,
+                                           inputRecordCount: Long,
+                                           outputRecordCount: Long,
+                                           jobStarted: Long,
+                                           jobFinished: Long,
+                                           isTableTransient: Boolean): Unit = {
+    if (isTableTransient || !isBookkeepingEnabled) {
+      val tableLowerCase = table.toLowerCase
+      val dataChunk = DataChunk(table, infoDate.toString, infoDateBegin.toString, infoDateEnd.toString, inputRecordCount, outputRecordCount, jobStarted, jobFinished)
+      this.synchronized {
+        val dataChunks = transientDataChunks.getOrElse(tableLowerCase, Array.empty[DataChunk])
+        val newDataChunks = (dataChunks :+ dataChunk).sortBy(_.jobFinished)
+        transientDataChunks += tableLowerCase -> newDataChunks
+      }
+    } else {
+      saveRecordCountToStorage(table, infoDate, infoDateBegin, infoDateEnd, inputRecordCount, outputRecordCount, jobStarted, jobFinished)
+    }
+  }
+
+  final def getLatestProcessedDate(table: String, until: Option[LocalDate] = None): Option[LocalDate] = {
+    val isTransient = this.synchronized {
+      transientDataChunks.contains(table.toLowerCase)
+    }
+
+    if (isTransient || !isBookkeepingEnabled) {
+      getLatestTransientDate(table, None, until)
+      getLatestTransientChunk(table, None, until).map(chunk => LocalDate.parse(chunk.infoDate))
+    } else {
+      getLatestProcessedDateFromStorage(table, until)
+    }
+  }
+
+
+  final def getLatestDataChunk(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk] = {
+    val isTransient = this.synchronized {
+      transientDataChunks.contains(table.toLowerCase)
+    }
+
+    if (isTransient || !isBookkeepingEnabled) {
+      getLatestTransientChunk(table, Option(dateBegin), Option(dateEnd))
+    } else {
+      getLatestDataChunkFromStorage(table, dateBegin, dateEnd)
+    }
+  }
+
+  final def getDataChunks(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Seq[DataChunk] = {
+    val isTransient = this.synchronized {
+      transientDataChunks.contains(table.toLowerCase)
+    }
+
+    if (isTransient || !isBookkeepingEnabled) {
+      getTransientDataChunks(table, Option(dateBegin), Option(dateEnd))
+    } else {
+      getDataChunksFromStorage(table, dateBegin, dateEnd)
+    }
+  }
+
+  final def getDataChunksCount(table: String, dateBeginOpt: Option[LocalDate], dateEndOpt: Option[LocalDate]): Long = {
+    val isTransient = this.synchronized {
+      transientDataChunks.contains(table.toLowerCase)
+    }
+
+    if (isTransient || !isBookkeepingEnabled) {
+      getTransientDataChunks(table, dateBeginOpt, dateEndOpt).length
+    } else {
+      getDataChunksCountFromStorage(table, dateBeginOpt, dateEndOpt)
+    }
+  }
+
+  private def getLatestTransientDate(table: String, from: Option[LocalDate], until: Option[LocalDate]): Option[LocalDate] = {
+    val chunks = getTransientDataChunks(table, from, until)
+
+    if (chunks.isEmpty) {
+      None
+    } else {
+      Option (
+        LocalDate.parse(chunks.maxBy(_.infoDate).infoDate)
+      )
+    }
+  }
+
+  private def getLatestTransientChunk(table: String, from: Option[LocalDate], until: Option[LocalDate]): Option[DataChunk] = {
+    getTransientDataChunks(table, from, until)
+      .lastOption
+  }
+
+
+  private def getTransientDataChunks(table: String, from: Option[LocalDate], until: Option[LocalDate]): Array[DataChunk] = {
+    val minDate = from.map(_.toString).getOrElse("0000-00-00")
+    val maxDate = until.map(_.toString).getOrElse("9999-99-99")
+    val tableLowerCase = table.toLowerCase
+    val allChunks = this.synchronized {
+      transientDataChunks.getOrElse(tableLowerCase, Array.empty[DataChunk])
+    }
+
+    allChunks.filter(chunk => chunk.infoDate >= minDate && chunk.infoDate <= maxDate)
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperHadoop.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperHadoop.scala
@@ -24,7 +24,7 @@ import java.time.LocalDate
 
 
 abstract class BookkeeperHadoop extends BookkeeperBase(true) {
-  protected def getFilter(tableName: String, infoDateBegin: Option[LocalDate], infoDateEnd: Option[LocalDate]): Column = {
+  private[core] def getFilter(tableName: String, infoDateBegin: Option[LocalDate], infoDateEnd: Option[LocalDate]): Column = {
     (infoDateBegin, infoDateEnd) match {
       case (Some(begin), Some(end)) =>
         val beginStr = getDateStr(begin)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperHadoop.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperHadoop.scala
@@ -23,9 +23,7 @@ import za.co.absa.pramen.core.model.DataChunk
 import java.time.LocalDate
 
 
-abstract class BookkeeperHadoop extends Bookkeeper {
-  protected def getDateStr(date: LocalDate): String = DataChunk.dateFormatter.format(date)
-
+abstract class BookkeeperHadoop extends BookkeeperBase(true) {
   protected def getFilter(tableName: String, infoDateBegin: Option[LocalDate], infoDateEnd: Option[LocalDate]): Column = {
     (infoDateBegin, infoDateEnd) match {
       case (Some(begin), Some(end)) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperNull.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperNull.scala
@@ -26,27 +26,27 @@ import java.time.LocalDate
   * this bookkeeper implementation is used. It always returns the state as if every table is new and no information is
   * available.
   */
-class BookkeeperNull() extends Bookkeeper {
+class BookkeeperNull() extends BookkeeperBase(false) {
   override val bookkeepingEnabled: Boolean = false
 
-  override def getLatestProcessedDate(table: String, until: Option[LocalDate]): Option[LocalDate] = None
+  override def getLatestProcessedDateFromStorage(table: String, until: Option[LocalDate]): Option[LocalDate] = None
 
-  override def getLatestDataChunk(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk] = None
+  override def getLatestDataChunkFromStorage(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk] = None
 
-  override def getDataChunks(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Seq[DataChunk] = Nil
+  override def getDataChunksFromStorage(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Seq[DataChunk] = Nil
 
-  override def getDataChunksCount(table: String, dateBeginOpt: Option[LocalDate], dateEndOpt: Option[LocalDate]): Long = 0
+  override def getDataChunksCountFromStorage(table: String, dateBeginOpt: Option[LocalDate], dateEndOpt: Option[LocalDate]): Long = 0
 
-  private[pramen] override def setRecordCount(table: String,
-                                               infoDate: LocalDate,
-                                               infoDateBegin: LocalDate,
-                                               infoDateEnd: LocalDate,
-                                               inputRecordCount: Long,
-                                               outputRecordCount: Long,
-                                               jobStarted: Long,
-                                               jobFinished: Long): Unit = { }
+  private[pramen] override def saveRecordCountToStorage(table: String,
+                                                        infoDate: LocalDate,
+                                                        infoDateBegin: LocalDate,
+                                                        infoDateEnd: LocalDate,
+                                                        inputRecordCount: Long,
+                                                        outputRecordCount: Long,
+                                                        jobStarted: Long,
+                                                        jobFinished: Long): Unit = {}
 
   override def getLatestSchema(table: String, until: LocalDate): Option[(StructType, LocalDate)] = None
 
-  override def saveSchema(table: String, infoDate: LocalDate, schema: StructType): Unit = { }
+  override def saveSchema(table: String, infoDate: LocalDate, schema: StructType): Unit = {}
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperText.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperText.scala
@@ -58,12 +58,12 @@ class BookkeeperText(bookkeepingPath: String)(implicit spark: SparkSession) exte
 
   override val bookkeepingEnabled: Boolean = true
 
-  override def getLatestProcessedDate(tableName: String, until: Option[LocalDate]): Option[LocalDate] = {
+  override def getLatestProcessedDateFromStorage(tableName: String, until: Option[LocalDate]): Option[LocalDate] = {
     val filter = until match {
       case Some(endDate) =>
         val endDateStr = getDateStr(endDate)
         col("tableName") === tableName && col("infoDate") <= endDateStr
-      case None          =>
+      case None =>
         col("tableName") === tableName
     }
 
@@ -77,28 +77,28 @@ class BookkeeperText(bookkeepingPath: String)(implicit spark: SparkSession) exte
     }
   }
 
-  override def getLatestDataChunk(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk] = {
-    getDataChunks(table, dateBegin, dateEnd).lastOption
+  override def getLatestDataChunkFromStorage(table: String, dateBegin: LocalDate, dateEnd: LocalDate): Option[DataChunk] = {
+    getDataChunksFromStorage(table, dateBegin, dateEnd).lastOption
   }
 
-  override def getDataChunks(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Seq[DataChunk] = {
+  override def getDataChunksFromStorage(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Seq[DataChunk] = {
     val infoDateFilter = getFilter(tableName, Option(infoDateBegin), Option(infoDateEnd))
 
     getData(infoDateFilter)
   }
 
-  def getDataChunksCount(table: String, dateBegin: Option[LocalDate], dateEnd: Option[LocalDate]): Long = {
+  def getDataChunksCountFromStorage(table: String, dateBegin: Option[LocalDate], dateEnd: Option[LocalDate]): Long = {
     getDf(getFilter(table, dateBegin, dateEnd)).count()
   }
 
-  private[pramen] override def setRecordCount(table: String,
-                                               infoDate: LocalDate,
-                                               infoDateBegin: LocalDate,
-                                               infoDateEnd: LocalDate,
-                                               inputRecordCount: Long,
-                                               outputRecordCount: Long,
-                                               jobStarted: Long,
-                                               jobFinished: Long): Unit = {
+  private[pramen] override def saveRecordCountToStorage(table: String,
+                                                        infoDate: LocalDate,
+                                                        infoDateBegin: LocalDate,
+                                                        infoDateEnd: LocalDate,
+                                                        inputRecordCount: Long,
+                                                        outputRecordCount: Long,
+                                                        jobStarted: Long,
+                                                        jobFinished: Long): Unit = {
     val lock: TokenLockHadoop = getLock
 
     try {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
@@ -19,7 +19,6 @@ package za.co.absa.pramen.core.config
 object Keys {
   val INFORMATION_DATE_COLUMN = "pramen.information.date.column"
   val INFORMATION_DATE_FORMAT_APP = "pramen.information.date.format"
-  val TEMPORARY_DIRECTORY = "pramen.temporary.directory"
 
   val PARALLEL_TASKS = "pramen.parallel.tasks"
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -68,13 +68,13 @@ class MetastoreImpl(tableDefs: Seq[MetaTable],
 
   override def saveTable(tableName: String, infoDate: LocalDate, df: DataFrame, inputRecordCount: Option[Long]): MetaTableStats = {
     val mt = getTableDef(tableName)
-
+    val isTransient = mt.format.isInstanceOf[DataFormat.Transient]
     val start = Instant.now.getEpochSecond
     val stats = MetastorePersistence.fromMetaTable(mt).saveTable(infoDate, df, inputRecordCount)
     val finish = Instant.now.getEpochSecond
 
     if (!skipBookKeepingUpdates) {
-      bookkeeper.setRecordCount(tableName, infoDate, infoDate, infoDate, inputRecordCount.getOrElse(stats.recordCount), stats.recordCount, start, finish)
+      bookkeeper.setRecordCount(tableName, infoDate, infoDate, infoDate, inputRecordCount.getOrElse(stats.recordCount), stats.recordCount, start, finish, isTransient)
     }
 
     stats

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
@@ -56,7 +56,7 @@ object DataFormatParser {
         val path = Query.Path(conf.getString(PATH_KEY)).path
         DataFormat.Raw(path)
       case FORMAT_TRANSIENT =>
-        val cachePolicy = getCachePolicy(conf).getOrElse(CachePolicy.NoCache)
+        val cachePolicy = getCachePolicy(conf).getOrElse(CachePolicy.Persist)
         DataFormat.Transient(cachePolicy)
       case _              => throw new IllegalArgumentException(s"Unknown format: $format")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
@@ -56,7 +56,7 @@ object DataFormatParser {
         val path = Query.Path(conf.getString(PATH_KEY)).path
         DataFormat.Raw(path)
       case FORMAT_TRANSIENT =>
-        val cachePolicy = getCachePolicy(conf).getOrElse(CachePolicy.Persist)
+        val cachePolicy = getCachePolicy(conf).getOrElse(CachePolicy.NoCache)
         DataFormat.Transient(cachePolicy)
       case _              => throw new IllegalArgumentException(s"Unknown format: $format")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceTransient.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceTransient.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.peristence
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import za.co.absa.pramen.api.CachePolicy
+import za.co.absa.pramen.core.metastore.MetaTableStats
+import za.co.absa.pramen.core.metastore.model.HiveConfig
+import za.co.absa.pramen.core.utils.FsUtils
+import za.co.absa.pramen.core.utils.hive.QueryExecutor
+
+import java.time.LocalDate
+import scala.collection.mutable
+
+class MetastorePersistenceTransient(tempPath: String,
+                                    tableName: String,
+                                    cachePolicy: CachePolicy
+                                   )(implicit spark: SparkSession) extends MetastorePersistence {
+
+  import MetastorePersistenceTransient._
+
+  override def loadTable(infoDateFrom: Option[LocalDate], infoDateTo: Option[LocalDate]): DataFrame = {
+    (infoDateFrom, infoDateTo) match {
+      case (Some(from), Some(to)) if from == to =>
+        getDataForTheDate(tableName, from)
+      case (Some(_), Some(_)) =>
+        throw new IllegalArgumentException("Metastore 'transient' format does not support ranged queries.")
+      case _ =>
+        throw new IllegalArgumentException("Metastore 'transient' format requires info date for querying its contents.")
+    }
+  }
+
+  override def saveTable(infoDate: LocalDate, df: DataFrame, numberOfRecordsEstimate: Option[Long]): MetaTableStats = {
+    val (dfOut, sizeBytesOpt) = cachePolicy match {
+      case CachePolicy.NoCache =>
+        addRawDataFrame(tableName, infoDate, df)
+      case CachePolicy.Cache =>
+        addCachedDataframe(tableName, infoDate, df)
+      case CachePolicy.Persist =>
+        addPersistedDataFrame(tableName, infoDate, df, tempPath)
+    }
+
+    val recordCount = numberOfRecordsEstimate match {
+      case Some(n) => n
+      case None => dfOut.count()
+    }
+
+    MetaTableStats(
+      recordCount,
+      sizeBytesOpt
+    )
+  }
+
+  override def getStats(infoDate: LocalDate): MetaTableStats = {
+    throw new UnsupportedOperationException("Transient format does not support getting record count and size statistics.")
+  }
+
+  override def createOrUpdateHiveTable(infoDate: LocalDate,
+                                       hiveTableName: String,
+                                       queryExecutor: QueryExecutor,
+                                       hiveConfig: HiveConfig): Unit = {
+    throw new UnsupportedOperationException("Transient format does not support Hive tables.")
+  }
+
+  override def repairHiveTable(hiveTableName: String,
+                               queryExecutor: QueryExecutor,
+                               hiveConfig: HiveConfig): Unit = {
+    throw new UnsupportedOperationException("Transient format does not support Hive tables.")
+  }
+}
+
+object MetastorePersistenceTransient {
+  case class MetastorePartition(tableName: String, infoDateStr: String)
+
+  private val rawDataframes = new mutable.HashMap[MetastorePartition, DataFrame]()
+  private val cachedDataframes = new mutable.HashMap[MetastorePartition, DataFrame]()
+  private val persistedLocations = new mutable.HashMap[MetastorePartition, String]()
+
+  private[core] def addRawDataFrame(tableName: String, infoDate: LocalDate, df: DataFrame): (DataFrame, Option[Long]) = synchronized {
+    val partition = getMetastorePartition(tableName, infoDate)
+
+    rawDataframes += partition -> df
+
+    (df, None)
+  }
+
+  private[core] def addCachedDataframe(tableName: String, infoDate: LocalDate, df: DataFrame): (DataFrame, Option[Long]) = {
+    val partition = getMetastorePartition(tableName, infoDate)
+
+    val cachedDf = df.cache()
+
+    this.synchronized {
+      cachedDataframes += partition -> cachedDf
+    }
+
+    (cachedDf, None)
+  }
+
+  private[core] def addPersistedDataFrame(tableName: String, infoDate: LocalDate, df: DataFrame, tempDir: String): (DataFrame,  Option[Long]) = {
+    val partition = getMetastorePartition(tableName, infoDate)
+    val spark = df.sparkSession
+    val partitionFolder = s"temp_partition_date=$infoDate"
+    val outputPath = new Path(tempDir, partitionFolder).toString
+
+    val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, outputPath)
+
+    fsUtils.createDirectoryRecursive(new Path(outputPath))
+
+    df.write.mode(SaveMode.Overwrite).parquet(outputPath)
+
+    val sizeBytes = fsUtils.getDirectorySize(outputPath)
+
+    this.synchronized {
+      persistedLocations += partition -> outputPath
+    }
+
+    (df.sparkSession.read.parquet(outputPath), Option(sizeBytes))
+  }
+
+  private[core] def getDataForTheDate(tableName: String, infoDate: LocalDate)(implicit spark: SparkSession): DataFrame = synchronized {
+    val partition = getMetastorePartition(tableName, infoDate)
+
+    if (MetastorePersistenceTransient.rawDataframes.contains(partition)) {
+      MetastorePersistenceTransient.rawDataframes(partition)
+    } else if (MetastorePersistenceTransient.cachedDataframes.contains(partition)) {
+      MetastorePersistenceTransient.cachedDataframes(partition)
+    } else if (MetastorePersistenceTransient.persistedLocations.contains(partition)) {
+      val path = MetastorePersistenceTransient.persistedLocations(partition)
+      spark.read.parquet(path)
+    } else {
+      throw new IllegalStateException(s"No data for transient table '$tableName' for '$infoDate'")
+    }
+  }
+
+  private[core] def cleanup()(implicit spark: SparkSession): Unit = synchronized {
+    rawDataframes.clear()
+    cachedDataframes.foreach { case (_, df) => df.unpersist() }
+    cachedDataframes.clear()
+
+    persistedLocations.foreach { case (_, path) =>
+      val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, path)
+
+      fsUtils.deleteDirectoryRecursively(new Path(path))
+    }
+    persistedLocations.clear()
+  }
+
+  private def getMetastorePartition(tableName: String, infoDate: LocalDate): MetastorePartition = {
+    MetastorePersistenceTransient.MetastorePartition(tableName.toLowerCase, infoDate.toString)
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -397,7 +397,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
 
     val taskName = s"Files sourced - ${task.job.outputTable.name} - ${task.runInfo.map(_.infoDate.toString).getOrElse(" ")}"
 
-    tableHeaders.append(TableHeader(TextElement(taskName), Align.Center))
+    tableHeaders.append(TableHeader(TextElement(taskName), Align.Left))
     tableBuilder.withHeaders(tableHeaders.toSeq)
 
     runStatus.filesRead.sorted.foreach(fileName => {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -332,7 +332,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
       if (haveHiveColumn) {
         val hiveTable = task.runStatus match {
           case s: Succeeded => s.hiveTablesUpdated.mkString(", ")
-          case _            => "-"
+          case _            => ""
         }
 
         row.append(TextElement(hiveTable))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -71,6 +71,9 @@ class IngestionJob(operationDef: OperationDef,
       case Reason.Skip(msg) =>
         log.warn(s"Validation of '${outputTable.name}' for $from..$to requested to skip the task. Reason: $msg.")
         return JobPreRunResult(JobPreRunStatus.Skip(msg), None, dependencyWarnings, Nil)
+      case Reason.SkipOnce(msg) =>
+        log.warn(s"Validation of '${outputTable.name}' for $from..$to requested to skip the task. Reason: $msg.")
+        return JobPreRunResult(JobPreRunStatus.Skip(msg), None, dependencyWarnings, Nil)
     }
 
     val recordCount = source.getRecordCount(sourceTable.query, from, to)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -82,7 +82,11 @@ class PythonTransformationJob(operationDef: OperationDef,
   }
 
   override def validate(infoDate: LocalDate, jobConfig: Config): Reason = {
+    if (outputTable.format.isInstanceOf[DataFormat.Transient]) {
+      Reason.NotReady(s"Python transformations cannot output to transient tables. Please, change teh format of ${outputTable.name}")
+    } else {
       Reason.Ready
+    }
   }
 
   override def run(infoDate: LocalDate, conf: Config): RunResult = {
@@ -135,7 +139,8 @@ class PythonTransformationJob(operationDef: OperationDef,
       stats.recordCount,
       stats.recordCount,
       jobStarted.getEpochSecond,
-      jobFinished.getEpochSecond)
+      jobFinished.getEpochSecond,
+      isTableTransient = false)
 
     SaveResult(stats)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{DataFormat, Reason}
 import za.co.absa.pramen.core.app.config.GeneralConfig.TEMPORARY_DIRECTORY_KEY
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
-import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.databricks.{DatabricksClient, PramenPyJobTemplate}
 import za.co.absa.pramen.core.exceptions.ProcessFailedException
 import za.co.absa.pramen.core.metastore.Metastore
@@ -273,7 +272,12 @@ class PythonTransformationJob(operationDef: OperationDef,
   }
 
   private[core] def getTemporaryPathForYamlConfig(conf: Config) = {
-    val temporaryDirectoryBase = conf.getString(TEMPORARY_DIRECTORY_KEY).stripSuffix("/")
+    val temporaryDirectoryBase = if (conf.hasPath(TEMPORARY_DIRECTORY_KEY) && conf.getString(TEMPORARY_DIRECTORY_KEY).nonEmpty) {
+      conf.getString(TEMPORARY_DIRECTORY_KEY).stripSuffix("/")
+    } else {
+      throw new IllegalArgumentException(s"Python transformation require temporary directory to be defined at: $TEMPORARY_DIRECTORY_KEY")
+    }
+
     val randomNumber = Random.nextInt(1000000)
 
     val pathForConfig = s"$temporaryDirectoryBase/pramen_py_configs/$randomNumber/config.yaml"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -20,6 +20,7 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{DataFormat, Reason}
+import za.co.absa.pramen.core.app.config.GeneralConfig.TEMPORARY_DIRECTORY_KEY
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.databricks.{DatabricksClient, PramenPyJobTemplate}
@@ -267,7 +268,7 @@ class PythonTransformationJob(operationDef: OperationDef,
   }
 
   private[core] def getTemporaryPathForYamlConfig(conf: Config) = {
-    val temporaryDirectoryBase = conf.getString(Keys.TEMPORARY_DIRECTORY).stripSuffix("/")
+    val temporaryDirectoryBase = conf.getString(TEMPORARY_DIRECTORY_KEY).stripSuffix("/")
     val randomNumber = Random.nextInt(1000000)
 
     val pathForConfig = s"$temporaryDirectoryBase/pramen_py_configs/$randomNumber/config.yaml"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.Config
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.{Reason, Sink}
+import za.co.absa.pramen.api.{DataFormat, Reason, Sink}
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.metastore.model.MetaTable
 import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore}
@@ -128,6 +128,8 @@ class SinkJob(operationDef: OperationDef,
       )
       val jobFinished = Instant.now
 
+      val isTransient = outputTable.format.isInstanceOf[DataFormat.Transient]
+
       bookkeeper.setRecordCount(outputTable.name,
         infoDate,
         infoDate,
@@ -135,7 +137,8 @@ class SinkJob(operationDef: OperationDef,
         inputRecordCount.getOrElse(sinkResult.recordsSent),
         sinkResult.recordsSent,
         jobStarted.getEpochSecond,
-        jobFinished.getEpochSecond
+        jobFinished.getEpochSecond,
+        isTransient
       )
 
       val stats = MetaTableStats(sinkResult.recordsSent, None)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.app.{AppContext, AppContextImpl}
 import za.co.absa.pramen.core.config.Keys.LOG_EXECUTOR_NODES
+import za.co.absa.pramen.core.metastore.peristence.MetastorePersistenceTransient
 import za.co.absa.pramen.core.pipeline.{Job, OperationSplitter, PipelineDef}
 import za.co.absa.pramen.core.runner.jobrunner.{ConcurrentJobRunner, ConcurrentJobRunnerImpl}
 import za.co.absa.pramen.core.runner.orchestrator.OrchestratorImpl
@@ -217,6 +218,7 @@ object AppRunner {
   private[core] def shutdown(taskRunner: TaskRunner, state: PipelineState): Try[Unit] = {
     handleFailure(Try {
       taskRunner.shutdown()
+      MetastorePersistenceTransient.cleanup()
     }, state, "shutting down task runner execution context")
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -20,6 +20,7 @@ import com.github.yruslan.channel.Channel
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.app.AppContext
 import za.co.absa.pramen.core.pipeline.{Job, JobDependency, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunner
@@ -83,9 +84,10 @@ class OrchestratorImpl extends Orchestrator {
 
       val missingTables = dependencyResolver.getMissingDependencies(job.outputTable.name)
 
+      val isTransient = job.outputTable.format.isInstanceOf[DataFormat.Transient]
       val isFailure = hasNonPassiveNonOptionalDeps(job, missingTables)
 
-      val taskResult = TaskResult(job, RunStatus.MissingDependencies(isFailure, missingTables), None, applicationId, Nil, Nil, Nil)
+      val taskResult = TaskResult(job, RunStatus.MissingDependencies(isFailure, missingTables), None, applicationId,isTransient, Nil, Nil, Nil)
 
       state.addTaskCompletion(taskResult :: Nil)
     })

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskResult.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskResult.scala
@@ -24,6 +24,7 @@ case class TaskResult(
                        runStatus: RunStatus,
                        runInfo: Option[RunInfo],
                        applicationId: String,
+                       isTransient: Boolean,
                        schemaChanges: Seq[SchemaDifference],
                        dependencyWarnings: Seq[DependencyWarning],
                        notificationTargetErrors: Seq[NotificationFailure]

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -211,7 +211,8 @@ abstract class TaskRunnerBase(conf: Config,
               case Reason.Skip(msg) =>
                 log.info(s"SKIP validation failure for the task: $outputTable for date: ${task.infoDate}. Reason: $msg")
                 if (bookkeeper.getLatestDataChunk(outputTable, task.infoDate, task.infoDate).isEmpty) {
-                  bookkeeper.setRecordCount(outputTable, task.infoDate, task.infoDate, task.infoDate, status.inputRecordsCount.getOrElse(0L), 0, started.getEpochSecond, Instant.now().getEpochSecond)
+                  val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
+                  bookkeeper.setRecordCount(outputTable, task.infoDate, task.infoDate, task.infoDate, status.inputRecordsCount.getOrElse(0L), 0, started.getEpochSecond, Instant.now().getEpochSecond, isTransient)
                 }
                 Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, Nil, status.dependencyWarnings, Nil))
             }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -118,7 +118,8 @@ abstract class TaskRunnerBase(conf: Config,
     val now = Instant.now()
     val runStatus = RunStatus.Skipped(reason)
     val runInfo = RunInfo(task.infoDate, now, now)
-    val taskResult = TaskResult(task.job, runStatus, Some(runInfo), applicationId, Nil, Nil, Nil)
+    val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
+    val taskResult = TaskResult(task.job, runStatus, Some(runInfo), applicationId, isTransient, Nil, Nil, Nil)
 
     onTaskCompletion(task, taskResult)
   }
@@ -135,6 +136,7 @@ abstract class TaskRunnerBase(conf: Config,
     */
   private[core] def preRunCheck(task: Task, started: Instant): Either[TaskResult, JobPreRunResult] = {
     val outputTable = task.job.outputTable.name
+    val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
 
     Try {
       task.job.preRunCheck(task.infoDate, conf)
@@ -149,23 +151,23 @@ abstract class TaskRunnerBase(conf: Config,
             Right(validationResult)
           case NoData(isFailure) =>
             log.info(s"NO DATA available for the task: $outputTable for date: ${task.infoDate}.")
-            Left(TaskResult(task.job, RunStatus.NoData(isFailure), getRunInfo(task.infoDate, started), applicationId, Nil, validationResult.dependencyWarnings, Nil))
+            Left(TaskResult(task.job, RunStatus.NoData(isFailure), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, validationResult.dependencyWarnings, Nil))
           case InsufficientData(actual, expected, oldRecordCount) =>
             log.info(s"INSUFFICIENT DATA available for the task: $outputTable for date: ${task.infoDate}. Expected = $expected, actual = $actual")
-            Left(TaskResult(task.job, RunStatus.InsufficientData(actual, expected, oldRecordCount), getRunInfo(task.infoDate, started), applicationId, Nil, validationResult.dependencyWarnings, Nil))
+            Left(TaskResult(task.job, RunStatus.InsufficientData(actual, expected, oldRecordCount), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, validationResult.dependencyWarnings, Nil))
           case AlreadyRan =>
             if (runtimeConfig.isRerun) {
               log.info(s"RE-RUNNING the task: $outputTable for date: ${task.infoDate}.")
               Right(validationResult)
             } else {
               log.info(s"SKIPPING already ran job: $outputTable for date: ${task.infoDate}.")
-              Left(TaskResult(task.job, RunStatus.NotRan, getRunInfo(task.infoDate, started), applicationId, Nil, validationResult.dependencyWarnings, Nil))
+              Left(TaskResult(task.job, RunStatus.NotRan, getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, validationResult.dependencyWarnings, Nil))
             }
           case Skip(msg) =>
             log.info(s"SKIPPING job: $outputTable for date: ${task.infoDate}. Reason: msg")
-            Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, Nil, validationResult.dependencyWarnings, Nil))
+            Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, validationResult.dependencyWarnings, Nil))
           case FailedDependencies(isFailure, failures) =>
-            Left(TaskResult(task.job, RunStatus.FailedDependencies(isFailure, failures), getRunInfo(task.infoDate, started), applicationId, Nil, Nil, Nil))
+            Left(TaskResult(task.job, RunStatus.FailedDependencies(isFailure, failures), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, Nil, Nil))
         }
         if (validationResult.dependencyWarnings.nonEmpty) {
           log.warn(s"$WARNING Validation of the task: $outputTable for date: ${task.infoDate} has " +
@@ -173,7 +175,7 @@ abstract class TaskRunnerBase(conf: Config,
         }
         resultToReturn
       case Failure(ex) =>
-        Left(TaskResult(task.job, RunStatus.ValidationFailed(ex), getRunInfo(task.infoDate, started), applicationId, Nil, Nil, Nil))
+        Left(TaskResult(task.job, RunStatus.ValidationFailed(ex), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, Nil, Nil))
     }
   }
 
@@ -189,6 +191,7 @@ abstract class TaskRunnerBase(conf: Config,
     */
   private[core] def validate(task: Task, started: Instant): Either[TaskResult, JobPreRunResult] = {
     val outputTable = task.job.outputTable.name
+    val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
 
     preRunCheck(task, started) match {
       case Left(result) =>
@@ -207,17 +210,17 @@ abstract class TaskRunnerBase(conf: Config,
                 Right(status.copy(warnings = reason.warnings))
               case Reason.NotReady(msg) =>
                 log.info(s"NOT READY validation failure for the task: $outputTable for date: ${task.infoDate}. Reason: $msg")
-                Left(TaskResult(task.job, RunStatus.ValidationFailed(new ReasonException(Reason.NotReady(msg), msg)), getRunInfo(task.infoDate, started), applicationId, Nil, status.dependencyWarnings, Nil))
+                Left(TaskResult(task.job, RunStatus.ValidationFailed(new ReasonException(Reason.NotReady(msg), msg)), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))
               case Reason.Skip(msg) =>
                 log.info(s"SKIP validation failure for the task: $outputTable for date: ${task.infoDate}. Reason: $msg")
                 if (bookkeeper.getLatestDataChunk(outputTable, task.infoDate, task.infoDate).isEmpty) {
                   val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
                   bookkeeper.setRecordCount(outputTable, task.infoDate, task.infoDate, task.infoDate, status.inputRecordsCount.getOrElse(0L), 0, started.getEpochSecond, Instant.now().getEpochSecond, isTransient)
                 }
-                Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, Nil, status.dependencyWarnings, Nil))
+                Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))
             }
           case Failure(ex) =>
-            Left(TaskResult(task.job, RunStatus.ValidationFailed(ex), getRunInfo(task.infoDate, started), applicationId, Nil, status.dependencyWarnings, Nil))
+            Left(TaskResult(task.job, RunStatus.ValidationFailed(ex), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))
         }
     }
   }
@@ -232,6 +235,7 @@ abstract class TaskRunnerBase(conf: Config,
     * @return an instance of TaskResult.
     */
   private[core] def run(task: Task, started: Instant, validationResult: JobPreRunResult): TaskResult = {
+    val isTransient = task.job.outputTable.format.isInstanceOf[DataFormat.Transient]
     val lock = lockFactory.getLock(getTokenName(task))
 
     val attempt = Try {
@@ -309,6 +313,7 @@ abstract class TaskRunnerBase(conf: Config,
           warnings),
         Some(RunInfo(task.infoDate, started, finished)),
         applicationId,
+        isTransient,
         schemaChangesBeforeTransform ::: schemaChangesAfterTransform,
         validationResult.dependencyWarnings,
         Seq.empty)
@@ -322,7 +327,7 @@ abstract class TaskRunnerBase(conf: Config,
       case Success(result) =>
         result
       case Failure(ex) =>
-        TaskResult(task.job, RunStatus.Failed(ex), getRunInfo(task.infoDate, started), applicationId,
+        TaskResult(task.job, RunStatus.Failed(ex), getRunInfo(task.infoDate, started), applicationId, isTransient,
           Nil,validationResult.dependencyWarnings, Nil)
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -218,6 +218,9 @@ abstract class TaskRunnerBase(conf: Config,
                   bookkeeper.setRecordCount(outputTable, task.infoDate, task.infoDate, task.infoDate, status.inputRecordsCount.getOrElse(0L), 0, started.getEpochSecond, Instant.now().getEpochSecond, isTransient)
                 }
                 Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))
+              case Reason.SkipOnce(msg) =>
+                log.info(s"SKIP today validation failure for the task: $outputTable for date: ${task.infoDate}. Reason: $msg")
+                Left(TaskResult(task.job, RunStatus.Skipped(msg), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))
             }
           case Failure(ex) =>
             Left(TaskResult(task.job, RunStatus.ValidationFailed(ex), getRunInfo(task.infoDate, started), applicationId, isTransient, Nil, status.dependencyWarnings, Nil))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
@@ -123,8 +123,8 @@ class ConversionTransformer extends Transformer {
       throw new IllegalArgumentException(s"Table $inputTable should be in 'raw' format so the for each file the metastore returns a file path.")
     }
 
-    if (filesDf.count() == 0) {
-      Reason.NotReady(s"Table $inputTable has no data for $infoDate")
+    if (filesDf.isEmpty) {
+      Reason.SkipOnce(s"Table $inputTable has no data for $infoDate")
     } else {
       Reason.Ready
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
@@ -37,7 +37,7 @@ class IdentityTransformer extends Transformer {
     if (emptyAllowed || !df.isEmpty) {
       Reason.Ready
     } else {
-      Reason.NotReady(s"No data for '$tableName' at $infoDate")
+      Reason.SkipOnce(s"No data for '$tableName' at $infoDate")
     }
   }
 

--- a/pramen/core/src/test/resources/test/config/integration_transient_transformer.conf
+++ b/pramen/core/src/test/resources/test/config/integration_transient_transformer.conf
@@ -1,0 +1,118 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variable is expected to be set up by the test suite
+#base.path = "/tmp"
+
+pramen {
+  pipeline.name = "Integration test with a file-based source"
+
+  temporary.directory = ${base.path}/temp
+
+  bookkeeping.enabled = false
+  stop.spark.session = false
+}
+
+pramen.metastore {
+  tables = [
+    {
+      name = "table1"
+      description = "Table 1 (file based)"
+      format = "raw"
+      path = ${base.path}/table1
+    },
+    {
+      name = "table2"
+      description = "Table 2 (transient)"
+      format = "transient"
+      cache.policy = ${cache.policy}
+    }
+    {
+      name = "table3"
+      description = "Table 3 (parquet)"
+      format = "parquet"
+      path = ${base.path}/table3
+    }
+  ]
+}
+
+pramen.sources.1 = [
+  {
+    name = "file_source"
+    factory.class = "za.co.absa.pramen.core.source.RawFileSource"
+  }
+]
+
+pramen.operations = [
+  {
+    name = "Sourcing from a folder"
+    type = "ingestion"
+    schedule.type = "daily"
+
+    source = "file_source"
+
+    info.date.expr = "@runDate"
+
+    tables = [
+      {
+        input.path = ${base.path}
+        output.metastore.table = table1
+      }
+    ]
+  },
+  {
+    name = "Converting to dataframe"
+    type = "transformation"
+
+    class = "za.co.absa.pramen.core.transformers.ConversionTransformer"
+    schedule.type = "daily"
+
+    output.table = "table2"
+
+    dependencies = [
+      {
+        tables = [ table1 ]
+        date.from = "@infoDate"
+        optional = true # Since no bookkeeping available the table will be seen as empty for the dependency manager
+      }
+    ]
+
+    option {
+      input.table = "table1"
+      input.format = "csv"
+
+      header = true
+    }
+  },
+  {
+    name = "Identity transformer"
+    type = "transformation"
+
+    class = "za.co.absa.pramen.core.transformers.IdentityTransformer"
+    schedule.type = "daily"
+
+    output.table = "table3"
+
+    dependencies = [
+      {
+        tables = [ table2 ]
+        date.from = "@infoDate"
+        optional = true # Since no bookkeeping available the table will be seen as empty for the dependency manager
+      }
+    ]
+
+    option {
+      table = "table2"
+    }
+  }
+]

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/AppContextFactorySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/AppContextFactorySuite.scala
@@ -17,7 +17,6 @@
 package za.co.absa.pramen.core
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.bookkeeper.BookkeeperNull

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
@@ -38,7 +38,7 @@ class GeneralConfigSuite extends AnyWordSpec {
 
       assert(generalConfig.timezoneId == ZoneId.of("Africa/Johannesburg"))
       assert(generalConfig.environmentName == "DummyEnv")
-      assert(generalConfig.temporaryDirectory == "/dummy/dir")
+      assert(generalConfig.temporaryDirectory.contains("/dummy/dir"))
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/TransientTablesSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/TransientTablesSuite.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.integration
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.runner.AppRunner
+import za.co.absa.pramen.core.utils.{FsUtils, ResourceUtils}
+
+import java.nio.file.Files
+import java.time.LocalDate
+
+class TransientTablesSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
+  private val infoDate = LocalDate.of(2021, 2, 18)
+
+  "Transient metastore tables" should {
+    val expected =
+      """{"id":"1","name":"John"}
+        |{"id":"2","name":"Jack"}
+        |{"id":"3","name":"Jill"}
+        |{"id":"4","name":"Mary"}
+        |{"id":"5","name":"Jane"}
+        |{"id":"6","name":"Kate"}
+        |""".stripMargin
+
+    "work end to end with a no_cache policy" in {
+      withTempDirectory("integration_file_based") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        fsUtils.writeFile(new Path(tempDir, "landing_file1.csv"), "id,name\n1,John\n2,Jack\n3,Jill\n")
+        fsUtils.writeFile(new Path(tempDir, "landing_file2.csv"), "id,name\n4,Mary\n5,Jane\n6,Kate\n")
+
+        val conf = getConfig(tempDir)
+
+        val exitCode = AppRunner.runPipeline(conf)
+
+        assert(exitCode == 0)
+
+        val table2Path = new Path(new Path(tempDir, "table2"), s"pramen_info_date=$infoDate")
+        val table3Path = new Path(new Path(tempDir, "table3"), s"pramen_info_date=$infoDate")
+
+        assert(!fsUtils.exists(table2Path))
+
+        val df = spark.read.parquet(table3Path.toString)
+        val actual = df.orderBy("id").toJSON.collect().mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+
+    "work end to end with a persist policy" in {
+      withTempDirectory("integration_file_based") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        fsUtils.writeFile(new Path(tempDir, "landing_file1.csv"), "id,name\n1,John\n2,Jack\n3,Jill\n")
+        fsUtils.writeFile(new Path(tempDir, "landing_file2.csv"), "id,name\n4,Mary\n5,Jane\n6,Kate\n")
+
+        val conf = getConfig(tempDir, cachePolicy = "persist")
+
+        val exitCode = AppRunner.runPipeline(conf)
+
+        assert(exitCode == 0)
+
+        val table2Path = new Path(new Path(tempDir, "table2"), s"pramen_info_date=$infoDate")
+        val table3Path = new Path(new Path(tempDir, "table3"), s"pramen_info_date=$infoDate")
+
+        assert(!fsUtils.exists(table2Path))
+
+        val df = spark.read.parquet(table3Path.toString)
+        val actual = df.orderBy("id").toJSON.collect().mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+  }
+
+  def getConfig(basePath: String, cachePolicy: String = "no_cache"): Config = {
+    val configContents = ResourceUtils.getResourceString("/test/config/integration_transient_transformer.conf")
+    val basePathEscaped = basePath.replace("\\", "\\\\")
+
+    val conf = ConfigFactory.parseString(
+      s"""base.path = "$basePathEscaped"
+         |cache.policy = $cachePolicy
+         |pramen.runtime.is.rerun = true
+         |pramen.current.date = "$infoDate"
+         |$configContents
+         |""".stripMargin
+    ).withFallback(ConfigFactory.load())
+      .resolve()
+
+    conf
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
@@ -86,7 +86,7 @@ class DataFormatSuite extends AnyWordSpec {
 
       assert(format.name == "transient")
       assert(format.isInstanceOf[Transient])
-      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.Persist)
+      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.NoCache)
     }
 
     "support cache policies for 'transient' format" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
@@ -25,7 +25,7 @@ import za.co.absa.pramen.core.metastore.model.DataFormatParser.{PATH_KEY, TABLE_
 class DataFormatSuite extends AnyWordSpec {
   "fromConfig()" should {
     "use 'parquet' as the default format" in {
-      val conf = ConfigFactory.parseString("""path = /a/b/c""")
+      val conf = ConfigFactory.parseString("path = /a/b/c")
 
       val format = DataFormatParser.fromConfig(conf, conf)
 
@@ -37,8 +37,7 @@ class DataFormatSuite extends AnyWordSpec {
 
     "use 'parquet' when specified explicitly" in {
       val conf = ConfigFactory.parseString(
-      """
-          |format = parquet
+        """format = parquet
           |path = /a/b/c
           |records.per.partition = 100
           |""".stripMargin)
@@ -53,8 +52,7 @@ class DataFormatSuite extends AnyWordSpec {
 
     "use 'delta' when specified explicitly" in {
       val conf = ConfigFactory.parseString(
-        """
-          |format = delta
+        """format = delta
           |path = /a/b/c
           |records.per.partition = 200
           |""".stripMargin)
@@ -70,8 +68,7 @@ class DataFormatSuite extends AnyWordSpec {
 
     "use 'raw' when specified explicitly" in {
       val conf = ConfigFactory.parseString(
-        """
-          |format = raw
+        """format = raw
           |path = /a/b/c
           |""".stripMargin)
 
@@ -83,22 +80,18 @@ class DataFormatSuite extends AnyWordSpec {
     }
 
     "use 'transient' when specified explicitly" in {
-      val conf = ConfigFactory.parseString(
-        """
-          |format = transient
-          |""".stripMargin)
+      val conf = ConfigFactory.parseString("format = transient")
 
       val format = DataFormatParser.fromConfig(conf, conf)
 
       assert(format.name == "transient")
       assert(format.isInstanceOf[Transient])
-      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.NoCache)
+      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.Persist)
     }
 
     "support cache policies for 'transient' format" in {
       val conf = ConfigFactory.parseString(
-        """
-          |format = transient
+        """format = transient
           |cache.policy = cache
           |""".stripMargin)
 
@@ -111,8 +104,7 @@ class DataFormatSuite extends AnyWordSpec {
 
     "use default records per partition" in {
       val conf = ConfigFactory.parseString(
-        """
-          |format = delta
+        """format = delta
           |path = /a/b/c
           |""".stripMargin)
 
@@ -128,10 +120,7 @@ class DataFormatSuite extends AnyWordSpec {
     }
 
     "throw an exception on unknown format" in {
-      val conf = ConfigFactory.parseString(
-        """
-          |format = isberg
-          |""".stripMargin)
+      val conf = ConfigFactory.parseString("format = isberg")
 
       val ex = intercept[IllegalArgumentException] {
         DataFormatParser.fromConfig(conf, conf)
@@ -141,10 +130,7 @@ class DataFormatSuite extends AnyWordSpec {
     }
 
     "throw an exception on mandatory options missing" in {
-      val conf = ConfigFactory.parseString(
-        """
-          |format = parquet
-          |""".stripMargin)
+      val conf = ConfigFactory.parseString("format = parquet")
 
       val ex = intercept[IllegalArgumentException] {
         DataFormatParser.fromConfig(conf, conf)
@@ -154,10 +140,7 @@ class DataFormatSuite extends AnyWordSpec {
     }
 
     "throw an exception when path is not specified for 'raw'" in {
-      val conf = ConfigFactory.parseString(
-        """
-          |format = raw
-          |""".stripMargin)
+      val conf = ConfigFactory.parseString("format = raw")
 
       val ex = intercept[IllegalArgumentException] {
         DataFormatParser.fromConfig(conf, conf)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
@@ -18,8 +18,9 @@ package za.co.absa.pramen.core.metastore.model
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.api.DataFormat.{Delta, Parquet}
-import za.co.absa.pramen.api.Query
+import za.co.absa.pramen.api.DataFormat.{Delta, Parquet, Raw, Transient}
+import za.co.absa.pramen.api.{CachePolicy, DataFormat, Query}
+import za.co.absa.pramen.core.metastore.model.DataFormatParser.{PATH_KEY, TABLE_KEY}
 
 class DataFormatSuite extends AnyWordSpec {
   "fromConfig()" should {
@@ -67,6 +68,47 @@ class DataFormatSuite extends AnyWordSpec {
       assert(format.asInstanceOf[Delta].recordsPerPartition.contains(200))
     }
 
+    "use 'raw' when specified explicitly" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |format = raw
+          |path = /a/b/c
+          |""".stripMargin)
+
+      val format = DataFormatParser.fromConfig(conf, conf)
+
+      assert(format.name == "raw")
+      assert(format.isInstanceOf[Raw])
+      assert(format.asInstanceOf[Raw].path == "/a/b/c")
+    }
+
+    "use 'transient' when specified explicitly" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |format = transient
+          |""".stripMargin)
+
+      val format = DataFormatParser.fromConfig(conf, conf)
+
+      assert(format.name == "transient")
+      assert(format.isInstanceOf[Transient])
+      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.NoCache)
+    }
+
+    "support cache policies for 'transient' format" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |format = transient
+          |cache.policy = cache
+          |""".stripMargin)
+
+      val format = DataFormatParser.fromConfig(conf, conf)
+
+      assert(format.name == "transient")
+      assert(format.isInstanceOf[Transient])
+      assert(format.asInstanceOf[Transient].cachePolicy == CachePolicy.Cache)
+    }
+
     "use default records per partition" in {
       val conf = ConfigFactory.parseString(
         """
@@ -110,6 +152,95 @@ class DataFormatSuite extends AnyWordSpec {
 
       assert(ex.getMessage.contains("Mandatory option missing: path"))
     }
+
+    "throw an exception when path is not specified for 'raw'" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |format = raw
+          |""".stripMargin)
+
+      val ex = intercept[IllegalArgumentException] {
+        DataFormatParser.fromConfig(conf, conf)
+      }
+
+      assert(ex.getMessage.contains("Mandatory option for a metastore table having 'raw' format"))
+    }
   }
 
+  "getCachePolicy" should {
+    "return None when no policy is defined" in {
+      val conf = ConfigFactory.empty()
+
+      val policy = DataFormatParser.getCachePolicy(conf)
+
+      assert(policy.isEmpty)
+    }
+
+    "return the proper object for policy 'cache'" in {
+      val conf = ConfigFactory.parseString("cache.policy = cache")
+
+      val policy = DataFormatParser.getCachePolicy(conf)
+
+      assert(policy.isDefined)
+      assert(policy.get == CachePolicy.Cache)
+    }
+
+    "return the proper object for policy 'no_cache'" in {
+      val conf = ConfigFactory.parseString("cache.policy = no_cache")
+
+      val policy = DataFormatParser.getCachePolicy(conf)
+
+      assert(policy.isDefined)
+      assert(policy.get == CachePolicy.NoCache)
+    }
+
+    "return the proper object for policy 'transient'" in {
+      val conf = ConfigFactory.parseString("cache.policy = persist")
+
+      val policy = DataFormatParser.getCachePolicy(conf)
+
+      assert(policy.isDefined)
+      assert(policy.get == CachePolicy.Persist)
+    }
+
+    "throw wn exception on invalid cache policy string" in {
+      val conf = ConfigFactory.parseString("cache.policy = dummy")
+
+      val ex = intercept[IllegalArgumentException] {
+        DataFormatParser.getCachePolicy(conf)
+      }
+
+      assert(ex.getMessage.contains("Incorrect cache policy: dummy"))
+    }
+  }
+
+  "getQuery" should {
+    "return the proper object for path" in {
+      val conf = ConfigFactory.parseString("path = /a/b/c")
+
+      val query = DataFormatParser.getQuery(conf)
+
+      assert(query.isInstanceOf[Query.Path])
+      assert(query.asInstanceOf[Query.Path].path == "/a/b/c")
+    }
+
+    "return the proper object for table" in {
+      val conf = ConfigFactory.parseString("table = db.table")
+
+      val query = DataFormatParser.getQuery(conf)
+
+      assert(query.isInstanceOf[Query.Table])
+      assert(query.asInstanceOf[Query.Table].dbTable == "db.table")
+    }
+
+    "throw an exception when neither path nor table is specified" in {
+      val conf = ConfigFactory.empty()
+
+      val ex = intercept[IllegalArgumentException] {
+        DataFormatParser.getQuery(conf)
+      }
+
+      assert(ex.getMessage.contains(s"Mandatory option missing: $PATH_KEY or $TABLE_KEY"))
+    }
+  }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -51,13 +51,17 @@ class MetaTableSuite extends AnyWordSpec {
           |    name = table3
           |    format = delta
           |    path = /a/b/c
+          |  },
+          |  {
+          |    name = table4
+          |    format = transient
           |  }
           |]
           |""".stripMargin)
 
       val metaTables = MetaTable.fromConfig(conf, "pramen.metastore.tables")
 
-      assert(metaTables.size == 3)
+      assert(metaTables.size == 4)
       assert(metaTables.head.name == "table1")
       assert(metaTables.head.format.name == "parquet")
       assert(metaTables.head.infoDateColumn == "INFO_DATE")
@@ -73,6 +77,8 @@ class MetaTableSuite extends AnyWordSpec {
       assert(metaTables(2).format.name == "delta")
       assert(metaTables(2).infoDateColumn == "INFORMATION_DATE")
       assert(metaTables(2).infoDateFormat == "yyyy-MM-dd")
+      assert(metaTables(3).name == "table4")
+      assert(metaTables(3).format.name == "transient")
     }
 
     "create an empty metastore if the config key is missing" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceTransientSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceTransientSuite.scala
@@ -48,6 +48,10 @@ class MetastorePersistenceTransientSuite extends AnyWordSpec with BeforeAndAfter
     super.afterAll()
   }
 
+  "cleanup should do nothing if spark session is not available" in {
+    MetastorePersistenceTransient.cleanup()
+  }
+
   "loadTable" should {
     "return data for a date when it is available" in {
       val persistor = new MetastorePersistenceTransient(null, "table1", CachePolicy.NoCache)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceTransientSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceTransientSuite.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.persistence
+
+import org.apache.spark.sql.DataFrame
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.api.CachePolicy
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.TempDirFixture
+import za.co.absa.pramen.core.metastore.peristence.MetastorePersistenceTransient
+
+import java.time.LocalDate
+
+class MetastorePersistenceTransientSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with TempDirFixture {
+
+  import spark.implicits._
+
+  private val infoDate = LocalDate.of(2022, 2, 18)
+
+  private def exampleDf: DataFrame = List(("A", 1), ("B", 2), ("C", 3)).toDF("a", "b")
+
+  private var tempDir: String = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    tempDir = createTempDir("transient_persist")
+  }
+
+  override def afterAll(): Unit = {
+    deleteDir(tempDir)
+
+    super.afterAll()
+  }
+
+  "loadTable" should {
+    "return data for a date when it is available" in {
+      val persistor = new MetastorePersistenceTransient(null, "table1", CachePolicy.NoCache)
+
+      persistor.saveTable(infoDate, exampleDf, Some(10))
+
+      val df = persistor.loadTable(Some(infoDate), Some(infoDate))
+
+      assert(df.count() == 3)
+    }
+
+    "throw an exception is the data is not available" in {
+      val persistor = new MetastorePersistenceTransient(null, "table2", CachePolicy.Cache)
+
+      persistor.saveTable(infoDate, exampleDf, Some(10))
+
+      val ex = intercept[IllegalStateException] {
+        persistor.loadTable(Some(infoDate.plusDays(1)), Some(infoDate.plusDays(1)))
+      }
+
+      assert(ex.getMessage.contains("No data for transient table 'table2' for '2022-02-19'"))
+    }
+
+    "throw an exception on range queries" in {
+      val persistor = new MetastorePersistenceTransient(null, "table2", CachePolicy.Cache)
+
+      persistor.saveTable(infoDate, exampleDf, None)
+
+      val ex = intercept[IllegalArgumentException] {
+        persistor.loadTable(Some(infoDate.minusDays(1)), Some(infoDate.plusDays(1)))
+      }
+
+      assert(ex.getMessage.contains("Metastore 'transient' format does not support ranged queries"))
+    }
+
+    "throw an exception if info date is not provided" in {
+      val persistor = new MetastorePersistenceTransient(null, "table2", CachePolicy.Cache)
+
+      val ex = intercept[IllegalArgumentException] {
+        persistor.loadTable(None, None)
+      }
+
+      assert(ex.getMessage.contains("Metastore 'transient' format requires info date for querying its contents"))
+    }
+  }
+
+  "saveTable" should {
+    "work with non-cached data frames" in {
+      val persistor = new MetastorePersistenceTransient(null, "table_not_cached", CachePolicy.NoCache)
+
+      val saveResult = persistor.saveTable(infoDate, exampleDf, Some(10))
+
+      assert(saveResult.recordCount == 10)
+      assert(saveResult.dataSizeBytes.isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+
+    "work with cached data frames" in {
+      val persistor = new MetastorePersistenceTransient(null, "table_cached", CachePolicy.Cache)
+
+      val saveResult = persistor.saveTable(infoDate, exampleDf, None)
+
+      assert(saveResult.recordCount == 3)
+      assert(saveResult.dataSizeBytes.isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+
+    "work with persisted data frames" in {
+      val persistor = new MetastorePersistenceTransient(tempDir, "table_persisted", CachePolicy.Persist)
+
+      val saveResult = persistor.saveTable(infoDate, exampleDf, None)
+
+      assert(saveResult.recordCount == 3)
+      assert(saveResult.dataSizeBytes.isDefined)
+      assert(saveResult.dataSizeBytes.exists(_ > 100))
+
+      MetastorePersistenceTransient.cleanup()
+    }
+  }
+
+  "getStats" should {
+    "not be supported" in {
+      val persistor = new MetastorePersistenceTransient(null, null, null)
+
+      assertThrows[UnsupportedOperationException] {
+        persistor.getStats(null)
+      }
+    }
+  }
+
+  "createOrUpdateHiveTable" should {
+    "not be supported" in {
+      val persistor = new MetastorePersistenceTransient(null, null, null)
+
+      assertThrows[UnsupportedOperationException] {
+        persistor.createOrUpdateHiveTable(null, null, null, null)
+      }
+    }
+  }
+
+  "repairHiveTable" should {
+    "not be supported" in {
+      val persistor = new MetastorePersistenceTransient(null, null, null)
+
+      assertThrows[UnsupportedOperationException] {
+        persistor.repairHiveTable(null, null, null)
+      }
+    }
+  }
+
+  "addRawDataFrame" should {
+    "return dataframe only" in {
+      val (df, size) = MetastorePersistenceTransient.addRawDataFrame("table_not_cached2", infoDate, exampleDf)
+
+      assert(df.schema.treeString == exampleDf.schema.treeString)
+      assert(df.count() == 3)
+      assert(size.isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+  }
+
+  "cachedDataframes" should {
+    "return dataframe only" in {
+      val (df, size) = MetastorePersistenceTransient.addCachedDataframe("table_cached2", infoDate, exampleDf)
+
+      assert(df.schema.treeString == exampleDf.schema.treeString)
+      assert(df.count() == 3)
+      assert(size.isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+  }
+
+  "addPersistedLocation" should {
+    "return dataframe and size" in {
+      val (df, size) = MetastorePersistenceTransient.addPersistedDataFrame("table_persist2", infoDate, exampleDf, tempDir)
+
+      assert(df.count() == 3)
+      assert(size.isDefined)
+      assert(size.exists(_ > 100))
+
+      MetastorePersistenceTransient.cleanup()
+    }
+  }
+
+  "getDataForTheDate" should {
+    "work for non-cached dataframes" in {
+      MetastorePersistenceTransient.addRawDataFrame("table_not_cached3", infoDate, exampleDf)
+
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_not_cached3", infoDate).isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+
+    "work for cached dataframes" in {
+      MetastorePersistenceTransient.addCachedDataframe("table_cached3", infoDate, exampleDf)
+
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_cached3", infoDate).isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+
+    "work for persisted dataframes" in {
+      MetastorePersistenceTransient.addPersistedDataFrame("table_persist3", infoDate, exampleDf, tempDir)
+
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_persist3", infoDate).isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+    }
+
+    "throw an exception if data not found" in {
+      MetastorePersistenceTransient.addCachedDataframe("table_cache", infoDate, exampleDf)
+
+      assertThrows[IllegalStateException] {
+        MetastorePersistenceTransient.getDataForTheDate("table_cache", infoDate.plusDays(1))
+      }
+
+      MetastorePersistenceTransient.cleanup()
+    }
+  }
+
+  "cleanup" should {
+    "remove all types of transient tables from the internal state" in {
+      MetastorePersistenceTransient.addRawDataFrame("table_not_cached4", infoDate, exampleDf)
+      MetastorePersistenceTransient.addCachedDataframe("table_cached4", infoDate, exampleDf)
+      MetastorePersistenceTransient.addPersistedDataFrame("table_persist4", infoDate, exampleDf, tempDir)
+
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_not_cached4", infoDate).isEmpty)
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_cached4", infoDate).isEmpty)
+      assert(!MetastorePersistenceTransient.getDataForTheDate("table_persist4", infoDate).isEmpty)
+
+      MetastorePersistenceTransient.cleanup()
+
+      assertThrows[IllegalStateException] {
+        MetastorePersistenceTransient.getDataForTheDate("table_not_cached4", infoDate)
+      }
+
+      assertThrows[IllegalStateException] {
+        MetastorePersistenceTransient.getDataForTheDate("table_cached4", infoDate)
+      }
+
+      assertThrows[IllegalStateException] {
+        MetastorePersistenceTransient.getDataForTheDate("table_persist4", infoDate)
+      }
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/TaskResultFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/TaskResultFactory.scala
@@ -28,12 +28,14 @@ object TaskResultFactory {
                          runStatus: RunStatus = RunStatus.Succeeded(Some(100), 200, Some(1000), TaskRunReason.New, Nil, Nil, Nil, Nil),
                          runInfo: Option[RunInfo] = Some(RunInfo(LocalDate.of(2022, 2, 18), Instant.ofEpochSecond(1234), Instant.ofEpochSecond(5678))),
                          applicationId: String = "app_123",
+                         isTransient: Boolean = false,
                          schemaDifferences: Seq[SchemaDifference] = Nil,
                          dependencyWarnings: Seq[DependencyWarning] = Nil): TaskResult = {
     TaskResult(job,
       runStatus,
       runInfo,
       applicationId,
+      isTransient,
       schemaDifferences,
       dependencyWarnings,
       Nil)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/bookkeeper/SyncBookkeeperMock.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/bookkeeper/SyncBookkeeperMock.scala
@@ -90,7 +90,8 @@ class SyncBookkeeperMock extends Bookkeeper {
                                                inputRecordCount: Long,
                                                outputRecordCount: Long,
                                                jobStarted: Long,
-                                               jobFinished: Long): Unit = {
+                                               jobFinished: Long,
+                                               isTableTransient: Boolean): Unit = {
     val dateStr = DataChunk.dateFormatter.format(infoDate)
     val dateBeginStr = DataChunk.dateFormatter.format(infoDateBegin)
     val dateEndStr = DataChunk.dateFormatter.format(infoDateEnd)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/runner/ConcurrentJobRunnerSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/runner/ConcurrentJobRunnerSpy.scala
@@ -74,7 +74,7 @@ class ConcurrentJobRunnerSpy(includeFails: Boolean = false,
         RunStatus.NoData(isNoDataFailure)
       }
 
-      val taskResult = TaskResult(job, status, Some(RunInfo(infoDate, started, finished)), "app_123", Nil, Nil, Nil)
+      val taskResult = TaskResult(job, status, Some(RunInfo(infoDate, started, finished)), "app_123", isTransient = false, Nil, Nil, Nil)
 
       completedJobsChannel.send((job, taskResult :: Nil, taskResult.runStatus.isInstanceOf[RunStatus.Succeeded] || taskResult.runStatus == RunStatus.NotRan))
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -99,7 +99,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
       "track already ran" in {
         val (bk, _, job) = getUseCase()
 
-        bk.setRecordCount("table1", infoDate, infoDate, infoDate, 3, 3, 123, 456)
+        bk.setRecordCount("table1", infoDate, infoDate, infoDate, 3, 3, 123, 456, isTableTransient = false)
 
         val result = job.preRunCheckJob(infoDate, conf, Nil)
 
@@ -110,7 +110,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
         "some records, default minimum records" in {
           val (bk, _, job) = getUseCase()
 
-          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456)
+          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456, isTableTransient = false)
 
           val result = job.preRunCheckJob(infoDate, conf, Nil)
 
@@ -120,7 +120,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
         "some records, custom minimum records" in {
           val (bk, _, job) = getUseCase(minRecords = Some(3))
 
-          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456)
+          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456, isTableTransient = false)
 
           val result = job.preRunCheckJob(infoDate, conf, Nil)
 
@@ -176,7 +176,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
         "needs update, some records, custom minimum records" in {
           val (bk, _, job) = getUseCase(minRecords = Some(4))
 
-          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456)
+          bk.setRecordCount("table1", infoDate, infoDate, infoDate, 100, 100, 123, 456, isTableTransient = false)
 
           val result = job.preRunCheckJob(infoDate, conf, Nil)
 
@@ -191,7 +191,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
 
         val noDataInfoDate = infoDate.plusDays(1)
 
-        bk.setRecordCount("table1", noDataInfoDate, noDataInfoDate, noDataInfoDate, 3, 3, 123, 456)
+        bk.setRecordCount("table1", noDataInfoDate, noDataInfoDate, noDataInfoDate, 3, 3, 123, 456, isTableTransient = false)
 
         val result = job.preRunCheckJob(noDataInfoDate, conf, Nil)
 
@@ -203,7 +203,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
 
         val noDataInfoDate = infoDate.plusDays(1)
 
-        bk.setRecordCount("table1", noDataInfoDate, noDataInfoDate, noDataInfoDate, 30, 30, 123, 456)
+        bk.setRecordCount("table1", noDataInfoDate, noDataInfoDate, noDataInfoDate, 30, 30, 123, 456, isTableTransient = false)
 
         val result = job.preRunCheckJob(noDataInfoDate, conf, Nil)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferJobSuite.scala
@@ -67,7 +67,7 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
     "return NeedsUpdate when the number of records do not match" in {
       val (job, bk) = getUseCase(numberOfRecords = 7)
 
-      bk.setRecordCount("table1->sink", infoDate, infoDate, infoDate, 3, 3, 10000, 1001)
+      bk.setRecordCount("table1->sink", infoDate, infoDate, infoDate, 3, 3, 10000, 1001, isTableTransient = false)
 
       val actual = job.preRunCheckJob(infoDate, conf, Nil)
 
@@ -77,7 +77,7 @@ class TransferJobSuite extends AnyWordSpec with SparkTestBase with TextCompariso
     "return AlreadyRan when the number of records didn't change" in {
       val (job, bk) = getUseCase(numberOfRecords = 7)
 
-      bk.setRecordCount("table1->sink", infoDate, infoDate, infoDate, 7, 3, 10000, 1001)
+      bk.setRecordCount("table1->sink", infoDate, infoDate, infoDate, 7, 3, 10000, 1001, isTableTransient = false)
 
       val actual = job.preRunCheckJob(infoDate, conf, Nil)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
@@ -136,7 +136,7 @@ class SourceValidationSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
 
     val state = new PipelineStateSpy
 
-    bookkeeper.setRecordCount("table_out", runDate.minusDays(1), runDate.minusDays(1), runDate.minusDays(1), 1, 1, 0, 0)
+    bookkeeper.setRecordCount("table_out", runDate.minusDays(1), runDate.minusDays(1), runDate.minusDays(1), 1, 1, 0, 0, isTableTransient = false)
 
     val sourceTable = SourceTableFactory.getDummySourceTable()
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperCommonSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperCommonSuite.scala
@@ -50,7 +50,7 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return a date when there is an entry" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table")
 
@@ -61,7 +61,7 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return None if the passed date is too old" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table", Some(infoDate1))
 
@@ -71,7 +71,7 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return a date when there is an entry and until date is passed" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table", Some(infoDate2))
 
@@ -82,9 +82,9 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return the latest date when there are several dates" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table")
 
@@ -103,9 +103,9 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return the latest date from the specified periods" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837, isTableTransient = false)
 
         val chunkOpt = bk.getLatestDataChunk("table", infoDate2, infoDate3)
         val infoDate3Str = infoDate3.format(DataChunk.dateFormatter)
@@ -132,9 +132,9 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "return entries if there are entries" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837)
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836, isTableTransient = false)
 
         val chunks = bk.getDataChunks("table", infoDate1, infoDate2).sortBy(_.infoDate)
 
@@ -153,8 +153,8 @@ class BookkeeperCommonSuite extends AnyWordSpec {
       "overwrite the previous entry" in {
         val bk = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839, isTableTransient = false)
 
         val chunks = bk.getDataChunks("table", infoDate1, infoDate1)
 
@@ -219,14 +219,14 @@ class BookkeeperCommonSuite extends AnyWordSpec {
         val bk2 = getBookkeeper()
         val bk3 = getBookkeeper()
 
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839, isTableTransient = false)
 
-        bk2.setRecordCount("table", infoDate2, infoDate2, infoDate2, 101, 10, 1597318833, 1597318837)
-        bk2.setRecordCount("table", infoDate3, infoDate3, infoDate3, 201, 20, 1597318838, 1597318839)
+        bk2.setRecordCount("table", infoDate2, infoDate2, infoDate2, 101, 10, 1597318833, 1597318837, isTableTransient = false)
+        bk2.setRecordCount("table", infoDate3, infoDate3, infoDate3, 201, 20, 1597318838, 1597318839, isTableTransient = false)
 
-        bk3.setRecordCount("table", infoDate3, infoDate3, infoDate3, 102, 10, 1597318833, 1597318837)
-        bk3.setRecordCount("table", infoDate2, infoDate2, infoDate2, 202, 20, 1597318838, 1597318839)
+        bk3.setRecordCount("table", infoDate3, infoDate3, infoDate3, 102, 10, 1597318833, 1597318837, isTableTransient = false)
+        bk3.setRecordCount("table", infoDate2, infoDate2, infoDate2, 202, 20, 1597318838, 1597318839, isTableTransient = false)
 
         val chunks = bk.getDataChunks("table", infoDate1, infoDate3).sortBy(_.infoDate)
         val chunks2 = bk2.getDataChunks("table", infoDate1, infoDate3).sortBy(_.infoDate)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperCommonSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperCommonSuite.scala
@@ -146,7 +146,26 @@ class BookkeeperCommonSuite extends AnyWordSpec {
         assert(chunk1.infoDate == "2020-08-11")
         assert(chunk2.infoDate == "2020-08-12")
       }
+    }
 
+    "getDataChunksCount()" should {
+      "return 0 if there are no entries" in {
+        val bk = getBookkeeper()
+
+        assert(bk.getDataChunksCount("table", Option(infoDate1), Option(infoDate1)) == 0)
+      }
+
+      "return the number of entries if there are entries" in {
+        val bk = getBookkeeper()
+
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836, isTableTransient = false)
+
+        val chunksCount = bk.getDataChunksCount("table", Option(infoDate1), Option(infoDate2))
+
+        assert(chunksCount == 2)
+      }
     }
 
     "setRecordCount()" should {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperMemSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperMemSuite.scala
@@ -43,7 +43,7 @@ class BookkeeperMemSuite extends AnyWordSpec with BeforeAndAfter {
       }
 
       "return a date when there is an entry" in {
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table")
 
@@ -52,9 +52,9 @@ class BookkeeperMemSuite extends AnyWordSpec with BeforeAndAfter {
       }
 
       "return the latest date when there are several dates" in {
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835, isTableTransient = false)
 
         val dateOpt = bk.getLatestProcessedDate("table")
 
@@ -69,9 +69,9 @@ class BookkeeperMemSuite extends AnyWordSpec with BeforeAndAfter {
       }
 
       "return the latest date from the specified periods" in {
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837, isTableTransient = false)
 
         val chunkOpt = bk.getLatestDataChunk("table", infoDate2, infoDate3)
         val infoDate3Str = infoDate3.format(DataChunk.dateFormatter)
@@ -94,9 +94,9 @@ class BookkeeperMemSuite extends AnyWordSpec with BeforeAndAfter {
       }
 
       "return entries if there are entries" in {
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837)
-        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835)
-        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318831, 1597318835, isTableTransient = false)
+        bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318832, 1597318836, isTableTransient = false)
 
         val chunks = bk.getDataChunks("table", infoDate1, infoDate2).sortBy(_.infoDate)
 
@@ -113,8 +113,8 @@ class BookkeeperMemSuite extends AnyWordSpec with BeforeAndAfter {
 
     "setRecordCount()" should {
       "overwrite the previous entry" in {
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837)
-        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 100, 10, 1597318833, 1597318837, isTableTransient = false)
+        bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 200, 20, 1597318838, 1597318839, isTableTransient = false)
 
         val chunks = bk.getDataChunks("table", infoDate1, infoDate1)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperNullSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperNullSuite.scala
@@ -17,7 +17,7 @@
 package za.co.absa.pramen.core.tests.bookkeeper
 
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, BookkeeperNull}
+import za.co.absa.pramen.core.bookkeeper.{BookkeeperBase, BookkeeperNull}
 
 import java.time.LocalDate
 
@@ -30,7 +30,7 @@ class BookkeeperNullSuite extends AnyWordSpec {
     "return nothing" in {
       val bk = getBookkeeper
 
-      val dateOpt = bk.getLatestProcessedDate("table", Some(infoDate2))
+      val dateOpt = bk.getLatestProcessedDateFromStorage("table", Some(infoDate2))
 
       assert(dateOpt.isEmpty)
     }
@@ -40,7 +40,7 @@ class BookkeeperNullSuite extends AnyWordSpec {
     "return nothing" in {
       val bk = getBookkeeper
 
-      val chunkOpt = bk.getLatestDataChunk("table", infoDate2, infoDate3)
+      val chunkOpt = bk.getLatestDataChunkFromStorage("table", infoDate2, infoDate3)
 
       assert(chunkOpt.isEmpty)
     }
@@ -50,7 +50,7 @@ class BookkeeperNullSuite extends AnyWordSpec {
     "return nothing" in {
       val bk = getBookkeeper
 
-      val chunks = bk.getDataChunks("table", infoDate1, infoDate2)
+      val chunks = bk.getDataChunksFromStorage("table", infoDate1, infoDate2)
 
       assert(chunks.isEmpty)
     }
@@ -59,9 +59,9 @@ class BookkeeperNullSuite extends AnyWordSpec {
   "setRecordCount()" should {
     "do nothing" in {
       val bk = getBookkeeper
-      bk.setRecordCount("table1", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+      bk.setRecordCount("table1", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = false)
 
-      val chunks = bk.getDataChunks("table", infoDate1, infoDate2)
+      val chunks = bk.getDataChunksFromStorage("table", infoDate1, infoDate2)
 
       assert(chunks.isEmpty)
     }
@@ -88,11 +88,11 @@ class BookkeeperNullSuite extends AnyWordSpec {
     }
   }
 
-  def getBookkeeper: Bookkeeper = {
+  def getBookkeeper: BookkeeperBase = {
     val bk = new BookkeeperNull
-    bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
-    bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835)
-    bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835)
+    bk.saveRecordCountToStorage("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835)
+    bk.saveRecordCountToStorage("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318835)
+    bk.saveRecordCountToStorage("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318835)
     bk
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperTextLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperTextLongSuite.scala
@@ -23,6 +23,8 @@ import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, BookkeeperText}
 import za.co.absa.pramen.core.fixtures.TempDirFixture
 import za.co.absa.pramen.core.utils.FsUtils
 
+import java.time.LocalDate
+
 class BookkeeperTextLongSuite extends BookkeeperCommonSuite with SparkTestBase with BeforeAndAfter with TempDirFixture {
 
   import za.co.absa.pramen.core.bookkeeper.BookkeeperText._
@@ -39,7 +41,7 @@ class BookkeeperTextLongSuite extends BookkeeperCommonSuite with SparkTestBase w
     deleteDir(tmpDir)
   }
 
-  def getBookkeeper: Bookkeeper = {
+  def getBookkeeper: BookkeeperText = {
     new BookkeeperText(tmpDir)
   }
 
@@ -56,4 +58,37 @@ class BookkeeperTextLongSuite extends BookkeeperCommonSuite with SparkTestBase w
     testBookKeeper(() => getBookkeeper)
   }
 
+  "getFilter" should {
+    "get a ranged filter" in {
+      val bk = getBookkeeper
+
+      val actual = bk.getFilter("table1", Some(LocalDate.of(2021, 1, 1)), Some(LocalDate.of(2021, 1, 2))).toString()
+
+      assert(actual == "(((tableName = table1) AND (infoDate >= 2021-01-01)) AND (infoDate <= 2021-01-02))")
+    }
+
+    "get a from filter" in {
+      val bk = getBookkeeper
+
+      val actual = bk.getFilter("table1", Some(LocalDate.of(2021, 1, 1)), None).toString()
+
+      assert(actual == "((tableName = table1) AND (infoDate >= 2021-01-01))")
+    }
+
+    "get a to filter" in {
+      val bk = getBookkeeper
+
+      val actual = bk.getFilter("table1", None, Some(LocalDate.of(2021, 1, 2))).toString()
+
+      assert(actual == "((tableName = table1) AND (infoDate <= 2021-01-02))")
+    }
+
+    "get a table filter" in {
+      val bk = getBookkeeper
+
+      val actual = bk.getFilter("table1", None, None).toString()
+
+      assert(actual == "(tableName = table1)")
+    }
+  }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperTransientSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperTransientSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.bookkeeper
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.bookkeeper.{BookkeeperBase, BookkeeperNull}
+
+import java.time.LocalDate
+
+class BookkeeperTransientSuite extends AnyWordSpec {
+  private val infoDate1 = LocalDate.of(2020, 8, 11)
+  private val infoDate2 = LocalDate.of(2020, 8, 12)
+  private val infoDate3 = LocalDate.of(2020, 8, 13)
+
+  "getLatestProcessedDate()" should {
+    "return information according to data available at the session" in {
+      val bk = getBookkeeper
+
+      val dateOpt = bk.getLatestProcessedDate("table", Some(infoDate2))
+
+      assert(dateOpt.isDefined)
+      assert(dateOpt.contains(infoDate2))
+    }
+
+    "return None if bookkeeping records not found" in {
+      val bk = getBookkeeper
+
+      val dateOpt = bk.getLatestProcessedDate("table", Some(infoDate1.minusDays(1)))
+
+      assert(dateOpt.isEmpty)
+    }
+  }
+
+  "getLatestDataChunk()" should {
+    "return information according to data available at the session" in {
+      val bk = getBookkeeper
+
+      val chunkOpt = bk.getLatestDataChunk("table", infoDate2, infoDate3)
+
+      assert(chunkOpt.isDefined)
+      assert(chunkOpt.get.infoDate == infoDate3.toString)
+    }
+  }
+
+  "getDataChunks()" should {
+    "return chunks from the current session" in {
+      val bk = getBookkeeper
+
+      val chunks = bk.getDataChunks("table", infoDate1, infoDate2)
+
+      assert(chunks.nonEmpty)
+      assert(chunks.length == 2)
+      assert(chunks.head.infoDate == infoDate2.toString)
+      assert(chunks(1).infoDate == infoDate1.toString)
+    }
+  }
+
+  "getDataChunksCount()" should {
+    "return the number of chunks from the current session" in {
+      val bk = getBookkeeper
+
+      val chunksCount = bk.getDataChunksCount("table", Option(infoDate1), Option(infoDate2))
+
+      assert(chunksCount == 2)
+    }
+  }
+
+  "setRecordCount()" should {
+    "return the newly added record" in {
+      val bk = getBookkeeper
+      bk.setRecordCount("table1", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = true)
+
+      val chunks = bk.getDataChunks("table1", infoDate2, infoDate2)
+
+      assert(chunks.length == 1)
+      assert(chunks.head.infoDate == infoDate2.toString)
+    }
+  }
+
+  def getBookkeeper: BookkeeperBase = {
+    val bk = new BookkeeperNull
+    bk.setRecordCount("table", infoDate2, infoDate2, infoDate2, 100, 10, 1597318830, 1597318835, isTableTransient = true)
+    bk.setRecordCount("table", infoDate3, infoDate3, infoDate3, 200, 20, 1597318830, 1597318836, isTableTransient = true)
+    bk.setRecordCount("table", infoDate1, infoDate1, infoDate1, 400, 40, 1597318830, 1597318837, isTableTransient = true)
+    bk
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
@@ -38,6 +38,7 @@ class TaskCompletedSuite extends AnyWordSpec {
         RunStatus.Succeeded(Some(1000), 2000, Some(3000), runReason, Nil, Nil, Nil, Nil),
         Some(RunInfo(infoDate, now.minusSeconds(10), now)),
         "app_123",
+        isTransient = false,
         Nil,
         Nil,
         Nil)
@@ -70,6 +71,7 @@ class TaskCompletedSuite extends AnyWordSpec {
         RunStatus.Failed(new IllegalStateException("Dummy Exception")),
         None,
         "app_123",
+        isTransient = false,
         Nil,
         Nil,
         Nil)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
@@ -187,7 +187,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
 
     val state = new PipelineStateSpy
 
-    bookkeeper.setRecordCount("table_out", runDate.minusDays(1), runDate.minusDays(1), runDate.minusDays(1), 1, 1, 0, 0)
+    bookkeeper.setRecordCount("table_out", runDate.minusDays(1), runDate.minusDays(1), runDate.minusDays(1), 1, 1, 0, 0, isTableTransient = false)
 
     val stats = MetaTableStats(2, Some(100))
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/ConversionTransformerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/ConversionTransformerSuite.scala
@@ -50,13 +50,13 @@ class ConversionTransformerSuite extends AnyWordSpec with SparkTestBase with Tem
       }
     }
 
-    "return NotReady when there is no data" in {
+    "return SkipOnce when there is no data" in {
       withTempDirectory("comparison_transformer") { tempDir =>
         val (transformer, metastoreReader) = getUseCase(tempDir)
 
         val result = transformer.validate(metastoreReader, infoDateWithEmptyDf, conversionOptions)
 
-        assert(result.isInstanceOf[Reason.NotReady])
+        assert(result.isInstanceOf[Reason.SkipOnce])
       }
     }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/IdentityTransformerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/IdentityTransformerSuite.scala
@@ -59,12 +59,12 @@ class IdentityTransformerSuite extends AnyWordSpec with SparkTestBase with TextC
       assert(outcome == Reason.Ready)
     }
 
-    "return not ready when empty is not allowed" in {
+    "return SkipOnce when empty is not allowed" in {
       val (transformer, metastore) = getUseCase
 
       val outcome = transformer.validate(metastore, infoDateWithEmptyDf, Map("table" -> "table1", "empty.allowed" -> "false"))
 
-      assert(outcome.isInstanceOf[Reason.NotReady])
+      assert(outcome.isInstanceOf[Reason.SkipOnce])
     }
 
     "fail when the mandatory option is absent" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/IdentityTransformerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/transformers/IdentityTransformerSuite.scala
@@ -38,6 +38,14 @@ class IdentityTransformerSuite extends AnyWordSpec with SparkTestBase with TextC
     "pass when the mandatory option is present" in {
       val (transformer, metastore) = getUseCase
 
+      val outcome = transformer.validate(metastore, infoDateWithData, Map("input.table" -> "table1"))
+
+      assert(outcome == Reason.Ready)
+    }
+
+    "pass when the legacy mandatory option is present" in {
+      val (transformer, metastore) = getUseCase
+
       val outcome = transformer.validate(metastore, infoDateWithData, Map("table" -> "table1"))
 
       assert(outcome == Reason.Ready)
@@ -66,7 +74,7 @@ class IdentityTransformerSuite extends AnyWordSpec with SparkTestBase with TextC
         transformer.validate(metastore, infoDateWithData, Map.empty)
       }
 
-      assert(ex.getMessage.contains("Option 'table' is not defined"))
+      assert(ex.getMessage.contains("Option 'input.table' is not defined"))
     }
   }
 

--- a/pramen/version.sbt
+++ b/pramen/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.5.3-SNAPSHOT"
+ThisBuild / version := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
Transient tables are not persisted, so you can chain multiple transformers together without saving all of them to a storage. This allows more flexibility to separate logical structure of the pipeline while maintaining reasonable storage costs.

```hocon
pramen.metastore {
  tables = [
    {
      name = "CSV_TEST_converted"
      format = "transient"
      cache.policy = "no_cache"
    },
    # ...
  ]
}
```

![Screenshot 2023-09-12 at 8 53 39](https://github.com/AbsaOSS/pramen/assets/4082463/67c2a47d-8646-482b-b73e-33e7aa84d8ec)
