### PR TITLE
#258 Make Spark Application name configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,6 +1296,11 @@ pramen {
   environment.name = "MyEnv/UAT"
   pipeline.name = "My Data Pipeline"
 
+  # Optionally, you can set the Spark Application name. Otherwise the default name will be used.
+  # This does not work when using Yarn in cluster deploy mode. In this case you need to set Spark application name
+  # via the spark-xubmit command line.
+  spark.app.name = "Pramen - "${pramen.pipeline.name}
+
   # The number of tasks to run in parallel. A task is a source, transformer, or sink running for a specified information date.
   # This feature is experimental, use more than 1 with caution. 
   parallel.tasks = 1

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/PipelineSparkSessionBuilder.scala
@@ -26,6 +26,8 @@ import za.co.absa.pramen.core.utils.ConfigUtils
 object PipelineSparkSessionBuilder {
   private val log = LoggerFactory.getLogger(this.getClass)
 
+  val SPARK_APP_NAME_KEY = "pramen.spark.app.name"
+
   /**
     * Builds a SparkSession for the pipeline from configuration.
     * The name of the Spark Application will be according to 'pramen.ingestion.name'
@@ -95,12 +97,15 @@ object PipelineSparkSessionBuilder {
     spark
   }
 
-  private def getSparkAppName(conf: Config): String = {
-    val ingestionSuffix = if (conf.hasPath(PIPELINE_NAME_KEY)) {
-      s" - ${conf.getString(PIPELINE_NAME_KEY)}"
+  private[core] def getSparkAppName(conf: Config): String = {
+    if (conf.hasPath(SPARK_APP_NAME_KEY)) {
+      conf.getString(SPARK_APP_NAME_KEY)
     } else {
-      ""
+      if (conf.hasPath(PIPELINE_NAME_KEY)) {
+        s"Pramen - ${conf.getString(PIPELINE_NAME_KEY)}"
+      } else {
+        "Pramen"
+      }
     }
-    s"Pramen$ingestionSuffix"
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/PipelineSparkSessionBuilderSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/PipelineSparkSessionBuilderSuite.scala
@@ -75,4 +75,44 @@ class PipelineSparkSessionBuilderSuite extends AnyWordSpec {
       assert(key2Set)
     }
   }
+
+  "getSparkAppName" should {
+    "use the name configured when available" in {
+      val conf = ConfigFactory.parseString("""pramen.spark.app.name = "My App"""")
+
+      val appName = PipelineSparkSessionBuilder.getSparkAppName(conf)
+
+      assert(appName == "My App")
+    }
+
+    "allow substitutions in spark app name" in {
+      val conf = ConfigFactory.parseString(
+        """pramen {
+          |  pipeline.name = "Data sourcing"
+          |  spark.app.name = "My App - "${pramen.pipeline.name}
+          |}
+          |""".stripMargin
+      ).resolve()
+
+      val appName = PipelineSparkSessionBuilder.getSparkAppName(conf)
+
+      assert(appName == "My App - Data sourcing")
+    }
+
+    "use pipeline name when configured" in {
+      val conf = ConfigFactory.parseString("""pramen.pipeline.name = "Data sourcing"""")
+
+      val appName = PipelineSparkSessionBuilder.getSparkAppName(conf)
+
+      assert(appName == "Pramen - Data sourcing")
+    }
+
+    "use the default name when not configured" in {
+      val conf = ConfigFactory.empty()
+
+      val appName = PipelineSparkSessionBuilder.getSparkAppName(conf)
+
+      assert(appName == "Pramen")
+    }
+  }
 }


### PR DESCRIPTION
## Example
```hocon
pramen.spark.app.name = "My app - "${pramen.pipeline.name}" on "${praman.environment.name}
```