### PR TITLE
Add maximumLength field metadata for JDBC 'varchar' fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,12 @@ is determined by the pipeline configuration.
       # https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
     }
 
+    # If enabled, additional metadata will be added to the Spark schema
+    # Currently, it includes 'maxLength' for VARCHAR(n) fields.
+    # This is turned off by default because it requires connecting to the database one more time, which slows
+    # the ingestion a little.
+    enable.schema.metadata = false
+
     # Convert decimals with no scale to integers and longs, fix 'NUMBER' SQL to Spark mapping. 
     correct.decimals.in.schema = true
     

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/BookkeepingRecords.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/BookkeepingRecords.scala
@@ -20,7 +20,7 @@ import slick.jdbc.H2Profile.api._
 import slick.lifted.TableQuery
 
 class BookkeepingRecords(tag: Tag) extends Table[BookkeepingRecord](tag, "bookkeeping") {
-  def pramenTableName = column[String]("watcher_table_name", O.Length(100))
+  def pramenTableName = column[String]("watcher_table_name", O.Length(128))
   def infoDate = column[String]("info_date", O.Length(20))
   def infoDateBegin = column[String]("info_date_begin", O.Length(20))
   def infoDateEnd = column[String]("info_date_end", O.Length(20))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/MetadataRecords.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/MetadataRecords.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.bookkeeper.model
 import slick.jdbc.H2Profile.api._
 
 class MetadataRecords(tag: Tag) extends Table[MetadataRecord](tag, "metadata") {
-  def pramenTableName = column[String]("table_name", O.Length(100))
+  def pramenTableName = column[String]("table_name", O.Length(128))
   def infoDate = column[String]("info_date", O.Length(20))
   def key = column[String]("key", O.Length(255))
   def value = column[String]("value")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/SchemaRecords.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/SchemaRecords.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.bookkeeper.model
 import slick.jdbc.H2Profile.api._
 
 class SchemaRecords(tag: Tag) extends Table[SchemaRecord](tag, "schemas") {
-  def pramenTableName = column[String]("watcher_table_name", O.Length(100))
+  def pramenTableName = column[String]("watcher_table_name", O.Length(128))
   def infoDate = column[String]("info_date", O.Length(20))
   def schemaJson = column[String]("schema_json")
   def * = (pramenTableName, infoDate, schemaJson) <> (SchemaRecord.tupled, SchemaRecord.unapply)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/journal/model/JournalTasks.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/journal/model/JournalTasks.scala
@@ -21,7 +21,7 @@ import slick.lifted.TableQuery
 
 class JournalTasks(tag: Tag) extends Table[JournalTask](tag, "journal") {
   def jobName = column[String]("job_name", O.Length(200))
-  def pramenTableName = column[String]("watcher_table_name", O.Length(100))
+  def pramenTableName = column[String]("watcher_table_name", O.Length(128))
   def periodBegin = column[String]("period_begin", O.Length(20))
   def periodEnd = column[String]("period_end", O.Length(20))
   def informationDate = column[String]("information_date", O.Length(20))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -167,7 +167,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
     }
 
     if (isDataQuery && jdbcReaderConfig.enableSchemaMetadata) {
-      JdbcSparkUtils.withJdbcMetadata(jdbcReaderConfig.jdbcConfig, qry) { jdbcMetadata =>
+      JdbcSparkUtils.withJdbcMetadata(jdbcReaderConfig.jdbcConfig, sql) { jdbcMetadata =>
         val newSchema = JdbcSparkUtils.addMetadataFromJdbc(df.schema, jdbcMetadata)
         df = spark.createDataFrame(df.rdd, newSchema)
       }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -27,12 +27,11 @@ import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils, JdbcSparkUtil
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate}
 
-class TableReaderJdbcNative(jdbcConfig: JdbcConfig)
+class TableReaderJdbcNative(jdbcConfig: JdbcConfig,
+                            jdbcUrlSelector: JdbcUrlSelector)
                            (implicit spark: SparkSession) extends TableReader {
 
   private val log = LoggerFactory.getLogger(this.getClass)
-
-  private val jdbcUrlSelector = JdbcUrlSelector(jdbcConfig)
 
   private val url = jdbcUrlSelector.getWorkingUrl(jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls))
 
@@ -97,7 +96,8 @@ object TableReaderJdbcNative {
             parent: String = "")
            (implicit spark: SparkSession): TableReaderJdbcNative = {
     val jdbcConfig = JdbcConfig.load(conf, parent)
+    val urlSelector = JdbcUrlSelector(jdbcConfig)
 
-    new TableReaderJdbcNative(jdbcConfig)
+    new TableReaderJdbcNative(jdbcConfig, urlSelector)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
@@ -53,7 +53,7 @@ class JdbcSource(sourceConfig: Config,
         new TableReaderJdbc(jdbcReaderConfig, sourceConfig)
       case Query.Sql(sql)       =>
         log.info(s"Using TableReaderJdbcNative to read the query: $sql")
-        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig)
+        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig, jdbcReaderConfig.enableSchemaMetadata)
       case q          =>
         throw new IllegalArgumentException(s"Unexpected '${q.name}' spec for the JDBC reader. Only 'table' or 'sql' are supported. Config path: $sourceConfigParentPath")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
@@ -46,14 +46,14 @@ class JdbcSource(sourceConfig: Config,
     SourceResult(df)
   }
 
-  private def getReader(query: Query): TableReader = {
+  private[core] def getReader(query: Query): TableReader = {
     query match {
       case Query.Table(dbTable) =>
         log.info(s"Using TableReaderJdbc to read the table: $dbTable")
         new TableReaderJdbc(jdbcReaderConfig, sourceConfig)
       case Query.Sql(sql)       =>
         log.info(s"Using TableReaderJdbcNative to read the query: $sql")
-        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig, jdbcReaderConfig.enableSchemaMetadata)
+        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig)
       case q          =>
         throw new IllegalArgumentException(s"Unexpected '${q.name}' spec for the JDBC reader. Only 'table' or 'sql' are supported. Config path: $sourceConfigParentPath")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -48,7 +48,7 @@ object JdbcNativeUtils {
   final val JDBC_WORDS_TO_REDACT = Set("password", "secret", "pwd", "token")
 
   /** Returns a JDBC URL and connection by a config. */
-  def getConnection(jdbcConfig: JdbcConfig, retries: Option[Int] = None): (String, Connection) = {
+  def getConnection(jdbcConfig: JdbcConfig): (String, Connection) = {
     val urlSelector = JdbcUrlSelector(jdbcConfig)
 
     def getConnectionWithRetries(jdbcConfig: JdbcConfig, retriesLeft: Int): (String, Connection) = {
@@ -66,7 +66,7 @@ object JdbcNativeUtils {
       }
     }
 
-    retries match {
+    jdbcConfig.retries match {
       case Some(n) => getConnectionWithRetries(jdbcConfig, n)
       case None    => getConnectionWithRetries(jdbcConfig, urlSelector.getNumberOfUrls - 1)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -88,8 +88,10 @@ object JdbcNativeUtils {
                             (implicit spark: SparkSession): DataFrame = {
 
     // Executing the query
-    val driverIterator = new ResultSetToRowIterator(getResultSet(jdbcConfig, url, query))
-    val schema = driverIterator.getSchema
+    val rs = getResultSet(jdbcConfig, url, query)
+    val driverIterator = new ResultSetToRowIterator(rs)
+    val schema = JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
+
     driverIterator.close()
 
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DateType, DecimalType, MetadataBuilder, StringType, StructType, TimestampType}
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.core.reader.model.JdbcConfig
+import za.co.absa.pramen.core.utils.SparkUtils.MAX_LENGTH_METADATA_KEY
+import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
+
+import java.sql.{Connection, ResultSet, ResultSetMetaData}
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+object JdbcSparkUtils {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  val MAXIMUM_VARCHAR_LENGTH = 8192
+
+  def addMetadataFromJdbc(schema: StructType, jdbcMetadata: ResultSetMetaData): StructType = {
+    val fieldToMetadataMap: Map[String, JdbcFieldMetadata] =
+      {
+        for (index <- Range.inclusive(1, jdbcMetadata.getColumnCount))
+          yield {
+            val fieldMetadata = getFieldMetadata(jdbcMetadata, index)
+            val name = fieldMetadata.name.toLowerCase
+            name -> fieldMetadata
+          }
+      }.toMap
+
+    StructType(
+      schema.fields.map {
+        field =>
+          val fieldNameLowerCase = field.name.toLowerCase
+          field.dataType match {
+            case StringType if fieldToMetadataMap.contains(fieldNameLowerCase) =>
+              val jdbcMetadata = fieldToMetadataMap(fieldNameLowerCase)
+              val maxLength = Math.max(jdbcMetadata.displaySize, jdbcMetadata.precision)
+              if (maxLength > 0 && maxLength < MAXIMUM_VARCHAR_LENGTH) {
+                val metadata = new MetadataBuilder
+                metadata.withMetadata(field.metadata)
+                metadata.putLong(MAX_LENGTH_METADATA_KEY, maxLength)
+                field.copy(metadata = metadata.build())
+              } else {
+                field
+              }
+            case _ =>
+              field
+          }
+      }
+    )
+  }
+
+  def withJdbcMetadata(jdbcConfig: JdbcConfig,
+                       nativeQuery: String)
+                      (action: ResultSetMetaData => Unit): Unit = {
+    val (url, connection) = JdbcNativeUtils.getConnection(jdbcConfig)
+
+    log.info(s"Successfully connected to JDBC URL: $url")
+
+    try {
+      withResultSet(connection, nativeQuery) { rs =>
+        action(rs.getMetaData)
+      }
+    } finally {
+      connection.close()
+    }
+  }
+
+  def withResultSet(connection: Connection,
+                           query: String)
+                           (action: ResultSet => Unit): Unit = {
+    val statement = try {
+      connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)
+    } catch {
+      case _: java.sql.SQLException =>
+        // Fallback with more permissible result type.
+        // JDBC sources should automatically downgrade result type, but Denodo driver doesn't do that.
+        connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+      case NonFatal(ex) =>
+        throw ex
+    }
+
+    try {
+      val resultSet = statement.executeQuery(query)
+      try {
+        action(resultSet)
+      } finally {
+        resultSet.close()
+      }
+    } finally {
+      statement.close()
+    }
+  }
+
+  def convertTimestampToDates(df: DataFrame): DataFrame = {
+    val dateColumns = new ListBuffer[String]
+
+    val newFields = df.schema.fields.map(fld => {
+      fld.dataType match {
+        case TimestampType =>
+          dateColumns += fld.name
+          col(fld.name).cast(DateType).as(fld.name)
+        case _ =>
+          col(fld.name)
+      }
+    })
+
+    if (dateColumns.nonEmpty) {
+      log.info(s"The following fields have been converted to Date: ${dateColumns.mkString(", ")}")
+      df.select(newFields: _*)
+    } else {
+      log.debug("No timestamp fields found in the dataset.")
+      df
+    }
+  }
+
+  def getCorrectedDecimalsSchema(df: DataFrame, fixPrecision: Boolean): Option[String] = {
+    val newSchema = new ListBuffer[String]
+
+    df.schema.fields.foreach(field => {
+      field.dataType match {
+        case t: DecimalType if t.scale == 0 && t.precision <= 9 =>
+          log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to int")
+          newSchema += s"${field.name} integer"
+        case t: DecimalType if t.scale == 0 && t.precision <= 18 =>
+          log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to long")
+          newSchema += s"${field.name} long"
+        case t: DecimalType if t.scale >= 18 =>
+          log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal(38, 18)")
+          newSchema += s"${field.name} decimal(38, 18)"
+        case t: DecimalType if fixPrecision && t.scale > 0 =>
+          val fixedPrecision = if (t.precision + t.scale > 38) 38 else t.precision + t.scale
+          log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal($fixedPrecision, ${t.scale})")
+          newSchema += s"${field.name} decimal($fixedPrecision, ${t.scale})"
+        case _ =>
+          field
+      }
+    })
+
+    if (newSchema.nonEmpty) {
+      val customSchema = newSchema.mkString(", ")
+      log.info(s"Custom schema: $customSchema")
+      Some(customSchema)
+    } else {
+      None
+    }
+  }
+
+  def getFieldMetadata(jdbcMetadata: ResultSetMetaData, fieldIndex: Int): JdbcFieldMetadata = {
+    val name = jdbcMetadata.getColumnName(fieldIndex).trim
+    val label = jdbcMetadata.getColumnLabel(fieldIndex).trim
+    val sqlType = jdbcMetadata.getColumnType(fieldIndex)
+    val sqlTypeName = jdbcMetadata.getColumnTypeName(fieldIndex)
+    val displaySize = jdbcMetadata.getColumnDisplaySize(fieldIndex)
+    val precision = jdbcMetadata.getPrecision(fieldIndex)
+    val scale = jdbcMetadata.getScale(fieldIndex)
+    val nullable = jdbcMetadata.isNullable(fieldIndex) != ResultSetMetaData.columnNoNulls
+
+    val effectiveName = if (name.isEmpty) label else name
+
+    JdbcFieldMetadata(effectiveName, label, sqlType, sqlTypeName, displaySize, precision, scale, nullable)
+  }
+
+  def getJdbcOptions(url: String,
+                     jdbcConfig: JdbcConfig,
+                     nativeQuery: String,
+                     extraSparkOptions: Map[String, String] = Map.empty): Map[String, String] = {
+    def getOptions(optionName: String, optionValue: Option[Any]): Map[String, String] = {
+      optionValue match {
+        case Some(value) =>
+          Map[String, String](optionName -> value.toString)
+        case None =>
+          Map[String, String]()
+      }
+    }
+
+    val databaseOptions = getOptions("database", jdbcConfig.database)
+    val userOptions = getOptions("user", jdbcConfig.user)
+    val passwordOptions = getOptions("password", jdbcConfig.password)
+
+    Map[String, String](
+      "url" -> url,
+      "driver" -> jdbcConfig.driver,
+      "dbtable" -> nativeQuery
+    ) ++
+      userOptions ++
+      passwordOptions ++
+      databaseOptions ++
+      jdbcConfig.extraOptions ++
+      extraSparkOptions
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/JdbcFieldMetadata.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/JdbcFieldMetadata.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.impl
+
+case class JdbcFieldMetadata(
+                              name: String,
+                              label: String,
+                              sqlType: Int,
+                              sqlTypeName: String,
+                              displaySize: Int,
+                              precision: Int,
+                              scale: Int,
+                              nullable: Boolean
+                            )

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/RelationalDbFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/RelationalDbFixture.scala
@@ -55,6 +55,26 @@ trait RelationalDbFixture extends BeforeAndAfterAll {
     while(rs.next()) {
       tables += rs.getString(1)
     }
+    rs.close()
+    st.close()
+    conn.close()
     tables.toSeq
+  }
+
+  def withQuery(sql: String)(action: ResultSet => Unit): Unit = {
+    val conn = getConnection
+    val st: Statement = conn.createStatement()
+
+    try {
+      val rs: ResultSet = st.executeQuery(sql)
+      try {
+        action(rs)
+      } finally {
+        rs.close()
+      }
+    } finally {
+      st.close()
+      conn.close()
+    }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -253,9 +253,10 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
       assert(df.count() == 3)
       assert(df.schema.fields.head.name == "ID")
       assert(df.schema.fields(1).name == "NAME")
-      assert(df.schema.fields(2).name == "EMAIL")
-      assert(df.schema.fields(3).name == "FOUNDED")
-      assert(df.schema.fields(4).name == "LAST_UPDATED")
+      assert(df.schema.fields(2).name == "DESCRIPTION")
+      assert(df.schema.fields(3).name == "EMAIL")
+      assert(df.schema.fields(4).name == "FOUNDED")
+      assert(df.schema.fields(5).name == "LAST_UPDATED")
     }
 
     "throw an exception on read failure" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/samples/RdbExampleTable.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/samples/RdbExampleTable.scala
@@ -55,6 +55,7 @@ object RdbExampleTable {
          |CREATE TABLE $tableName (
          |  id INT NOT NULL,
          |  name VARCHAR(50) NOT NULL,
+         |  description VARCHAR NOT NULL,
          |  email VARCHAR(50) NOT NULL,
          |  founded DATE NOT NULL,
          |  last_updated TIMESTAMP NOT NULL,
@@ -63,9 +64,9 @@ object RdbExampleTable {
          |""".stripMargin
 
     val inserts: Seq[String] = Seq(
-      s"INSERT INTO $tableName VALUES (1,'Company1', 'company1@example.com', DATE '2000-10-11', TIMESTAMP '2020-11-04 10:11:00+02:00', '2022-02-18')",
-      s"INSERT INTO $tableName VALUES (2,'Company2', 'company2@example.com', DATE '2005-03-29', TIMESTAMP '2020-11-04 10:22:33+02:00', '2022-02-18')",
-      s"INSERT INTO $tableName VALUES (3,'Company3', 'company3@example.com', DATE '2016-12-30', TIMESTAMP '2020-11-04 10:33:59+02:00', '2022-02-18')"
+      s"INSERT INTO $tableName VALUES (1,'Company1', 'description1', 'company1@example.com', DATE '2000-10-11', TIMESTAMP '2020-11-04 10:11:00+02:00', '2022-02-18')",
+      s"INSERT INTO $tableName VALUES (2,'Company2', 'description2', 'company2@example.com', DATE '2005-03-29', TIMESTAMP '2020-11-04 10:22:33+02:00', '2022-02-18')",
+      s"INSERT INTO $tableName VALUES (3,'Company3', 'description3', 'company3@example.com', DATE '2016-12-30', TIMESTAMP '2020-11-04 10:33:59+02:00', '2022-02-18')"
     )
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/JdbcSourceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/JdbcSourceSuite.scala
@@ -32,13 +32,11 @@ class JdbcSourceSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestB
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
     RdbExampleTable.Company.initTable(getConnection)
   }
 
   override protected def afterAll(): Unit = {
     RdbExampleTable.Company.dropTable(getConnection)
-
     super.afterAll()
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -17,30 +17,46 @@
 package za.co.absa.pramen.core.tests.reader
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
-import za.co.absa.pramen.core.reader.TableReaderJdbc
-import za.co.absa.pramen.core.sql.SqlGeneratorOracle
+import za.co.absa.pramen.core.fixtures.RelationalDbFixture
+import za.co.absa.pramen.core.reader.{JdbcUrlSelector, TableReaderJdbc}
+import za.co.absa.pramen.core.samples.RdbExampleTable
+import za.co.absa.pramen.core.sql.SqlGeneratorHsqlDb
+import org.mockito.Mockito.{mock, when => whenMock}
+import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
+import za.co.absa.pramen.core.utils.SparkUtils.MAX_LENGTH_METADATA_KEY
 
-class TableReaderJdbcSuite extends AnyWordSpec with SparkTestBase {
+class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with RelationalDbFixture {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    RdbExampleTable.Company.initTable(getConnection)
+  }
+
+  override protected def afterAll(): Unit = {
+    RdbExampleTable.Company.dropTable(getConnection)
+    super.afterAll()
+  }
+
   "TableReaderJdbc" should {
     val conf = ConfigFactory.parseString(
-      """reader {
-        |  jdbc {
-        |    driver = "oracle.jdbc.OracleDriver"
-        |    connection.string = "url"
-        |    user = "user"
-        |    password = "password"
-        |  }
-        |
-        |  has.information.date.column = true
-        |
-        |  information.date.column = "INFO_DATE"
-        |  information.date.type = "number"
-        |  information.date.app.format = "yyyy-MM-DD"
-        |  information.date.sql.format = "YYYY-mm-DD"
-        |
-        |}""".stripMargin)
+      s"""reader {
+         |  jdbc {
+         |    driver = "$driver"
+         |    connection.string = "$url"
+         |    user = "$user"
+         |    password = "$password"
+         |  }
+         |
+         |  has.information.date.column = false
+         |
+         |  information.date.column = "INFO_DATE"
+         |  information.date.type = "number"
+         |  information.date.app.format = "yyyy-MM-DD"
+         |  information.date.sql.format = "YYYY-mm-DD"
+         |
+         |}""".stripMargin)
 
     "be able to be constructed properly from config" in {
       val reader = TableReaderJdbc(conf.getConfig("reader"), "reader")
@@ -48,22 +64,22 @@ class TableReaderJdbcSuite extends AnyWordSpec with SparkTestBase {
       val jdbc = reader.getJdbcConfig
 
       assert(jdbc.jdbcConfig.database.isEmpty)
-      assert(jdbc.jdbcConfig.driver == "oracle.jdbc.OracleDriver")
-      assert(jdbc.jdbcConfig.primaryUrl.get == "url")
-      assert(jdbc.jdbcConfig.user.contains("user"))
-      assert(jdbc.jdbcConfig.password.contains("password"))
+      assert(jdbc.jdbcConfig.driver == driver)
+      assert(jdbc.jdbcConfig.primaryUrl.get == url)
+      assert(jdbc.jdbcConfig.user.contains(user))
+      assert(jdbc.jdbcConfig.password.contains(password))
       assert(jdbc.infoDateColumn == "INFO_DATE")
       assert(jdbc.infoDateType == "number")
       assert(jdbc.infoDateFormatApp == "yyyy-MM-DD")
       assert(jdbc.infoDateFormatSql == "YYYY-mm-DD")
-      assert(jdbc.hasInfoDate)
+      assert(!jdbc.hasInfoDate)
       assert(!jdbc.saveTimestampsAsDates)
     }
 
     "ensure sql query generator is properly selected" in {
       val reader = TableReaderJdbc(conf.getConfig("reader"), "reader")
 
-      assert(reader.sqlGen.isInstanceOf[SqlGeneratorOracle])
+      assert(reader.sqlGen.isInstanceOf[SqlGeneratorHsqlDb])
     }
 
     "ensure jdbc config properties are passed correctly" in {
@@ -78,6 +94,70 @@ class TableReaderJdbcSuite extends AnyWordSpec with SparkTestBase {
       assert(jdbc.correctDecimalsInSchema)
     }
 
-  }
+    "getTableName" should {
 
+    }
+
+    "getWithRetry" should {
+      "return the successful dataframe on the second try" in {
+        val readerConfig = conf.getConfig("reader")
+        val jdbcTableReaderConfig = TableReaderJdbcConfig.load(readerConfig, "reader")
+
+        val urlSelector = mock(classOf[JdbcUrlSelector])
+
+        whenMock(urlSelector.getUrl)
+          .thenThrow(new RuntimeException("dummy"))
+          .thenReturn(url)
+
+        val reader = new TableReaderJdbc(jdbcTableReaderConfig, urlSelector, readerConfig)
+
+        reader.getWithRetry("company", isDataQuery = true, 2) { df =>
+          assert(!df.isEmpty)
+        }
+      }
+
+      "pass the exception when out of retries" in {
+        val readerConfig = conf.getConfig("reader")
+        val jdbcTableReaderConfig = TableReaderJdbcConfig.load(readerConfig, "reader")
+
+        val urlSelector = mock(classOf[JdbcUrlSelector])
+
+        whenMock(urlSelector.getUrl)
+          .thenThrow(new RuntimeException("dummy"))
+          .thenThrow(new RuntimeException("dummy"))
+          .thenReturn(url)
+
+        val reader = new TableReaderJdbc(jdbcTableReaderConfig, urlSelector, readerConfig)
+
+        val ex = intercept[RuntimeException] {
+          reader.getWithRetry("company", isDataQuery = true, 2) { _ => }
+        }
+
+        assert(ex.getMessage.contains("dummy"))
+      }
+    }
+
+    "getDataFrame" should {
+      "support varchar metadata when enabled" in {
+        val readerConfig = conf.getConfig("reader")
+          .withValue("reader.save.timestamps.as.dates", ConfigValueFactory.fromAnyRef(true))
+          .withValue("reader.correct.decimals.in.schema", ConfigValueFactory.fromAnyRef(true))
+          .withValue("enable.schema.metadata", ConfigValueFactory.fromAnyRef(true))
+
+        val jdbcTableReaderConfig = TableReaderJdbcConfig.load(readerConfig, "reader")
+        val urlSelector = JdbcUrlSelector(jdbcTableReaderConfig.jdbcConfig)
+
+        val reader = new TableReaderJdbc(jdbcTableReaderConfig, urlSelector, readerConfig)
+
+        val df = reader.getDataFrame("SELECT * FROM company", isDataQuery = true)
+
+        // NAME VARCHAR(50)
+        assert(df.schema.fields(1).name == "NAME")
+        assert(df.schema.fields(1).metadata.getLong(MAX_LENGTH_METADATA_KEY) == 50L)
+        // DESCRIPTION VARCHAR
+        assert(df.schema.fields(2).name == "DESCRIPTION")
+        assert(!df.schema.fields(2).metadata.contains(MAX_LENGTH_METADATA_KEY))
+      }
+    }
+  }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -351,7 +351,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("company", Nil, None) == "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company")
+      assert(gen.getDataQuery("company", Nil, None) == "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company")
     }
 
     "generate data queries when list of columns is specified" in {
@@ -359,7 +359,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("company", Nil, Some(100)) == "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company LIMIT 100")
+      assert(gen.getDataQuery("company", Nil, Some(100)) == "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company LIMIT 100")
     }
 
     "generate ranged count queries" when {
@@ -388,30 +388,30 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged data queries" when {
       "date is in DATE format" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17'")
         assert(gen.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
         assert(genStr.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = '2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = '2020-08-17'")
         assert(genStr.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
         assert(genNum.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = 20200817")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = 20200817")
         assert(genNum.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= 20200817 AND D <= 20200830")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17' LIMIT 100")
         assert(gen.getDataQuery("company", date1, date2, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
@@ -114,6 +114,11 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
           |    "nullable" : true,
           |    "metadata" : { }
           |  }, {
+          |    "name" : "DESCRIPTION",
+          |    "type" : "string",
+          |    "nullable" : true,
+          |    "metadata" : { }
+          |  }, {
           |    "name" : "EMAIL",
           |    "type" : "string",
           |    "nullable" : true,

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.utils
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.RelationalDbFixture
+import za.co.absa.pramen.core.reader.model.JdbcConfig
+import za.co.absa.pramen.core.samples.RdbExampleTable
+import za.co.absa.pramen.core.utils.JdbcSparkUtils
+import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
+
+class JdbcSparkUtilsSuite extends AnyWordSpec with SparkTestBase with RelationalDbFixture with BeforeAndAfterAll {
+  val jdbcConfig: JdbcConfig = JdbcConfig(driver, Some(url), Nil, None, Some(user), Some(password))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    RdbExampleTable.Company.initTable(getConnection)
+  }
+
+  "addMetadataFromJdbc" should {
+
+  }
+
+  "withJdbcMetadata" should {
+
+  }
+
+  "withResultSet" should {
+
+  }
+
+  "convertTimestampToDates" should {
+
+  }
+
+  "getCorrectedDecimalsSchema" should {
+
+  }
+
+  "getFieldMetadata" should {
+    "convert sized varchar to the internal model" in {
+      val expectedVarcharN = JdbcFieldMetadata(
+        name = "NAME",
+        label = "NAME",
+        sqlType = java.sql.Types.VARCHAR,
+        sqlTypeName = "VARCHAR",
+        displaySize = 50,
+        precision = 50,
+        scale = 0,
+        nullable = false
+      )
+
+      withQuery("SELECT name FROM COMPANY WHERE 0=1") { rs =>
+        val actualVarcharN = JdbcSparkUtils.getFieldMetadata(rs.getMetaData, 1)
+
+        assert(actualVarcharN == expectedVarcharN)
+      }
+    }
+
+    "work with unsized data types" in {
+      val expectedVarchar = JdbcFieldMetadata(
+        name = "DESCRIPTION",
+        label = "DESCRIPTION",
+        sqlType = java.sql.Types.VARCHAR,
+        sqlTypeName = "VARCHAR",
+        displaySize = 32768,
+        precision = 32768,
+        scale = 0,
+        nullable = false
+      )
+
+      withQuery("SELECT description FROM COMPANY WHERE 0=1") { rs =>
+        val actualVarchar = JdbcSparkUtils.getFieldMetadata(rs.getMetaData, 1)
+
+        assert(actualVarchar == expectedVarchar)
+      }
+    }
+  }
+
+  "getJdbcOptions" should {
+    "combine all provided options to a single map" in {
+      val jdbcConfig = JdbcConfig(
+        primaryUrl = Option(url),
+        user = Option("user"),
+        password = Option("password1"),
+        database = Option("mydb"),
+        driver = "org.hsqldb.jdbc.JDBCDriver",
+        extraOptions = Map("key1" -> "value1", "key2" -> "value2")
+      )
+
+      val extraOptions = Map("key1" -> "value11", "key3" -> "value3")
+
+      val options = JdbcSparkUtils.getJdbcOptions(url, jdbcConfig, "my_table", extraOptions)
+
+      assert(options.size == 9)
+      assert(options("url") == url)
+      assert(options("user") == "user")
+      assert(options("password") == "password1")
+      assert(options("dbtable") == "my_table")
+      assert(options("database") == "mydb")
+      assert(options("driver") == "org.hsqldb.jdbc.JDBCDriver")
+      assert(options("key1") == "value11")
+      assert(options("key2") == "value2")
+      assert(options("key3") == "value3")
+    }
+
+    "work with minimum configuration" in {
+      val jdbcConfig = JdbcConfig(
+        driver = "org.hsqldb.jdbc.JDBCDriver",
+        primaryUrl = None
+      )
+
+      val extraOptions = Map.empty[String, String]
+
+      val options = JdbcSparkUtils.getJdbcOptions(url, jdbcConfig, "my_table", extraOptions)
+
+      assert(options.size == 3)
+      assert(options("url") == url)
+      assert(options("dbtable") == "my_table")
+      assert(options("driver") == "org.hsqldb.jdbc.JDBCDriver")
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -28,14 +28,13 @@ import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.utils.JdbcSparkUtils
 import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
 
-class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with RelationalDbFixture  with TextComparisonFixture {
+class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with RelationalDbFixture with TextComparisonFixture {
   import spark.implicits._
 
   val jdbcConfig: JdbcConfig = JdbcConfig(driver, Some(url), Nil, None, Some(user), Some(password))
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-
     RdbExampleTable.Company.initTable(getConnection)
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -39,6 +39,11 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
     RdbExampleTable.Company.initTable(getConnection)
   }
 
+  override protected def afterAll(): Unit = {
+    RdbExampleTable.Company.dropTable(getConnection)
+    super.afterAll()
+  }
+
   "addMetadataFromJdbc" should {
     "add varchar metadata to Spark fields" in {
       val connectionOptions = JdbcSparkUtils.getJdbcOptions(url, jdbcConfig, RdbExampleTable.Company.tableName, Map.empty)

--- a/pramen/examples/enceladus_sourcing/sources.conf
+++ b/pramen/examples/enceladus_sourcing/sources.conf
@@ -37,6 +37,7 @@ pramen.sources = [
     save.timestamps.as.dates = true
     correct.decimals.in.schema = true
     correct.decimals.fix.precision = true
+    enable.schema.metadata = false
 
     information.date.column = "INFORMATION_DATE"
     information.date.type = "string"
@@ -61,5 +62,6 @@ pramen.sources = [
     save.timestamps.as.dates = true
     correct.decimals.in.schema = true
     correct.decimals.fix.precision = true
+    enable.schema.metadata = false
   }
 ]

--- a/pramen/examples/jdbc_sourcing/sources.conf
+++ b/pramen/examples/jdbc_sourcing/sources.conf
@@ -38,6 +38,7 @@ pramen.sources = [
     save.timestamps.as.dates = true
     correct.decimals.in.schema = true
     correct.decimals.fix.precision = true
+    enable.schema.metadata = false
 
     information.date.column = "INFORMATION_DATE"
     information.date.type = "string"


### PR DESCRIPTION
Closes #276

Example: for
```
NAME VARCHAR(50)
DESCRIPTION VARCHAR
```

Thye schema when loaded using the JDBC source with `enable.schema.metadata = true`

```json
{
  "type" : "struct",
  "fields" : [ {
    "name" : "NAME",
    "type" : "string",
    "nullable" : true,
    "metadata" : {
      "maxLength" : 50
    }
  }, {
    "name" : "DESCRIPTION",
    "type" : "string",
    "nullable" : true,
    "metadata" : { }
  } ]
}
```