### PR TITLE
#312 Fix the requirement of 'information.date.format.sql' to be present for the JDBC source.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -59,7 +59,7 @@ object TableReaderJdbcConfig {
     if (hasInformationDate) {
       ConfigUtils.validatePathsExistence(conf,
         parent,
-        INFORMATION_DATE_COLUMN :: INFORMATION_DATE_TYPE :: INFORMATION_DATE_APP_FORMAT :: INFORMATION_DATE_SQL_FORMAT :: Nil)
+        INFORMATION_DATE_COLUMN :: INFORMATION_DATE_TYPE :: Nil)
     }
 
     val saveTimestampsAsDates = ConfigUtils.getOptionBoolean(conf, JDBC_TIMESTAMPS_AS_DATES).getOrElse(false)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -99,6 +99,48 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
       assert(jdbc.correctDecimalsInSchema)
     }
 
+    "ensure jdbc minimal snapshot configuration works" in {
+      val testConfig = ConfigFactory.parseString(
+        s"""reader {
+           |  jdbc {
+           |    driver = "$driver"
+           |    connection.string = "$url"
+           |    user = "$user"
+           |    password = "$password"
+           |  }
+           |
+           |  has.information.date.column = false
+           |}""".stripMargin)
+      val reader = TableReaderJdbc(testConfig.getConfig("reader"), "reader")
+
+      val jdbc = reader.getJdbcConfig
+
+      assert(!jdbc.hasInfoDate)
+    }
+
+    "ensure jdbc minimal event configuration works" in {
+      val testConfig = ConfigFactory.parseString(
+        s"""reader {
+           |  jdbc {
+           |    driver = "$driver"
+           |    connection.string = "$url"
+           |    user = "$user"
+           |    password = "$password"
+           |  }
+           |
+           |  has.information.date.column = true
+           |  information.date.column = "sync_date"
+           |  information.date.type = "date"
+           |}""".stripMargin)
+      val reader = TableReaderJdbc(testConfig.getConfig("reader"), "reader")
+
+      val jdbc = reader.getJdbcConfig
+
+      assert(jdbc.hasInfoDate)
+      assert(jdbc.infoDateColumn == "sync_date")
+      assert(jdbc.infoDateType == "date")
+    }
+
     "getWithRetry" should {
       "return the successful dataframe on the second try" in {
         val readerConfig = conf.getConfig("reader")


### PR DESCRIPTION
Closes #312 