### PR TITLE
Add options to set informtation start date relative to the current date.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,6 +1366,16 @@ pramen {
   # This feature is experimental, use more than 1 with caution. 
   parallel.tasks = 1
 
+
+  # You can specify either the oldest date that cannot be overwritten
+  # of the maximum number of days before today the data can still be writtenm
+  # (this option overrides all other options)
+  #
+  #write.oldest {
+  #  info.date = "2020-01-01"
+  #  info.days.from.today = 30
+  #}
+
   # Pramen-Py settings
   py {
     # This is mandatory of you want to use Python transformations and run Pramen-Py on the command line

--- a/README.md
+++ b/README.md
@@ -280,16 +280,23 @@ Here is an example of a metastore configuration with a single table (Parquet for
 ```hocon
 pramen.metastore {
   tables = [
-  {  
-    name = "table_name"
-    format = "parquet"
-    path = "hdfs://cluster/path/to/parquet/folder"
-    records.per.partition = 1000000
-    information.date.column = "INFORMATION_DATE"
-    information.date.format = "yyyy-MM-dd"
-    information.date.start = "2022-01-01"
-  }
-]
+    {
+      name = "table_name"
+      format = "parquet"
+      path = "hdfs://cluster/path/to/parquet/folder"
+      records.per.partition = 1000000
+      information.date.column = "INFORMATION_DATE"
+      information.date.format = "yyyy-MM-dd"
+
+      # You can set the start date beyond which Pramen won't allow writes:
+      information.date.start = "2022-01-01"
+
+      # Alternatively, you can set the time window in days that from the current system
+      # date that the table could be written to. This is helpful is the table is archived.
+      #information.date.max.days.behind = 180
+    }
+  ]
+}
 ```
 
 Metastore table options:

--- a/README.md
+++ b/README.md
@@ -1366,15 +1366,11 @@ pramen {
   # This feature is experimental, use more than 1 with caution. 
   parallel.tasks = 1
 
+  # You can set this option so that Pramen never writes to partitions older than the specified date
+  #information.date.start = "2010-01-01"
 
-  # You can specify either the oldest date that cannot be overwritten
-  # of the maximum number of days before today the data can still be writtenm
-  # (this option overrides all other options)
-  #
-  #write.oldest {
-  #  info.date = "2020-01-01"
-  #  info.days.from.today = 30
-  #}
+  # Or you can specify the same option in the number of days from the current calendar date.
+  #information.date.max.days.behind = 30
 
   # Pramen-Py settings
   py {

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -40,7 +40,7 @@ pramen {
   # Default information column date field used for the metastore. Sourced tables will be partitioned by this field.
   information.date.column = "pramen_info_date"
   information.date.format = "yyyy-MM-dd"
-  information.date.start = "2020-01-01"
+  information.date.start = "2010-01-01"
 
   # If non-zero, specifies how many tasks can be ran in parallel
   parallel.tasks = 1
@@ -68,8 +68,14 @@ pramen {
   # (This is a DEPRECATED parameter, please do not change th default)
   expected.delay.days = 0
 
-  # 1 - Mon, 7 - Sun
-  schedule.weekly.days.of.week = [ 7 ]
+  # You can specify either the oldest date that cannot be overwritten
+  # of the maximum number of days before today the data can still be writtenm
+  # (this option overrides all other options)
+  #
+  #write.oldest {
+  #  information.date = "2020-01-01"
+  #  information.days.from.today = 30
+  #}
 
   # This needs to be specified. The path should be accessible by Hadoop (HDFS, S3, etc)
   # temporary.directory = ""

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -40,7 +40,12 @@ pramen {
   # Default information column date field used for the metastore. Sourced tables will be partitioned by this field.
   information.date.column = "pramen_info_date"
   information.date.format = "yyyy-MM-dd"
-  information.date.start = "2010-01-01"
+
+  # You can set this option so that Pramen never writes to partitions older than the specified date
+  #information.date.start = "2010-01-01"
+
+  # Or you can specify the same option in the number of days from the current calendar date.
+  #information.date.max.days.behind = 30
 
   # If non-zero, specifies how many tasks can be ran in parallel
   parallel.tasks = 1
@@ -67,15 +72,6 @@ pramen {
   # Do not expect data to arrive specified number of days from now
   # (This is a DEPRECATED parameter, please do not change th default)
   expected.delay.days = 0
-
-  # You can specify either the oldest date that cannot be overwritten
-  # of the maximum number of days before today the data can still be writtenm
-  # (this option overrides all other options)
-  #
-  #write.oldest {
-  #  information.date = "2020-01-01"
-  #  information.days.from.today = 30
-  #}
 
   # This needs to be specified. The path should be accessible by Hadoop (HDFS, S3, etc)
   # temporary.directory = ""

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/AppContextFactory.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/AppContextFactory.scala
@@ -18,6 +18,7 @@ package za.co.absa.pramen.core
 
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.app.{AppContext, AppContextImpl}
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.journal.Journal
@@ -39,10 +40,11 @@ object AppContextFactory {
   }
 
   private [pramen] def createMockAppContext(conf: Config,
+                                            infoDateConfig: InfoDateConfig,
                                             bookkeeper: Bookkeeper,
                                             journal: Journal
                                               )(implicit spark: SparkSession): AppContext = this.synchronized {
-    appContext = AppContextImpl.getMock(conf, bookkeeper, journal)
+    appContext = AppContextImpl.getMock(conf, infoDateConfig, bookkeeper, journal)
     appContext
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/AppContextImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/AppContextImpl.scala
@@ -20,6 +20,7 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import za.co.absa.pramen.api.MetadataManager
 import za.co.absa.pramen.core.PramenImpl
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.lock.{TokenLockFactory, TokenLockFactoryAllow}
@@ -56,7 +57,7 @@ object AppContextImpl {
 
     val (bookkeeper, tokenLockFactory, journal, metadataManager, closable) = Bookkeeper.fromConfig(appConfig.bookkeepingConfig, appConfig.runtimeConfig)
 
-    val metastore: Metastore = MetastoreImpl.fromConfig(conf, bookkeeper, metadataManager)
+    val metastore: Metastore = MetastoreImpl.fromConfig(conf, appConfig.infoDateDefaults, bookkeeper, metadataManager)
 
     PramenImpl.instance.asInstanceOf[PramenImpl].setMetadataManager(metadataManager)
     PramenImpl.instance.asInstanceOf[PramenImpl].setWorkflowConfig(conf)
@@ -76,13 +77,14 @@ object AppContextImpl {
   }
 
   def getMock(conf: Config,
+              infoDateConfig: InfoDateConfig,
               bookkeeper: Bookkeeper,
               journal: Journal)(implicit spark: SparkSession): AppContextImpl = {
     val appConfig = AppConfig.fromConfig(conf)
 
     val metadataManager = new MetadataManagerNull(isPersistenceEnabled = false)
 
-    val metastore: Metastore = MetastoreImpl.fromConfig(conf, bookkeeper, metadataManager)
+    val metastore: Metastore = MetastoreImpl.fromConfig(conf, infoDateConfig, bookkeeper, metadataManager)
 
     val appContext = new AppContextImpl(
       appConfig,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
@@ -17,20 +17,25 @@
 package za.co.absa.pramen.core.app.config
 
 import com.typesafe.config.Config
+import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.utils.ConfigUtils
 
-import java.time.ZoneId
+import java.time.{LocalDate, ZoneId}
 
 case class GeneralConfig(
                           timezoneId: ZoneId,
                           environmentName: String,
                           temporaryDirectory: Option[String],
+                          writeOldestInfoDate: Option[LocalDate],
                           enableMultipleJobsPerTable: Boolean
                         )
+
 object GeneralConfig {
   val TIMEZONE_ID_KEY = "pramen.timezone"
   val ENVIRONMENT_NAME_KEY = "pramen.environment.name"
   val TEMPORARY_DIRECTORY_KEY = "pramen.temporary.directory"
+  val WRITE_OLDEST_RUN_DATE_KEY = "pramen.write.oldest.information.date"
+  val WRITE_OLDEST_DAYS_FROM_TODAY_KEY = "pramen.write.oldest.information.days.from.today"
   val ENABLE_MULTIPLE_JOBS_PER_OUTPUT_TABLE = "pramen.enable.multiple.jobs.per.output.table"
 
   def fromConfig(conf: Config): GeneralConfig = {
@@ -41,6 +46,21 @@ object GeneralConfig {
     val temporaryDirectory = ConfigUtils.getOptionString(conf, TEMPORARY_DIRECTORY_KEY)
     val enableMultipleJobsPerTable = conf.getBoolean(ENABLE_MULTIPLE_JOBS_PER_OUTPUT_TABLE)
 
-    GeneralConfig(timezoneId, environmentName, temporaryDirectory, enableMultipleJobsPerTable)
+    val oldestInfoDateOpt = ConfigUtils.getDateOpt(conf, WRITE_OLDEST_RUN_DATE_KEY, DEFAULT_DATE_FORMAT)
+    val oldestInfoDaysOpt = ConfigUtils.getOptionInt(conf, WRITE_OLDEST_DAYS_FROM_TODAY_KEY)
+
+    val writeOldestInfoDateOpt = (oldestInfoDateOpt, oldestInfoDaysOpt) match {
+      case (Some(_), Some(_)) =>
+        throw new IllegalArgumentException(s"Incompatible options used. Please, use only one of: " +
+          s"$WRITE_OLDEST_RUN_DATE_KEY, $WRITE_OLDEST_DAYS_FROM_TODAY_KEY")
+      case (Some(oldestDate), None) =>
+        Option(oldestDate)
+      case (None, Some(days)) =>
+        Option(LocalDate.now().minusDays(days))
+      case (None, None) =>
+        None
+    }
+
+    GeneralConfig(timezoneId, environmentName, temporaryDirectory, writeOldestInfoDateOpt, enableMultipleJobsPerTable)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/GeneralConfig.scala
@@ -17,16 +17,14 @@
 package za.co.absa.pramen.core.app.config
 
 import com.typesafe.config.Config
-import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.utils.ConfigUtils
 
-import java.time.{LocalDate, ZoneId}
+import java.time.ZoneId
 
 case class GeneralConfig(
                           timezoneId: ZoneId,
                           environmentName: String,
                           temporaryDirectory: Option[String],
-                          writeOldestInfoDate: Option[LocalDate],
                           enableMultipleJobsPerTable: Boolean
                         )
 
@@ -34,8 +32,6 @@ object GeneralConfig {
   val TIMEZONE_ID_KEY = "pramen.timezone"
   val ENVIRONMENT_NAME_KEY = "pramen.environment.name"
   val TEMPORARY_DIRECTORY_KEY = "pramen.temporary.directory"
-  val WRITE_OLDEST_RUN_DATE_KEY = "pramen.write.oldest.information.date"
-  val WRITE_OLDEST_DAYS_FROM_TODAY_KEY = "pramen.write.oldest.information.days.from.today"
   val ENABLE_MULTIPLE_JOBS_PER_OUTPUT_TABLE = "pramen.enable.multiple.jobs.per.output.table"
 
   def fromConfig(conf: Config): GeneralConfig = {
@@ -46,21 +42,6 @@ object GeneralConfig {
     val temporaryDirectory = ConfigUtils.getOptionString(conf, TEMPORARY_DIRECTORY_KEY)
     val enableMultipleJobsPerTable = conf.getBoolean(ENABLE_MULTIPLE_JOBS_PER_OUTPUT_TABLE)
 
-    val oldestInfoDateOpt = ConfigUtils.getDateOpt(conf, WRITE_OLDEST_RUN_DATE_KEY, DEFAULT_DATE_FORMAT)
-    val oldestInfoDaysOpt = ConfigUtils.getOptionInt(conf, WRITE_OLDEST_DAYS_FROM_TODAY_KEY)
-
-    val writeOldestInfoDateOpt = (oldestInfoDateOpt, oldestInfoDaysOpt) match {
-      case (Some(_), Some(_)) =>
-        throw new IllegalArgumentException(s"Incompatible options used. Please, use only one of: " +
-          s"$WRITE_OLDEST_RUN_DATE_KEY, $WRITE_OLDEST_DAYS_FROM_TODAY_KEY")
-      case (Some(oldestDate), None) =>
-        Option(oldestDate)
-      case (None, Some(days)) =>
-        Option(LocalDate.now().minusDays(days))
-      case (None, None) =>
-        None
-    }
-
-    GeneralConfig(timezoneId, environmentName, temporaryDirectory, writeOldestInfoDateOpt, enableMultipleJobsPerTable)
+    GeneralConfig(timezoneId, environmentName, temporaryDirectory, enableMultipleJobsPerTable)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/InfoDateConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/InfoDateConfig.scala
@@ -33,7 +33,7 @@ case class InfoDateConfig(
                            expressionMonthly: String,
                            initialSourcingDateExprDaily: String,
                            initialSourcingDateExprWeekly: String,
-                           initialSourcingDateExprMonthly: String                         )
+                           initialSourcingDateExprMonthly: String)
 
 object InfoDateConfig {
   val DEFAULT_DATE_FORMAT = "yyyy-MM-dd"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
@@ -41,6 +41,7 @@ case class RuntimeConfig(
                           isInverseOrder: Boolean,
                           parallelTasks: Int,
                           stopSparkSession: Boolean,
+                          allowEmptyPipeline: Boolean,
                           historicalRunMode: RunMode
                         )
 
@@ -64,6 +65,7 @@ object RuntimeConfig {
   val LOAD_DATE_TO = "pramen.load.date.to"
   val STOP_SPARK_SESSION = "pramen.stop.spark.session"
   val VERBOSE = "pramen.verbose"
+  val ALLOW_EMPTY_PIPELINE = "pramen.allow.empty.pipeline"
 
   def fromConfig(conf: Config): RuntimeConfig = {
     val infoDateFormat = conf.getString(INFORMATION_DATE_FORMAT_APP)
@@ -125,6 +127,8 @@ object RuntimeConfig {
       true
     }
 
+    val allowEmptyPipeline = ConfigUtils.getOptionBoolean(conf, ALLOW_EMPTY_PIPELINE).getOrElse(false)
+
     RuntimeConfig(
       isDryRun = isDryRun,
       isRerun = isRerun,
@@ -139,6 +143,7 @@ object RuntimeConfig {
       isInverseOrder = ConfigUtils.getOptionBoolean(conf, IS_INVERSE_ORDER).getOrElse(false),
       parallelTasks = parallelTasks,
       stopSparkSession = conf.getBoolean(STOP_SPARK_SESSION),
+      allowEmptyPipeline,
       runMode
     )
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/ValidationException.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/ValidationException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.exceptions
+
+class ValidationException(msg: String, cause: Throwable = null) extends Exception(msg, cause)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -20,7 +20,8 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.types.{DateType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.{DataFormat, MetaTableDef, MetaTableRunInfo, MetadataManager, MetastoreReader, Query}
+import za.co.absa.pramen.api._
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.app.config.RuntimeConfig.UNDERCOVER
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
@@ -228,8 +229,11 @@ object MetastoreImpl {
   val METASTORE_KEY = "pramen.metastore.tables"
   val DEFAULT_RECORDS_PER_PARTITION = 500000
 
-  def fromConfig(conf: Config, bookkeeper: Bookkeeper, metadataManager: MetadataManager)(implicit spark: SparkSession): MetastoreImpl = {
-    val tableDefs = MetaTable.fromConfig(conf, METASTORE_KEY)
+  def fromConfig(conf: Config,
+                 infoDateConfig: InfoDateConfig,
+                 bookkeeper: Bookkeeper,
+                 metadataManager: MetadataManager)(implicit spark: SparkSession): MetastoreImpl = {
+    val tableDefs = MetaTable.fromConfig(conf, infoDateConfig, METASTORE_KEY)
 
     val isUndercover = ConfigUtils.getOptionBoolean(conf, UNDERCOVER).getOrElse(false)
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
@@ -20,9 +20,7 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.app.config.InfoDateConfig
-import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.config.InfoDateOverride
-import za.co.absa.pramen.core.utils.DateUtils.convertStrToDate
 import za.co.absa.pramen.core.utils.{AlgorithmicUtils, ConfigUtils}
 
 import java.time.LocalDate
@@ -76,11 +74,11 @@ object MetaTable {
   val TABLE_HIVE_CONFIG_PREFIX = "hive"
   val DEFAULT_HIVE_CONFIG_PREFIX = "pramen.hive"
 
-  def fromConfig(conf: Config, key: String): Seq[MetaTable] = {
-    val defaultInfoDateColumnName = conf.getString(InfoDateConfig.INFORMATION_DATE_COLUMN_KEY)
-    val defaultInfoDateFormat = conf.getString(InfoDateConfig.INFORMATION_DATE_FORMAT_KEY)
-    val defaultStartDate = convertStrToDate(conf.getString(InfoDateConfig.INFORMATION_DATE_START_KEY), DEFAULT_DATE_FORMAT, defaultInfoDateFormat)
-    val defaultTrackDays = conf.getInt(InfoDateConfig.TRACK_DAYS)
+  def fromConfig(conf: Config, infoDateConfig: InfoDateConfig, key: String): Seq[MetaTable] = {
+    val defaultInfoDateColumnName = infoDateConfig.columnName
+    val defaultInfoDateFormat = infoDateConfig.dateFormat
+    val defaultStartDate = infoDateConfig.startDate
+    val defaultTrackDays = infoDateConfig.defaultTrackDays
     val defaultHiveConfig = HiveDefaultConfig.fromConfig(ConfigUtils.getOptionConfig(conf, DEFAULT_HIVE_CONFIG_PREFIX))
 
     val tableConfigs = ConfigUtils.getOptionConfigList(conf, key)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -18,7 +18,7 @@ package za.co.absa.pramen.core.notify.pipeline
 
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.notification.{Align, NotificationEntry, Style, TableHeader, TextElement}
+import za.co.absa.pramen.api.notification._
 import za.co.absa.pramen.core.config.Keys.TIMEZONE
 import za.co.absa.pramen.core.exceptions.{CmdFailedException, ProcessFailedException}
 import za.co.absa.pramen.core.notify.message._
@@ -505,7 +505,7 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
       case s: Succeeded           => getSuccessTextElement(s, task.dependencyWarnings.nonEmpty)
       case _: InsufficientData    => TextElement("Insufficient data", Style.Exception)
       case NoData(isFailure)      => TextElement("No Data", if (isFailure) Style.Exception else Style.Warning)
-      case _: Skipped             => TextElement("Skipped", successStyle)
+      case s: Skipped             => if (s.isWarning) TextElement("Skipped", Style.Warning) else TextElement("Skipped", successStyle)
       case NotRan                 => TextElement("Skipped", Style.Warning)
       case _: ValidationFailed    => TextElement("Validation failed", Style.Warning)
       case _: MissingDependencies => TextElement("Skipped", Style.Warning)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationDef.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationDef.scala
@@ -81,7 +81,7 @@ object OperationDef {
       return None
     }
 
-    val operationType = OperationType.fromConfig(conf, appConfig, parent)
+    val operationType = OperationType.fromConfig(conf, appConfig, infoDateConfig, parent)
     val schedule = Schedule.fromConfig(conf)
     val expectedDelayDays = ConfigUtils.getOptionInt(conf, EXPECTED_DELAY_DAYS_KEY).getOrElse(defaultDelayDays)
     val consumeThreads = getThreadsToConsume(name, conf, appConfig)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationType.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationType.scala
@@ -17,6 +17,7 @@
 package za.co.absa.pramen.core.pipeline
 
 import com.typesafe.config.Config
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.utils.ConfigUtils
 
 /** This is a base class for all Pramen jobs (new API). */
@@ -38,23 +39,23 @@ object OperationType {
   val PYTHON_CLASS_KEY = "python.class"
   val OUTPUT_TABLE_KEY = "output.table"
 
-  def fromConfig(conf: Config, appConfig: Config, parent: String): OperationType = {
+  def fromConfig(conf: Config, appConfig: Config, infoDateConfig: InfoDateConfig, parent: String): OperationType = {
     if (conf.hasPath(TYPE_KEY)) {
-      getOperationTypeFromName(conf.getString(TYPE_KEY), conf, appConfig, parent)
+      getOperationTypeFromName(conf.getString(TYPE_KEY), conf, infoDateConfig, parent)
     } else {
-      getDefaultOperationType(conf, appConfig, parent)
+      getDefaultOperationType(conf, appConfig, infoDateConfig, parent)
     }
   }
 
-  private [core] def getDefaultOperationType(conf: Config, appConfig: Config, parent: String): OperationType = {
+  private [core] def getDefaultOperationType(conf: Config, appConfig: Config, infoDateConfig: InfoDateConfig, parent: String): OperationType = {
     if (appConfig.hasPath(DEFAULT_TYPE_KEY)) {
-      getOperationTypeFromName(appConfig.getString(DEFAULT_TYPE_KEY), conf, appConfig, parent)
+      getOperationTypeFromName(appConfig.getString(DEFAULT_TYPE_KEY), conf, infoDateConfig, parent)
     } else {
       throw new IllegalArgumentException(s"Missing either $parent.$TYPE_KEY or $DEFAULT_TYPE_KEY")
     }
   }
 
-  private[core] def getOperationTypeFromName(name: String, conf: Config, appConfig: Config, parent: String): OperationType = {
+  private[core] def getOperationTypeFromName(name: String, conf: Config, infoDateConfig: InfoDateConfig, parent: String): OperationType = {
     name match {
       case "ingestion" | "sourcing" | "extract" =>
         ConfigUtils.validatePathsExistence(conf, parent, Seq(SOURCE_KEY, TABLES_KEY))
@@ -85,7 +86,7 @@ object OperationType {
         val source = conf.getString(SOURCE_KEY)
         val sink = conf.getString(SINK_KEY)
 
-        val tables = TransferTable.fromConfig(conf, appConfig, TABLES_KEY, sink)
+        val tables = TransferTable.fromConfig(conf, infoDateConfig, TABLES_KEY, sink)
 
         Transfer(source, sink, tables)
       case _ => throw new IllegalArgumentException(s"Unknown operation type: ${conf.getString(TYPE_KEY)} at $parent")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TaskRunReason.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TaskRunReason.scala
@@ -34,4 +34,8 @@ object TaskRunReason {
   case object Late extends TaskRunReason {
     override def toString: String = "Late"
   }
+
+  case class Skip(reason: String) extends TaskRunReason {
+    override def toString: String = "Skip"
+  }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransferTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransferTable.scala
@@ -20,11 +20,9 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{DataFormat, Query}
 import za.co.absa.pramen.core.app.config.InfoDateConfig
-import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.config.InfoDateOverride
 import za.co.absa.pramen.core.metastore.model.{HiveConfig, MetaTable}
 import za.co.absa.pramen.core.model.QueryBuilder
-import za.co.absa.pramen.core.utils.DateUtils.convertStrToDate
 import za.co.absa.pramen.core.utils.{AlgorithmicUtils, ConfigUtils}
 
 import java.time.LocalDate
@@ -109,10 +107,9 @@ object TransferTable {
     TransferTable(query, jobMetaTable, conf, dateFromExpr, dateToExpr, startDate, trackDays, trackDaysExplicitlySet, transformations, filters, columns, readOptions, writeOptions, sourceOverrideConf, sinkOverrideConf)
   }
 
-  def fromConfig(conf: Config, appConfig: Config, arrayPath: String, sinkName: String): Seq[TransferTable] = {
-    val defaultInfoDateFormat = appConfig.getString(InfoDateConfig.INFORMATION_DATE_FORMAT_KEY)
-    val defaultStartDate = convertStrToDate(appConfig.getString(InfoDateConfig.INFORMATION_DATE_START_KEY), DEFAULT_DATE_FORMAT, defaultInfoDateFormat)
-    val defaultTrackDays = appConfig.getInt(InfoDateConfig.TRACK_DAYS)
+  def fromConfig(conf: Config, infoDateConfig: InfoDateConfig, arrayPath: String, sinkName: String): Seq[TransferTable] = {
+    val defaultStartDate = infoDateConfig.startDate
+    val defaultTrackDays = infoDateConfig.defaultTrackDays
 
     val tableConfigs = conf.getConfigList(arrayPath).asScala
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.runner.jobrunner
 import com.github.yruslan.channel.{Channel, ReadChannel}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.DataFormat
-import za.co.absa.pramen.core.app.config.RuntimeConfig
+import za.co.absa.pramen.core.app.AppConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.exceptions.FatalErrorWrapper
 import za.co.absa.pramen.core.pipeline.Job
@@ -35,7 +35,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContextExecutorService, Future}
 import scala.util.control.NonFatal
 
-class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
+class ConcurrentJobRunnerImpl(appConfig: AppConfig,
                               bookkeeper: Bookkeeper,
                               taskRunner: TaskRunner,
                               applicationId: String) extends ConcurrentJobRunner {
@@ -45,7 +45,7 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
   private val completedJobsChannel = Channel.make[JobRunResults](1)
   private var workersFuture: Future[Unit] = _
 
-  private val executor: ExecutorService = newFixedThreadPool(runtimeConfig.parallelTasks)
+  private val executor: ExecutorService = newFixedThreadPool(appConfig.runtimeConfig.parallelTasks)
   implicit private  val executionContext: ExecutionContextExecutorService = fromExecutorService(executor)
 
   override def getCompletedJobsChannel: ReadChannel[JobRunResults] = {
@@ -58,7 +58,7 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
     }
     loopStarted = true
 
-    val workers = Range(0, runtimeConfig.parallelTasks).map(workerNum => {
+    val workers = Range(0, appConfig.runtimeConfig.parallelTasks).map(workerNum => {
       Future {
         workerLoop(workerNum, incomingJobs)
       }
@@ -107,7 +107,12 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
   }
 
   private[core] def runJob(job: Job): Boolean = {
-    val scheduleParams = ScheduleParams.fromRuntimeConfig(runtimeConfig, job.trackDays, job.operation.expectedDelayDays)
+    val scheduleParams = ScheduleParams.fromRuntimeConfig(appConfig.runtimeConfig, job.trackDays, job.operation.expectedDelayDays)
+
+    val minimumDate = appConfig.generalConfig.writeOldestInfoDate match {
+      case Some(date) => date
+      case None => job.outputTable.infoDateStart
+    }
 
     val taskDefs = job.scheduleStrategy.getDaysToRun(
       job.outputTable.name,
@@ -117,7 +122,7 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
       job.operation.schedule,
       scheduleParams,
       job.operation.initialSourcingDateExpression,
-      job.outputTable.infoDateStart
+      minimumDate
     )
 
     log.info(s"Dates selected to run for '${job.outputTable.name}': ${taskDefs.map(_.infoDate).mkString(", ")}")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.app.AppContext
-import za.co.absa.pramen.core.exceptions.FatalErrorWrapper
+import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, ValidationException}
 import za.co.absa.pramen.core.pipeline.{Job, JobDependency, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunner
 import za.co.absa.pramen.core.runner.splitter.ScheduleStrategyUtils.evaluateRunDate
@@ -40,6 +40,7 @@ class OrchestratorImpl extends Orchestrator {
   private var pendingJobs = List.empty[Job]
   private val runningJobs: mutable.Set[Job] = mutable.HashSet.empty[Job]
 
+  @throws[ValidationException]
   override def validateJobs(jobs: Seq[Job])(implicit appContext: AppContext,
                                             spark: SparkSession): Unit = {
     val enableMultipleJobsPerTable = appContext.appConfig.generalConfig.enableMultipleJobsPerTable
@@ -194,6 +195,7 @@ class OrchestratorImpl extends Orchestrator {
     }
   }
 
+  @throws[ValidationException]
   private[core] def validateJobs(jobs: Seq[Job],
                                  runDate: LocalDate,
                                  allowMultipleJobsPerTable: Boolean): Unit = {
@@ -207,7 +209,7 @@ class OrchestratorImpl extends Orchestrator {
       val issues = duplicateJobs.flatMap(duplicateJobs => validateOverlapInfoDates(duplicateJobs, runDate))
 
       if (issues.nonEmpty) {
-        throw new IllegalArgumentException(s"Job validation issues found: ${issues.mkString("; ")}")
+        throw new ValidationException(s"Job validation issues found: ${issues.mkString("; ")}")
       }
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategySourcing.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategySourcing.scala
@@ -83,6 +83,6 @@ class ScheduleStrategySourcing extends ScheduleStrategy {
         getHistorical(outputTable, dateFrom, dateTo, schedule, mode, infoDateExpression, minimumDate, inverseDateOrder, bookkeeper)
     }
 
-    filterOutPastMinimumDates(outputTable, dates, minimumDate)
+    filterOutPastMinimumDates(dates, minimumDate)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategyTransformation.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/splitter/ScheduleStrategyTransformation.scala
@@ -80,6 +80,6 @@ class ScheduleStrategyTransformation extends ScheduleStrategy {
         getHistorical(outputTable, dateFrom, dateTo, schedule, mode, infoDateExpression, minimumDate, inverseDateOrder, bookkeeper)
     }
 
-    filterOutPastMinimumDates(outputTable, dates, minimumDate)
+    filterOutPastMinimumDates(dates, minimumDate)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/RunStatus.scala
@@ -99,7 +99,7 @@ object RunStatus {
     override def getReason(): Option[String] = None
   }
 
-  case class Skipped(msg: String) extends RunStatus {
+  case class Skipped(msg: String, isWarning: Boolean = false) extends RunStatus {
     val isFailure: Boolean = false
 
     override def toString: String = "Skipped"

--- a/pramen/core/src/test/resources/test/config/pipeline_v2_empty.conf
+++ b/pramen/core/src/test/resources/test/config/pipeline_v2_empty.conf
@@ -13,6 +13,7 @@
 
 pramen {
   bookkeeping.enabled = false
+  allow.empty.pipeline = true
 }
 
 pramen.metastore {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/AppConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/AppConfigFactory.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core
+
+import za.co.absa.pramen.core.app.AppConfig
+import za.co.absa.pramen.core.app.config._
+
+object AppConfigFactory {
+  def getDummyAppConfig(generalConfig: GeneralConfig = GeneralConfigFactory.getDummyGeneralConfig(),
+                        bookkeepingConfig: BookkeeperConfig = BookkeepingConfigFactory.getDummyBookkeepingConfig(),
+                        runtimeConfig: RuntimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(),
+                        infoDateDefaults: InfoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig(),
+                        hookConfig: HookConfig = HookConfig(None, None)): AppConfig = {
+    AppConfig(
+      generalConfig,
+      bookkeepingConfig,
+      runtimeConfig,
+      infoDateDefaults,
+      hookConfig
+    )
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/AppContextFactorySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/AppContextFactorySuite.scala
@@ -65,8 +65,9 @@ class AppContextFactorySuite extends AnyWordSpec with SparkTestBase {
     "be able to create mock app context" in {
       val bookkeeper = new BookkeeperNull()
       val journal = new JournalNull()
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
 
-      val context = AppContextFactory.createMockAppContext(conf, bookkeeper, journal)
+      val context = AppContextFactory.createMockAppContext(conf, infoDateConfig, bookkeeper, journal)
 
       assert(context == AppContextFactory.get)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/BookkeepingConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/BookkeepingConfigFactory.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core
+
+import za.co.absa.pramen.core.app.config.{BookkeeperConfig, HadoopFormat}
+import za.co.absa.pramen.core.reader.model.JdbcConfig
+
+object BookkeepingConfigFactory {
+  def getDummyBookkeepingConfig(bookkeepingEnabled: Boolean = false,
+                                bookkeepingLocation: Option[String] = None,
+                                bookkeepingHadoopFormat: HadoopFormat = HadoopFormat.Text,
+                                bookkeepingConnectionString: Option[String] = None,
+                                bookkeepingDbName: Option[String] = None,
+                                bookkeepingJdbcConfig: Option[JdbcConfig] = None): BookkeeperConfig = {
+    BookkeeperConfig(
+      bookkeepingEnabled,
+      bookkeepingLocation,
+      bookkeepingHadoopFormat,
+      bookkeepingConnectionString,
+      bookkeepingDbName,
+      bookkeepingJdbcConfig
+    )
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/GeneralConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/GeneralConfigFactory.scala
@@ -18,19 +18,17 @@ package za.co.absa.pramen.core
 
 import za.co.absa.pramen.core.app.config.GeneralConfig
 
-import java.time.{LocalDate, ZoneId}
+import java.time.ZoneId
 
 object GeneralConfigFactory {
   def getDummyGeneralConfig(timezoneId: ZoneId = ZoneId.of("Africa/Johannesburg"),
                             environmentName: String = "TEST",
                             temporaryDirectory: Option[String] = None,
-                            writeOldestInfoDate: Option[LocalDate] = None,
                             enableMultipleJobsPerTable: Boolean = false): GeneralConfig = {
     GeneralConfig(
       timezoneId,
       environmentName,
       temporaryDirectory,
-      writeOldestInfoDate,
       enableMultipleJobsPerTable
     )
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/GeneralConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/GeneralConfigFactory.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core
+
+import za.co.absa.pramen.core.app.config.GeneralConfig
+
+import java.time.{LocalDate, ZoneId}
+
+object GeneralConfigFactory {
+  def getDummyGeneralConfig(timezoneId: ZoneId = ZoneId.of("Africa/Johannesburg"),
+                            environmentName: String = "TEST",
+                            temporaryDirectory: Option[String] = None,
+                            writeOldestInfoDate: Option[LocalDate] = None,
+                            enableMultipleJobsPerTable: Boolean = false): GeneralConfig = {
+    GeneralConfig(
+      timezoneId,
+      environmentName,
+      temporaryDirectory,
+      writeOldestInfoDate,
+      enableMultipleJobsPerTable
+    )
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/InfoDateConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/InfoDateConfigFactory.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core
+
+import za.co.absa.pramen.core.app.config.InfoDateConfig
+
+import java.time.LocalDate
+
+object InfoDateConfigFactory {
+  def getDummyInfoDateConfig(columnName: String = "pramen_info_date",
+                             dateFormat: String = "yyyy-MM-dd",
+                             startDate: LocalDate = LocalDate.parse("2010-01-01"),
+                             defaultTrackDays: Int = 0,
+                             defaultDelayDays: Int = 0,
+                             expressionDaily: String = "@runDate",
+                             expressionWeekly: String = "lastMonday(@runDate)",
+                             expressionMonthly: String = "beginOfMonth(@runDate)",
+                             initialSourcingDateExprDaily: String = "@runDate",
+                             initialSourcingDateExprWeekly: String = "@runDate - 6",
+                             initialSourcingDateExprMonthly: String = "beginOfMonth(@runDate)"): InfoDateConfig = {
+    InfoDateConfig(
+      columnName,
+      dateFormat,
+      startDate,
+      defaultTrackDays,
+      defaultDelayDays,
+      expressionDaily,
+      expressionWeekly,
+      expressionMonthly,
+      initialSourcingDateExprDaily,
+      initialSourcingDateExprWeekly,
+      initialSourcingDateExprMonthly
+    )
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/PipelineRunnerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/PipelineRunnerSuite.scala
@@ -61,6 +61,7 @@ class PipelineRunnerSuite extends AnyWordSpec with BeforeAndAfterAll with TempDi
           |  pipeline.name = "Test pipeline"
           |  bookkeeping.enabled = false
           |  stop.spark.session = false
+          |  allow.empty.pipeline = true
           |}
           |""".stripMargin)
       withTempDirectory("pramen_main") { tempDir =>

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
@@ -36,6 +36,7 @@ object RuntimeConfigFactory {
                             isInverseOrder: Boolean = false,
                             parallelTasks: Int = 1,
                             stopSparkSession: Boolean = false,
+                            allowEmptyPipeline: Boolean = false,
                             historicalRunMode: RunMode = RunMode.CheckUpdates): RuntimeConfig = {
     RuntimeConfig(isDryRun,
       isRerun,
@@ -50,6 +51,7 @@ object RuntimeConfigFactory {
       isInverseOrder,
       parallelTasks,
       stopSparkSession,
+      allowEmptyPipeline,
       historicalRunMode)
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/app/AppContextSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/app/AppContextSuite.scala
@@ -18,6 +18,7 @@ package za.co.absa.pramen.core.app
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.InfoDateConfigFactory
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.bookkeeper.BookkeeperNull
 import za.co.absa.pramen.core.journal.JournalNull
@@ -57,10 +58,11 @@ class AppContextSuite extends AnyWordSpec with SparkTestBase{
     }
 
     "be able to create mock app context" in {
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
       val bookkeeper = new BookkeeperNull()
       val journal = new JournalNull()
 
-      val context = AppContextImpl.getMock(conf, bookkeeper, journal)
+      val context = AppContextImpl.getMock(conf, infoDateConfig, bookkeeper, journal)
 
       assert(context.bookkeeper == bookkeeper)
       assert(context.journal == journal)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
@@ -18,9 +18,8 @@ package za.co.absa.pramen.core.app.config
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.core.app.config.GeneralConfig.{WRITE_OLDEST_DAYS_FROM_TODAY_KEY, WRITE_OLDEST_RUN_DATE_KEY}
 
-import java.time.{LocalDate, ZoneId}
+import java.time.ZoneId
 
 class GeneralConfigSuite extends AnyWordSpec {
   "GeneralConfig" should {
@@ -42,45 +41,6 @@ class GeneralConfigSuite extends AnyWordSpec {
       assert(generalConfig.environmentName == "DummyEnv")
       assert(generalConfig.temporaryDirectory.contains("/dummy/dir"))
       assert(generalConfig.enableMultipleJobsPerTable)
-      assert(generalConfig.writeOldestInfoDate.isEmpty)
-    }
-
-    "support the oldest date" in {
-      val configStr = s"""$WRITE_OLDEST_RUN_DATE_KEY = "2023-12-14""""
-
-      val config = ConfigFactory.parseString(configStr)
-        .withFallback(ConfigFactory.load())
-
-      val generalConfig = GeneralConfig.fromConfig(config)
-
-      assert(generalConfig.writeOldestInfoDate.contains(LocalDate.parse("2023-12-14")))
-    }
-
-    "support the oldest day" in {
-      val configStr = s"$WRITE_OLDEST_DAYS_FROM_TODAY_KEY = 30"
-
-      val config = ConfigFactory.parseString(configStr)
-        .withFallback(ConfigFactory.load())
-
-      val generalConfig = GeneralConfig.fromConfig(config)
-
-      assert(generalConfig.writeOldestInfoDate.contains(LocalDate.now().minusDays(30)))
-    }
-
-    "throw an exception if incompatible options are specified" in {
-      val configStr =
-        s"""$WRITE_OLDEST_RUN_DATE_KEY = "2023-12-14"
-           |$WRITE_OLDEST_DAYS_FROM_TODAY_KEY = 30
-           |""".stripMargin
-
-      val config = ConfigFactory.parseString(configStr)
-        .withFallback(ConfigFactory.load())
-
-      val ex = intercept[IllegalArgumentException] {
-        GeneralConfig.fromConfig(config)
-      }
-
-      assert(ex.getMessage.contains(s"Incompatible options used. Please, use only one of: $WRITE_OLDEST_RUN_DATE_KEY, $WRITE_OLDEST_DAYS_FROM_TODAY_KEY"))
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/app/config/GeneralConfigSuite.scala
@@ -18,8 +18,9 @@ package za.co.absa.pramen.core.app.config
 
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.app.config.GeneralConfig.{WRITE_OLDEST_DAYS_FROM_TODAY_KEY, WRITE_OLDEST_RUN_DATE_KEY}
 
-import java.time.ZoneId
+import java.time.{LocalDate, ZoneId}
 
 class GeneralConfigSuite extends AnyWordSpec {
   "GeneralConfig" should {
@@ -41,6 +42,45 @@ class GeneralConfigSuite extends AnyWordSpec {
       assert(generalConfig.environmentName == "DummyEnv")
       assert(generalConfig.temporaryDirectory.contains("/dummy/dir"))
       assert(generalConfig.enableMultipleJobsPerTable)
+      assert(generalConfig.writeOldestInfoDate.isEmpty)
+    }
+
+    "support the oldest date" in {
+      val configStr = s"""$WRITE_OLDEST_RUN_DATE_KEY = "2023-12-14""""
+
+      val config = ConfigFactory.parseString(configStr)
+        .withFallback(ConfigFactory.load())
+
+      val generalConfig = GeneralConfig.fromConfig(config)
+
+      assert(generalConfig.writeOldestInfoDate.contains(LocalDate.parse("2023-12-14")))
+    }
+
+    "support the oldest day" in {
+      val configStr = s"$WRITE_OLDEST_DAYS_FROM_TODAY_KEY = 30"
+
+      val config = ConfigFactory.parseString(configStr)
+        .withFallback(ConfigFactory.load())
+
+      val generalConfig = GeneralConfig.fromConfig(config)
+
+      assert(generalConfig.writeOldestInfoDate.contains(LocalDate.now().minusDays(30)))
+    }
+
+    "throw an exception if incompatible options are specified" in {
+      val configStr =
+        s"""$WRITE_OLDEST_RUN_DATE_KEY = "2023-12-14"
+           |$WRITE_OLDEST_DAYS_FROM_TODAY_KEY = 30
+           |""".stripMargin
+
+      val config = ConfigFactory.parseString(configStr)
+        .withFallback(ConfigFactory.load())
+
+      val ex = intercept[IllegalArgumentException] {
+        GeneralConfig.fromConfig(config)
+      }
+
+      assert(ex.getMessage.contains(s"Incompatible options used. Please, use only one of: $WRITE_OLDEST_RUN_DATE_KEY, $WRITE_OLDEST_DAYS_FROM_TODAY_KEY"))
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/config/InfoDateOverrideSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/config/InfoDateOverrideSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.LocalDate
+
+class InfoDateOverrideSuite extends AnyWordSpec {
+  "fromConfig" should {
+    "return all None for an empty config" in {
+      val conf = ConfigFactory.empty()
+      val infoDateOverride = InfoDateOverride.fromConfig(conf)
+
+      assert(infoDateOverride.columnName.isEmpty)
+      assert(infoDateOverride.dateFormat.isEmpty)
+      assert(infoDateOverride.expression.isEmpty)
+      assert(infoDateOverride.startDate.isEmpty)
+    }
+
+    "return the configuration when keys are set" in {
+      val confStr =
+        s"""information.date.column = "dummy_col"
+           |information.date.format = "dummy_format"
+           |information.date.expression = "dummy_expr"
+           |information.date.start = "2020-01-31"
+           |""".stripMargin
+
+      val conf = ConfigFactory.parseString(confStr)
+
+      val infoDateOverride = InfoDateOverride.fromConfig(conf)
+
+      assert(infoDateOverride.columnName.contains("dummy_col"))
+      assert(infoDateOverride.dateFormat.contains("dummy_format"))
+      assert(infoDateOverride.expression.contains("dummy_expr"))
+      assert(infoDateOverride.startDate.contains(LocalDate.parse("2020-01-31")))
+    }
+
+    "support days behind" in {
+      val confStr = "information.date.max.days.behind = 20"
+
+      val conf = ConfigFactory.parseString(confStr)
+
+      val infoDateOverride = InfoDateOverride.fromConfig(conf)
+
+      assert(infoDateOverride.startDate.contains(LocalDate.now().minusDays(20)))
+    }
+
+    "fail on incompatible options" in {
+      val confStr =
+        s"""information.date.start = "2020-01-31"
+           |information.date.max.days.behind = 20
+           |""".stripMargin
+
+      val conf = ConfigFactory.parseString(confStr)
+
+      val ex = intercept[IllegalArgumentException] {
+        InfoDateOverride.fromConfig(conf)
+      }
+
+      assert(ex.getMessage == "Incompatible options used. Please, use only one of: information.date.start, information.date.max.days.behind.")
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/AppContextFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/fixtures/AppContextFixture.scala
@@ -18,11 +18,11 @@ package za.co.absa.pramen.core.fixtures
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.sql.SparkSession
-import za.co.absa.pramen.core.AppContextFactory
 import za.co.absa.pramen.core.app.AppContext
 import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, BookkeeperNull}
 import za.co.absa.pramen.core.journal.{Journal, JournalNull}
 import za.co.absa.pramen.core.utils.ResourceUtils
+import za.co.absa.pramen.core.{AppContextFactory, InfoDateConfigFactory}
 
 trait AppContextFixture {
 
@@ -61,8 +61,9 @@ trait AppContextFixture {
       .withFallback(ConfigFactory.load())
       .resolve()
 
+    val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
     val journal: Journal = new JournalNull()
-    val context = AppContextFactory.createMockAppContext(conf, bookkeeper, journal)(spark)
+    val context = AppContextFactory.createMockAppContext(conf, infoDateConfig, bookkeeper, journal)(spark)
 
     f(context)
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
@@ -484,10 +485,11 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
     val conf = ConfigFactory.parseString(
       confString
-    )
+    ).withFallback(ConfigFactory.load())
 
+    val infoDateConfig = InfoDateConfig.fromConfig(conf)
     val bk = new SyncBookkeeperMock
     val mm = new MetadataManagerNull(isPersistenceEnabled = false)
-    (MetastoreImpl.fromConfig(conf, bk, mm), bk)
+    (MetastoreImpl.fromConfig(conf, infoDateConfig, bk, mm), bk)
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -19,6 +19,7 @@ package za.co.absa.pramen.core.metastore.model
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.api.DataFormat.Parquet
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates
 
@@ -59,7 +60,9 @@ class MetaTableSuite extends AnyWordSpec {
           |]
           |""".stripMargin)
 
-      val metaTables = MetaTable.fromConfig(conf, "pramen.metastore.tables")
+      val infoDateConfig = InfoDateConfig.fromConfig(conf.withFallback(ConfigFactory.load()))
+
+      val metaTables = MetaTable.fromConfig(conf, infoDateConfig, "pramen.metastore.tables")
 
       assert(metaTables.size == 4)
       assert(metaTables.head.name == "table1")
@@ -90,7 +93,9 @@ class MetaTableSuite extends AnyWordSpec {
           |pramen.hive.api = sql
           |""".stripMargin)
 
-      val metaTables = MetaTable.fromConfig(conf, "pramen.metastore.tables")
+      val infoDateConfig = InfoDateConfig.fromConfig(conf.withFallback(ConfigFactory.load()))
+
+      val metaTables = MetaTable.fromConfig(conf, infoDateConfig, "pramen.metastore.tables")
 
       assert(metaTables.isEmpty)
     }
@@ -121,9 +126,10 @@ class MetaTableSuite extends AnyWordSpec {
           |  }
           |]
           |""".stripMargin)
+      val infoDateConfig = InfoDateConfig.fromConfig(conf.withFallback(ConfigFactory.load()))
 
       val ex = intercept[IllegalArgumentException] {
-        MetaTable.fromConfig(conf, "pramen.metastore.tables")
+        MetaTable.fromConfig(conf, infoDateConfig, "pramen.metastore.tables")
       }
 
       assert(ex.getMessage.contains("Duplicate table definitions in the metastore: TABLE1"))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/AppContextMock.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/AppContextMock.scala
@@ -18,10 +18,10 @@ package za.co.absa.pramen.core.mocks
 
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.apache.spark.sql.SparkSession
-import za.co.absa.pramen.core.AppContextFactory
 import za.co.absa.pramen.core.journal.JournalNull
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.utils.ResourceUtils
+import za.co.absa.pramen.core.{AppContextFactory, InfoDateConfigFactory}
 
 object AppContextMock {
   def initAppContext(confInOpt: Option[Config] = None)(implicit spark: SparkSession): Unit = {
@@ -44,8 +44,9 @@ object AppContextMock {
 
     val bookkeeper = new SyncBookkeeperMock
     val journal = new JournalNull
+    val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
 
-    AppContextFactory.createMockAppContext(conf, bookkeeper, journal)
+    AppContextFactory.createMockAppContext(conf, infoDateConfig, bookkeeper, journal)
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationTypeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/OperationTypeSuite.scala
@@ -19,6 +19,7 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.api.Query.Table
+import za.co.absa.pramen.core.InfoDateConfigFactory
 import za.co.absa.pramen.core.pipeline.OperationType.{Ingestion, Transformation}
 
 class OperationTypeSuite extends AnyWordSpec {
@@ -37,7 +38,8 @@ class OperationTypeSuite extends AnyWordSpec {
            |""".stripMargin
       )
 
-      val opType = OperationType.fromConfig(conf, conf, "path").asInstanceOf[Ingestion]
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
+      val opType = OperationType.fromConfig(conf, conf, infoDateConfig, "path").asInstanceOf[Ingestion]
 
       assert(opType.sourceName == "jdbc1")
       assert(opType.sourceTables.size == 1)
@@ -53,7 +55,8 @@ class OperationTypeSuite extends AnyWordSpec {
            |""".stripMargin
       )
 
-      val opType = OperationType.fromConfig(conf, conf, "path").asInstanceOf[Transformation]
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
+      val opType = OperationType.fromConfig(conf, conf, infoDateConfig, "path").asInstanceOf[Transformation]
 
       assert(opType.clazz == "myclass")
     }
@@ -72,7 +75,8 @@ class OperationTypeSuite extends AnyWordSpec {
            |""".stripMargin
       )
 
-      val opType = OperationType.fromConfig(conf, conf, "path").asInstanceOf[OperationType.Sink]
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
+      val opType = OperationType.fromConfig(conf, conf, infoDateConfig, "path").asInstanceOf[OperationType.Sink]
 
       assert(opType.sinkName == "kafka1")
       assert(opType.sinkTables.size == 1)
@@ -92,7 +96,8 @@ class OperationTypeSuite extends AnyWordSpec {
            |""".stripMargin
       )
 
-      val opType = OperationType.fromConfig(conf, appConfig, "path").asInstanceOf[Transformation]
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
+      val opType = OperationType.fromConfig(conf, appConfig, infoDateConfig, "path").asInstanceOf[Transformation]
 
       assert(opType.clazz == "myclass")
     }
@@ -104,8 +109,10 @@ class OperationTypeSuite extends AnyWordSpec {
            |""".stripMargin
       )
 
+      val infoDateConfig = InfoDateConfigFactory.getDummyInfoDateConfig()
+
       val ex = intercept[IllegalArgumentException] {
-        OperationType.fromConfig(conf, conf, "path").asInstanceOf[Transformation]
+        OperationType.fromConfig(conf, conf, infoDateConfig, "path").asInstanceOf[Transformation]
       }
 
       assert(ex.getMessage.contains("Missing either path.type or pramen.default.operation.type"))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransferTableSuite.scala
@@ -19,6 +19,7 @@ package za.co.absa.pramen.core.pipeline
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.api.{DataFormat, Query}
+import za.co.absa.pramen.core.app.config.InfoDateConfig
 
 import java.time.LocalDate
 
@@ -73,7 +74,8 @@ class TransferTableSuite extends AnyWordSpec {
           |""".stripMargin)
         .withFallback(ConfigFactory.load())
 
-      val tables = TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+      val infoDateConfig = InfoDateConfig.fromConfig(conf)
+      val tables = TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
 
       assert(tables.size == 4)
 
@@ -164,8 +166,10 @@ class TransferTableSuite extends AnyWordSpec {
           |""".stripMargin)
         .withFallback(ConfigFactory.load())
 
+      val infoDateConfig = InfoDateConfig.fromConfig(conf)
+
       val ex = intercept[IllegalArgumentException] {
-        TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+        TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
       }
 
       assert(ex.getMessage.contains("Duplicate table definitions for the transfer job: db1.table1->mysink"))
@@ -182,8 +186,9 @@ class TransferTableSuite extends AnyWordSpec {
           |""".stripMargin)
         .withFallback(ConfigFactory.load())
 
+      val infoDateConfig = InfoDateConfig.fromConfig(conf)
       val ex = intercept[IllegalArgumentException] {
-        TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+        TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
       }
 
       assert(ex.getMessage.contains("Cannot determine metastore table name for 'Sql(SELECT * FROM users) -> mysink"))
@@ -223,7 +228,8 @@ class TransferTableSuite extends AnyWordSpec {
 
     "getSourceTable()" should {
       "correctly create a source table" in {
-        val tables = TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+        val infoDateConfig = InfoDateConfig.fromConfig(conf)
+        val tables = TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
 
         val sourceTable = tables.head.getSourceTable
 
@@ -242,7 +248,8 @@ class TransferTableSuite extends AnyWordSpec {
 
     "getSinkTable()" should {
       "correctly create a sink table" in {
-        val tables = TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+        val infoDateConfig = InfoDateConfig.fromConfig(conf)
+        val tables = TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
 
         val sinkTable = tables.head.getSinkTable
 
@@ -260,7 +267,8 @@ class TransferTableSuite extends AnyWordSpec {
 
     "getMetaTable()" should {
       "correctly create a metastore table" in {
-        val tables = TransferTable.fromConfig(conf, conf, "transfer.tables", "mysink")
+        val infoDateConfig = InfoDateConfig.fromConfig(conf)
+        val tables = TransferTable.fromConfig(conf, infoDateConfig, "transfer.tables", "mysink")
 
         val metaTable = tables.head.getMetaTable
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
@@ -34,7 +34,7 @@ import za.co.absa.pramen.core.pipeline.{IngestionJob, Job, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunnerImpl
 import za.co.absa.pramen.core.runner.task.{RunStatus, TaskRunnerMultithreaded}
 import za.co.absa.pramen.core.utils.LocalFsUtils
-import za.co.absa.pramen.core.{OperationDefFactory, RuntimeConfigFactory}
+import za.co.absa.pramen.core.{AppConfigFactory, OperationDefFactory, RuntimeConfigFactory}
 
 import java.io.File
 import java.time.LocalDate
@@ -128,6 +128,7 @@ class SourceValidationSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
 
   def getIngestionUseCase(runDateIn: LocalDate = runDate, sourceName: String = "source_mock1"): (ConcurrentJobRunnerImpl, Bookkeeper, PipelineStateSpy, Job) = {
     val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(runDate = runDateIn)
+    val appConfig = AppConfigFactory.getDummyAppConfig(runtimeConfig = runtimeConfig)
 
     val metastore = new MetastoreSpy()
     val bookkeeper = new SyncBookkeeperMock
@@ -156,7 +157,7 @@ class SourceValidationSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
 
     val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, journal, tokenLockFactory, state, runtimeConfig, "app_123")
 
-    val jobRunner = new ConcurrentJobRunnerImpl(runtimeConfig, bookkeeper, taskRunner, "app_123")
+    val jobRunner = new ConcurrentJobRunnerImpl(appConfig, bookkeeper, taskRunner, "app_123")
 
     (jobRunner, bookkeeper, state, job)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SourceValidationSuite.scala
@@ -34,7 +34,7 @@ import za.co.absa.pramen.core.pipeline.{IngestionJob, Job, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunnerImpl
 import za.co.absa.pramen.core.runner.task.{RunStatus, TaskRunnerMultithreaded}
 import za.co.absa.pramen.core.utils.LocalFsUtils
-import za.co.absa.pramen.core.{AppConfigFactory, OperationDefFactory, RuntimeConfigFactory}
+import za.co.absa.pramen.core.{OperationDefFactory, RuntimeConfigFactory}
 
 import java.io.File
 import java.time.LocalDate
@@ -128,7 +128,6 @@ class SourceValidationSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
 
   def getIngestionUseCase(runDateIn: LocalDate = runDate, sourceName: String = "source_mock1"): (ConcurrentJobRunnerImpl, Bookkeeper, PipelineStateSpy, Job) = {
     val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(runDate = runDateIn)
-    val appConfig = AppConfigFactory.getDummyAppConfig(runtimeConfig = runtimeConfig)
 
     val metastore = new MetastoreSpy()
     val bookkeeper = new SyncBookkeeperMock
@@ -157,7 +156,7 @@ class SourceValidationSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
 
     val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, journal, tokenLockFactory, state, runtimeConfig, "app_123")
 
-    val jobRunner = new ConcurrentJobRunnerImpl(appConfig, bookkeeper, taskRunner, "app_123")
+    val jobRunner = new ConcurrentJobRunnerImpl(runtimeConfig, bookkeeper, taskRunner, "app_123")
 
     (jobRunner, bookkeeper, state, job)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/NotificationTargetManagerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/NotificationTargetManagerSuite.scala
@@ -104,7 +104,7 @@ class NotificationTargetManagerSuite extends AnyWordSpec with SparkTestBase {
     }
 
     "decode skipped" in {
-      assert(NotificationTargetManager.runStatusToTaskStatus(RunStatus.Skipped("msg")).contains(TaskStatus.Skipped("msg")))
+      assert(NotificationTargetManager.runStatusToTaskStatus(RunStatus.Skipped("msg", isWarning = true)).contains(TaskStatus.Skipped("msg")))
     }
 
     "decode not ran" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/pipeline/PipelineNotificationBuilderHtmlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/notify/pipeline/PipelineNotificationBuilderHtmlSuite.scala
@@ -22,11 +22,9 @@ import za.co.absa.pramen.api.notification.NotificationEntry.Paragraph
 import za.co.absa.pramen.api.notification._
 import za.co.absa.pramen.core.exceptions.{CmdFailedException, ProcessFailedException}
 import za.co.absa.pramen.core.fixtures.TextComparisonFixture
-import za.co.absa.pramen.core.metastore.model.MetastoreDependency
 import za.co.absa.pramen.core.mocks.{SchemaDifferenceFactory, TaskResultFactory, TestPrototypes}
 import za.co.absa.pramen.core.notify.message.{MessageBuilderHtml, ParagraphBuilder}
 import za.co.absa.pramen.core.notify.pipeline.PipelineNotificationBuilderHtml
-import za.co.absa.pramen.core.pipeline.DependencyFailure
 import za.co.absa.pramen.core.runner.task.{NotificationFailure, RunStatus}
 import za.co.absa.pramen.core.utils.ResourceUtils
 
@@ -276,7 +274,15 @@ class PipelineNotificationBuilderHtmlSuite extends AnyWordSpec with TextComparis
 
       val actual = builder.getStatus(TaskResultFactory.getDummyTaskResult(runStatus = RunStatus.Skipped("dummy")))
 
-      assert(actual ==TextElement("Skipped", Style.Success))
+      assert(actual == TextElement("Skipped", Style.Success))
+    }
+
+    "work for skipped with warnings" in {
+      val builder = getBuilder
+
+      val actual = builder.getStatus(TaskResultFactory.getDummyTaskResult(runStatus = RunStatus.Skipped("dummy", isWarning = true)))
+
+      assert(actual == TextElement("Skipped", Style.Warning))
     }
 
     "work for not ran" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/AppRunnerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/AppRunnerSuite.scala
@@ -142,6 +142,12 @@ class AppRunnerSuite extends AnyWordSpec with SparkTestBase {
     }
   }
 
+  "validatePipeline" should {
+    "return success when the pipeline is okay" in {
+
+    }
+  }
+
   "createAppContext()" should {
     "be able to initialize proper application context" in {
       implicit val conf: Config = getTestConfig()

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/AppRunnerSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/AppRunnerSuite.scala
@@ -172,23 +172,6 @@ class AppRunnerSuite extends AnyWordSpec with SparkTestBase {
       assert(attempt.failed.get.getCause.getMessage == "No jobs defined in the pipeline. Please, define one or more operations.")
     }
 
-    "throw when the run date is before the start information date" in {
-      implicit val appContext: AppContext = mock(classOf[AppContext])
-      implicit val state: PipelineState = getMockPipelineState
-      implicit val jobs: Seq[Job] = Seq(new JobSpy)
-
-      val minDate = LocalDate.parse("2023-11-12")
-      val generalConfig = GeneralConfigFactory.getDummyGeneralConfig(writeOldestInfoDate = Some(minDate))
-      val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(runDate = LocalDate.parse("2023-11-11"))
-
-      when(appContext.appConfig).thenReturn(AppConfigFactory.getDummyAppConfig(generalConfig = generalConfig, runtimeConfig = runtimeConfig))
-
-      val attempt = AppRunner.validatePipeline
-
-      assert(attempt.isFailure)
-      assert(attempt.failed.get.getCause.getMessage == "The requested run date '2023-11-11' is older than the minimum allowed write date '2023-11-12'.")
-    }
-
     "throw when the run date is before the minimum allowed write date date" in {
       implicit val appContext: AppContext = mock(classOf[AppContext])
       implicit val state: PipelineState = getMockPipelineState

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
@@ -32,7 +32,7 @@ import za.co.absa.pramen.core.pipeline.{Job, RunResult}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunnerImpl
 import za.co.absa.pramen.core.runner.task.RunStatus.{Failed, Succeeded}
 import za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded
-import za.co.absa.pramen.core.{OperationDefFactory, RuntimeConfigFactory}
+import za.co.absa.pramen.core.{AppConfigFactory, OperationDefFactory, RuntimeConfigFactory}
 
 import java.time.{Instant, LocalDate, Duration => Dur}
 
@@ -180,6 +180,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
     val conf = ConfigFactory.empty()
 
     val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(isRerun = isRerun, runDate = runDateIn, parallelTasks = parallelTasks)
+    val appConfig = AppConfigFactory.getDummyAppConfig(runtimeConfig = runtimeConfig)
 
     val bookkeeper = new SyncBookkeeperMock
     val journal = new JournalMock
@@ -196,7 +197,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
 
     val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, journal, tokenLockFactory, state, runtimeConfig, "app_123")
 
-    val jobRunner = new ConcurrentJobRunnerImpl(runtimeConfig, bookkeeper, taskRunner, "app_123")
+    val jobRunner = new ConcurrentJobRunnerImpl(appConfig, bookkeeper, taskRunner, "app_123")
 
     (jobRunner, bookkeeper, state, job)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/jobrunner/TaskRunnerMultithreadedSuite.scala
@@ -32,7 +32,7 @@ import za.co.absa.pramen.core.pipeline.{Job, RunResult}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunnerImpl
 import za.co.absa.pramen.core.runner.task.RunStatus.{Failed, Succeeded}
 import za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded
-import za.co.absa.pramen.core.{AppConfigFactory, OperationDefFactory, RuntimeConfigFactory}
+import za.co.absa.pramen.core.{OperationDefFactory, RuntimeConfigFactory}
 
 import java.time.{Instant, LocalDate, Duration => Dur}
 
@@ -180,7 +180,6 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
     val conf = ConfigFactory.empty()
 
     val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(isRerun = isRerun, runDate = runDateIn, parallelTasks = parallelTasks)
-    val appConfig = AppConfigFactory.getDummyAppConfig(runtimeConfig = runtimeConfig)
 
     val bookkeeper = new SyncBookkeeperMock
     val journal = new JournalMock
@@ -197,7 +196,7 @@ class TaskRunnerMultithreadedSuite extends AnyWordSpec with SparkTestBase {
 
     val taskRunner = new TaskRunnerMultithreaded(conf, bookkeeper, journal, tokenLockFactory, state, runtimeConfig, "app_123")
 
-    val jobRunner = new ConcurrentJobRunnerImpl(appConfig, bookkeeper, taskRunner, "app_123")
+    val jobRunner = new ConcurrentJobRunnerImpl(runtimeConfig, bookkeeper, taskRunner, "app_123")
 
     (jobRunner, bookkeeper, state, job)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/splitter/ScheduleStrategySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/splitter/ScheduleStrategySuite.scala
@@ -148,7 +148,8 @@ class ScheduleStrategySuite extends AnyWordSpec {
 
           val result = strategy.getDaysToRun(outputTable, dependencies, bk, infoDateExpression, schedule, params, initialSourcingDateExpr, minimumDate)
 
-          assert(result.isEmpty)
+          assert(result.length == 1)
+          assert(result.head.reason.isInstanceOf[TaskRunReason.Skip])
         }
       }
 
@@ -536,7 +537,8 @@ class ScheduleStrategySuite extends AnyWordSpec {
 
           val result = strategy.getDaysToRun(outputTable, dependencies, bk, infoDateExpression, schedule, params, initialSourcingDateExpr, minimumDate)
 
-          assert(result.isEmpty)
+          assert(result.length == 1)
+          assert(result.head.reason.isInstanceOf[TaskRunReason.Skip])
         }
       }
 

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
     "com.typesafe.slick"   %% "slick-hikaricp"             % slickVersion,
     "org.postgresql"       %  "postgresql"                 % postgreSqlDriverVersion,
     "com.github.scopt"     %% "scopt"                      % scoptVersion,
-    "com.github.yruslan"   %% "channel_scala"              % channelsVersion,
+    "com.github.yruslan"   %% "channel_scala"              % channelVersion,
     "org.apache.kafka"     %  "kafka-clients"              % kafkaClientVersion,
     "com.sun.mail"         %  "javax.mail"                 % javaXMailVersion,
     "com.lihaoyi"          %% "requests"                   % requestsVersion,

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -28,7 +28,7 @@ object Versions {
   val hsqlDbVersion = "2.7.1"
   val slickVersion = "3.3.3"
   val scoptVersion = "3.7.1"
-  val channelsVersion = "0.1.5"
+  val channelVersion = "0.1.6"
   val requestsVersion = "0.8.0"
   val kafkaClientVersion = "2.5.1"
   val javaXMailVersion = "1.6.2"


### PR DESCRIPTION
Closes #286

When some of jobs ran for the info date that is older than the start date:
![Screenshot 2023-12-05 at 9 59 37](https://github.com/AbsaOSS/pramen/assets/4082463/ee5c43a6-c39b-4c2d-9354-55365b319641)

When the pipeline is attempted to ran for a date that is older than the minimum date, the following exception will be thrown:
![Screenshot 2023-12-05 at 9 59 20](https://github.com/AbsaOSS/pramen/assets/4082463/fbb78304-790f-4237-a6a6-d2bcfb28e903)
