### PR TITLE
#292 Fix the last expected info date calculation.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategyTransformation.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategyTransformation.scala
@@ -40,12 +40,14 @@ class ScheduleStrategyTransformation extends ScheduleStrategy {
                            ): Seq[TaskPreDef] = {
     val dates = params match {
       case ScheduleParams.Normal(runDate, trackDays, delayDays, newOnly, lateOnly)                      =>
-        log.info(s"Normal run strategy: runDate=$runDate, trackDays=$trackDays, delayDays=$delayDays, newOnly=$newOnly, lateOnly=$lateOnly")
+        val infoDate = evaluateRunDate(runDate, infoDateExpression)
+        log.info(s"Normal run strategy: runDate=$runDate, trackDays=$trackDays, delayDays=$delayDays, newOnly=$newOnly, lateOnly=$lateOnly, infoDate=$infoDate")
         val retrospective = getInfoDateRange(runDate.minusDays(trackDays + delayDays), runDate.minusDays(delayDays), infoDateExpression, schedule)
           .filter(date => anyDependencyUpdatedRetrospectively(outputTable, date, dependencies, bookkeeper))
           .map(d => pipeline.TaskPreDef(d, TaskRunReason.Update))
 
-        val lastProcessedDate = bookkeeper.getLatestProcessedDate(outputTable)
+        val lastProcessedDate = bookkeeper.getLatestProcessedDate(outputTable, Option(infoDate))
+        lastProcessedDate.foreach(d => log.info(s"Last processed info date: $d"))
 
         val lateDays = if (!newOnly) {
           getLate(outputTable, runDate.minusDays(delayDays), schedule, infoDateExpression, initialSourcingDateExpr, lastProcessedDate)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/splitter/ScheduleStrategyUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/splitter/ScheduleStrategyUtilsSuite.scala
@@ -333,4 +333,70 @@ class ScheduleStrategyUtilsSuite extends AnyWordSpec {
       }
     }
   }
+
+  "getNextExpectedInfoDate" should {
+    "correctly work with daily dates" in {
+      val schedule = Schedule.EveryDay()
+      val infoDateExpression = "minusDays(@runDate,1)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-05"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-06"))
+    }
+
+    "correctly work with weekly dates" in {
+      val schedule = Schedule.Weekly(Seq(DayOfWeek.MONDAY))
+      val infoDateExpression = "minusDays(@runDate,1)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-05"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-12"))
+    }
+
+    "correctly work with weekly dates and more complicated info date formula" in {
+      val schedule = Schedule.Weekly(Seq(DayOfWeek.MONDAY))
+      val infoDateExpression = "lastSaturday(@runDate)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-04"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-11"))
+    }
+
+    "correctly work with monthly dates" in {
+      val schedule = Schedule.Monthly(Seq(1))
+      val infoDateExpression = "minusDays(@runDate,1)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-01"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-30"))
+    }
+
+    "correctly work with schedules that never enabled" in {
+      val schedule = Schedule.Monthly(Seq.empty)
+      val infoDateExpression = "minusDays(@runDate,1)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-01"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-02"))
+    }
+
+    "correctly work with dates that increase with info date" in {
+      val schedule = Schedule.EveryDay()
+      val infoDateExpression = "plusDays(@runDate,1)"
+
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2023-11-05"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2023-11-07"))
+    }
+
+    "correctly work with an out of schedule example" in {
+      val schedule = Schedule.Weekly(Seq(DayOfWeek.SUNDAY))
+      val infoDateExpression = "lastSaturday(@runDate)"
+
+      // 2022-07-03. 2022-07-10 - Sundays
+      val nextExpected = getNextExpectedInfoDate(LocalDate.parse("2022-07-05"), infoDateExpression, schedule)
+
+      assert(nextExpected == LocalDate.parse("2022-07-09"))
+    }
+  }
 }


### PR DESCRIPTION
Closes #292

The bug made partitions that are already loaded consider late data in certain circumstances.