### PR TITLE
#298 Do not include Delta Lake classes in the runner bundle by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,35 +141,38 @@ The following Scala and Spark combinations are supported:
 |     2.12      | 3.0 and above |
 |     2.13      | 3.2 and above |
 
-## Building Pramen to suite your environment
+## Getting Pramen runner for your environment
 
-Pramen is released as a set of thin JAR libraries. When running on a specific environment you might want to tune the pipeline
-runner and extra pipeline elements to Scala and Spark version. You can do that by building Pramen from source and creating
-an uber JAR file that contains all dependencies required to run the pipeline on a Spark cluster (an uber jar aka fat jar).
+Pramen is released as a set of thin JAR libraries. When running on a specific environment you might want to include all
+dependencies in an uber jar that you can build for your Scala version. You can do that by either 
+- Downloading pre-compiled version of Pramen runners at the [Releases](https://github.com/AbsaOSS/pramen/releases) section of the project.
+- Or by building Pramen from source and creating an uber JAR file that contains all dependencies required to run the pipeline on a Spark cluster (see below).
+
+### Building a Pramen runner JAR from sources
 
 Creating an uber jar for Pramen is very easy. Just clone the repository and run one of the following commands:
 ```sh
-sbt -DSPARK_VERSION="2.4.8" ++2.11.12 assembly 
-
-sbt -DSPARK_VERSION="3.1.4" ++2.12.18 assembly 
-sbt -DSPARK_VERSION="3.2.4" ++2.12.18 assembly 
-sbt -DSPARK_VERSION="3.3.2" ++2.12.18 assembly
-sbt -DSPARK_VERSION="3.4.1" ++2.12.18 assembly
-
-sbt -DSPARK_VERSION="3.2.4" ++2.13.11 assembly
-sbt -DSPARK_VERSION="3.3.2" ++2.13.11 assembly 
-sbt -DSPARK_VERSION="3.4.1" ++2.13.11 assembly
+sbt ++2.11.12 assembly 
+sbt ++2.12.18 assembly
+sbt ++2.13.12 assembly
 ```
 
 You can collect the uber jar of Pramen either at
 - `core/target/scala-2.x/` for the pipeline runner.
 - `extras/target/scala-2.x/` for extra pipeline elements.
 
-depending on the Scala version you used.
+Since `1.7.0` Pramen runner bundle does not include Delta Lake format classes since they are most often available in 
+Spark distributions. This makes the runner independent of Spark version. But if you want to include Delta Lake files
+in your bundle, use one of example commands specifying your Spark version:
+```sh
+sbt -DSPARK_VERSION="2.4.8" -Dassembly.features="includeDelta" ++2.11.12 assembly 
+sbt -DSPARK_VERSION="3.3.3" -Dassembly.features="includeDelta" ++2.12.18 assembly
+sbt -DSPARK_VERSION="3.4.1" -Dassembly.features="includeDelta" ++2.13.12 assembly
+```
 
 Then, run `spark-shell` or `spark-submit` adding the fat jar as the option.
 ```sh
-$ spark-shell --jars pramen-runner_2.12_3.2-1.5.2-SNAPSHOT.jar
+$ spark-shell --jars pramen-runner_2.12-1.7.1-SNAPSHOT.jar
 ```
 
 # Creating a data pipeline

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/RunnerCommons.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/RunnerCommons.scala
@@ -120,7 +120,6 @@ object RunnerCommons {
       log.info(s"Fetching '$file'...")
       val fs = new Path(file).getFileSystem(hadoopConfig)
 
-
       fs.copyToLocalFile(new Path(file), currentPath)
     })
   }

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     "org.scalatest"        %% "scalatest"                  % scalatestVersion           % Test
   )
 
-  def CoreDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
+  def CoreDependencies(scalaVersion: String, isDeltaCompile: Boolean): Seq[ModuleID] = Seq(
     "org.apache.spark"     %% "spark-sql"                  % sparkVersion(scalaVersion) % Provided,
     "org.mongodb.scala"    %% "mongo-scala-driver"         % mongoDbScalaDriverVersion,
     "com.typesafe.slick"   %% "slick"                      % slickVersion,
@@ -42,7 +42,7 @@ object Dependencies {
     "org.mockito"          %  "mockito-core"               % mockitoVersion             % Test,
     "de.flapdoodle.embed"  %  "de.flapdoodle.embed.mongo"  % embeddedMongoDbVersion     % Test,
     "org.hsqldb"           %  "hsqldb"                     % hsqlDbVersion              % Test classifier "jdk8"
-  ) :+ getDeltaDependency(sparkVersion(scalaVersion))
+  ) :+ getDeltaDependency(sparkVersion(scalaVersion), isDeltaCompile)
 
   def ExtrasJobsDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
     "org.apache.spark"     %% "spark-sql"                  % sparkVersion(scalaVersion) % Provided,

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -42,12 +42,15 @@ object Dependencies {
     "org.mockito"          %  "mockito-core"               % mockitoVersion             % Test,
     "de.flapdoodle.embed"  %  "de.flapdoodle.embed.mongo"  % embeddedMongoDbVersion     % Test,
     "org.hsqldb"           %  "hsqldb"                     % hsqlDbVersion              % Test classifier "jdk8"
-  ) :+ getDeltaDependency(sparkVersion(scalaVersion), isDeltaCompile)
+  ) :+ getDeltaDependency(sparkVersion(scalaVersion), isDeltaCompile, isTest = false)
 
   def ExtrasJobsDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
     "org.apache.spark"     %% "spark-sql"                  % sparkVersion(scalaVersion) % Provided,
     "net.sourceforge.jtds" %  "jtds"                       % msSqlDriverVersion,
     "org.scalatest"        %% "scalatest"                  % scalatestVersion           % Test
-  ) :+ getAbrisDependency(scalaVersion)
+  ) ++ Seq(
+    getAbrisDependency(scalaVersion),
+    getDeltaDependency(sparkVersion(scalaVersion), isCompile = false, isTest = true)
+  )
 
 }

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -67,7 +67,7 @@ object Versions {
     }
   }
 
-  def getDeltaDependency(sparkVersion: String): ModuleID = {
+  def getDeltaDependency(sparkVersion: String, isCompile: Boolean): ModuleID = {
     // According to this: https://docs.delta.io/latest/releases.html
     val (deltaArtifact, deltaVersion) = sparkVersion match {
       case version if version.startsWith("2.")   => ("delta-core", "0.6.1")
@@ -79,8 +79,13 @@ object Versions {
       case version if version.startsWith("3.5.") => ("delta-spark", "3.0.0")  // 'delta-core' was renamed to 'delta-spark' since 3.0.0.
       case _                                     => throw new IllegalArgumentException(s"Spark $sparkVersion not supported.")
     }
-    println(s"Using Delta version $deltaArtifact:$deltaVersion")
-    "io.delta" %% deltaArtifact % deltaVersion
+    if (isCompile) {
+      println(s"Using Delta version $deltaArtifact:$deltaVersion (compile)")
+      "io.delta" %% deltaArtifact % deltaVersion % Compile
+    } else {
+      println(s"Using Delta version $deltaArtifact:$deltaVersion (provided)")
+      "io.delta" %% deltaArtifact % deltaVersion % Provided
+    }
   }
 
   def getAbrisDependency(scalaVersion: String): ModuleID = {

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -67,7 +67,7 @@ object Versions {
     }
   }
 
-  def getDeltaDependency(sparkVersion: String, isCompile: Boolean): ModuleID = {
+  def getDeltaDependency(sparkVersion: String, isCompile: Boolean, isTest: Boolean): ModuleID = {
     // According to this: https://docs.delta.io/latest/releases.html
     val (deltaArtifact, deltaVersion) = sparkVersion match {
       case version if version.startsWith("2.")   => ("delta-core", "0.6.1")
@@ -79,12 +79,16 @@ object Versions {
       case version if version.startsWith("3.5.") => ("delta-spark", "3.0.0")  // 'delta-core' was renamed to 'delta-spark' since 3.0.0.
       case _                                     => throw new IllegalArgumentException(s"Spark $sparkVersion not supported.")
     }
-    if (isCompile) {
-      println(s"Using Delta version $deltaArtifact:$deltaVersion (compile)")
-      "io.delta" %% deltaArtifact % deltaVersion % Compile
+    if (isTest) {
+      "io.delta" %% deltaArtifact % deltaVersion % Test
     } else {
-      println(s"Using Delta version $deltaArtifact:$deltaVersion (provided)")
-      "io.delta" %% deltaArtifact % deltaVersion % Provided
+      if (isCompile) {
+        println(s"Using Delta version $deltaArtifact:$deltaVersion (compile)")
+        "io.delta" %% deltaArtifact % deltaVersion % Compile
+      } else {
+        println(s"Using Delta version $deltaArtifact:$deltaVersion (provided)")
+        "io.delta" %% deltaArtifact % deltaVersion % Provided
+      }
     }
   }
 


### PR DESCRIPTION
Closes #298

Delta format is now not included in the pramen runner bundle by default, so you don't need to specify Spark version and just run
```sh
sbt ++2.12.18 assembly
```