### PR TITLE
#314 make `information.date.sql.format`obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2120,8 +2120,7 @@ pramen.sources = [
     has.information.date.column = true
     information.date.column = "info_date"
     information.date.type = "date"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   }
 ]
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -41,7 +41,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
 
   private val jdbcRetries = jdbcReaderConfig.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
 
-  private val infoDateFormatter = DateTimeFormatter.ofPattern(jdbcReaderConfig.infoDateFormatApp)
+  private val infoDateFormatter = DateTimeFormatter.ofPattern(jdbcReaderConfig.infoDateFormat)
 
   logConfiguration()
 
@@ -210,7 +210,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
       case Some(infoDateType) =>
         SqlConfig(jdbcReaderConfig.infoDateColumn,
           infoDateType,
-          jdbcReaderConfig.infoDateFormatApp)
+          jdbcReaderConfig.infoDateFormat)
       case None => throw new IllegalArgumentException(s"Unknown info date type specified (${jdbcReaderConfig.infoDateType}). " +
         s"It should be one of: date, string, number")
     }
@@ -232,7 +232,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
     if (jdbcReaderConfig.hasInfoDate) {
       log.info(s"Info date column name:        ${jdbcReaderConfig.infoDateColumn}")
       log.info(s"Info date column data type:   ${jdbcReaderConfig.infoDateType}")
-      log.info(s"Info date format:             ${jdbcReaderConfig.infoDateFormatApp}")
+      log.info(s"Info date format:             ${jdbcReaderConfig.infoDateFormat}")
     }
     log.info(s"Save timestamp as dates:      ${jdbcReaderConfig.saveTimestampsAsDates}")
     log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -210,7 +210,6 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
       case Some(infoDateType) =>
         SqlConfig(jdbcReaderConfig.infoDateColumn,
           infoDateType,
-          jdbcReaderConfig.infoDateFormatSql,
           jdbcReaderConfig.infoDateFormatApp)
       case None => throw new IllegalArgumentException(s"Unknown info date type specified (${jdbcReaderConfig.infoDateType}). " +
         s"It should be one of: date, string, number")
@@ -233,8 +232,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
     if (jdbcReaderConfig.hasInfoDate) {
       log.info(s"Info date column name:        ${jdbcReaderConfig.infoDateColumn}")
       log.info(s"Info date column data type:   ${jdbcReaderConfig.infoDateType}")
-      log.info(s"Info date format (SQL):       ${jdbcReaderConfig.infoDateFormatSql}")
-      log.info(s"Info date format (App):       ${jdbcReaderConfig.infoDateFormatApp}")
+      log.info(s"Info date format:             ${jdbcReaderConfig.infoDateFormatApp}")
     }
     log.info(s"Save timestamp as dates:      ${jdbcReaderConfig.saveTimestampsAsDates}")
     log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -20,17 +20,16 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{Query, TableReader}
-import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.reader.model.JdbcConfig
-import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig.INFORMATION_DATE_APP_FORMAT
-import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils, TimeUtils}
+import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig.getInfoDateFormat
+import za.co.absa.pramen.core.utils.{JdbcNativeUtils, TimeUtils}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDate}
 
 class TableReaderJdbcNative(jdbcConfig: JdbcConfig,
                             jdbcUrlSelector: JdbcUrlSelector,
-                            infoDateFormatPattern: String)
+                            val infoDateFormatPattern: String)
                            (implicit spark: SparkSession) extends TableReader {
   import TableReaderJdbcNative._
 
@@ -89,7 +88,8 @@ object TableReaderJdbcNative {
            (implicit spark: SparkSession): TableReaderJdbcNative = {
     val jdbcConfig = JdbcConfig.load(conf, parent)
     val urlSelector = JdbcUrlSelector(jdbcConfig)
-    val infoDateFormat = ConfigUtils.getOptionString(conf, INFORMATION_DATE_APP_FORMAT).getOrElse(DEFAULT_DATE_FORMAT)
+
+    val infoDateFormat = getInfoDateFormat(conf)
 
     new TableReaderJdbcNative(jdbcConfig, urlSelector, infoDateFormat)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -26,7 +26,6 @@ case class TableReaderJdbcConfig(
                                   infoDateColumn: String,
                                   infoDateType: String,
                                   infoDateFormatApp: String = "yyyy-MM-dd",
-                                  infoDateFormatSql: String = "YYYY-MM-DD",
                                   limitRecords: Option[Int] = None,
                                   saveTimestampsAsDates: Boolean = false,
                                   correctDecimalsInSchema: Boolean = false,
@@ -42,7 +41,6 @@ object TableReaderJdbcConfig {
   val INFORMATION_DATE_COLUMN = "information.date.column"
   val INFORMATION_DATE_TYPE = "information.date.type"
   val INFORMATION_DATE_APP_FORMAT = "information.date.app.format"
-  val INFORMATION_DATE_SQL_FORMAT = "information.date.sql.format"
 
   val JDBC_SYNC_LIMIT_RECORDS = "limit.records"
   val JDBC_TIMESTAMPS_AS_DATES = "save.timestamps.as.dates"
@@ -74,7 +72,6 @@ object TableReaderJdbcConfig {
       infoDateColumn = ConfigUtils.getOptionString(conf, INFORMATION_DATE_COLUMN).getOrElse(""),
       infoDateType = ConfigUtils.getOptionString(conf, INFORMATION_DATE_TYPE).getOrElse("date"),
       infoDateFormatApp = ConfigUtils.getOptionString(conf, INFORMATION_DATE_APP_FORMAT).getOrElse("yyyy-MM-dd"),
-      infoDateFormatSql = ConfigUtils.getOptionString(conf, INFORMATION_DATE_SQL_FORMAT).getOrElse("YYYY-MM-DD"),
       limitRecords = ConfigUtils.getOptionInt(conf, JDBC_SYNC_LIMIT_RECORDS),
       saveTimestampsAsDates,
       correctDecimalsInSchema = ConfigUtils.getOptionBoolean(conf, CORRECT_DECIMALS_IN_SCHEMA).getOrElse(false),

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -25,7 +25,7 @@ case class TableReaderJdbcConfig(
                                   hasInfoDate: Boolean,
                                   infoDateColumn: String,
                                   infoDateType: String,
-                                  infoDateFormatApp: String = "yyyy-MM-dd",
+                                  infoDateFormat: String = "yyyy-MM-dd",
                                   limitRecords: Option[Int] = None,
                                   saveTimestampsAsDates: Boolean = false,
                                   correctDecimalsInSchema: Boolean = false,
@@ -40,6 +40,7 @@ object TableReaderJdbcConfig {
   val HAS_INFO_DATE = "has.information.date.column"
   val INFORMATION_DATE_COLUMN = "information.date.column"
   val INFORMATION_DATE_TYPE = "information.date.type"
+  val INFORMATION_DATE_FORMAT = "information.date.format"
   val INFORMATION_DATE_APP_FORMAT = "information.date.app.format"
 
   val JDBC_SYNC_LIMIT_RECORDS = "limit.records"
@@ -66,12 +67,14 @@ object TableReaderJdbcConfig {
       log.warn(s"An obsolete flag '$JDBC_TIMESTAMPS_AS_DATES' is used. Please, use inline column transformations instead ('transformations = { ... }').")
     }
 
+    val infoDateFormat = getInfoDateFormat(conf)
+
     TableReaderJdbcConfig(
       jdbcConfig = JdbcConfig.load(conf, parent),
       hasInfoDate = conf.getBoolean(HAS_INFO_DATE),
       infoDateColumn = ConfigUtils.getOptionString(conf, INFORMATION_DATE_COLUMN).getOrElse(""),
       infoDateType = ConfigUtils.getOptionString(conf, INFORMATION_DATE_TYPE).getOrElse("date"),
-      infoDateFormatApp = ConfigUtils.getOptionString(conf, INFORMATION_DATE_APP_FORMAT).getOrElse("yyyy-MM-dd"),
+      infoDateFormat,
       limitRecords = ConfigUtils.getOptionInt(conf, JDBC_SYNC_LIMIT_RECORDS),
       saveTimestampsAsDates,
       correctDecimalsInSchema = ConfigUtils.getOptionBoolean(conf, CORRECT_DECIMALS_IN_SCHEMA).getOrElse(false),
@@ -79,5 +82,15 @@ object TableReaderJdbcConfig {
       enableSchemaMetadata = ConfigUtils.getOptionBoolean(conf, ENABLE_SCHEMA_METADATA_KEY).getOrElse(false),
       useJdbcNative = ConfigUtils.getOptionBoolean(conf, USE_JDBC_NATIVE).getOrElse(false)
     )
+  }
+
+  def getInfoDateFormat(conf: Config): String = {
+    if (conf.hasPath(INFORMATION_DATE_APP_FORMAT)) {
+      log.warn(s"An obsolete option is used: '$INFORMATION_DATE_APP_FORMAT'. Please, replace it with '$INFORMATION_DATE_FORMAT'.")
+      conf.getString(INFORMATION_DATE_APP_FORMAT)
+    } else if (conf.hasPath(INFORMATION_DATE_FORMAT))
+      conf.getString(INFORMATION_DATE_FORMAT)
+    else
+      "yyyy-MM-dd"
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
@@ -60,7 +60,7 @@ class JdbcSource(sourceConfig: Config,
         new TableReaderJdbc(jdbcReaderConfig, urlSelector, sourceConfig)
       case Query.Sql(sql)  =>
         log.info(s"Using TableReaderJdbcNative to read the query: $sql")
-        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig, urlSelector, jdbcReaderConfig.infoDateFormatApp)
+        new TableReaderJdbcNative(jdbcReaderConfig.jdbcConfig, urlSelector, jdbcReaderConfig.infoDateFormat)
       case q =>
         throw new IllegalArgumentException(s"Unexpected '${q.name}' spec for the JDBC reader. Only 'table' or 'sql' are supported. Config path: $sourceConfigParentPath")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api._
 import za.co.absa.pramen.core.config.Keys.KEYS_TO_REDACT
 import za.co.absa.pramen.core.reader.TableReaderSpark
+import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig.{HAS_INFO_DATE, INFORMATION_DATE_COLUMN, getInfoDateFormat}
 import za.co.absa.pramen.core.utils.{ConfigUtils, FsUtils}
 
 import java.time.LocalDate
@@ -86,9 +87,6 @@ class SparkSource(val format: Option[String],
 object SparkSource extends ExternalChannelFactory[SparkSource] {
   val FORMAT = "format"
   val SCHEMA = "schema"
-  val HAS_INFO_DATE = "has.information.date.column"
-  val INFO_COLUMN_NAME = "information.date.column"
-  val INFO_COLUMN_FORMAT = "information.date.app.format"
 
   override def apply(conf: Config, parentPath: String, spark: SparkSession): SparkSource = {
     val format = ConfigUtils.getOptionString(conf, FORMAT)
@@ -96,7 +94,7 @@ object SparkSource extends ExternalChannelFactory[SparkSource] {
 
     val hasInfoDate = conf.hasPath(HAS_INFO_DATE) && conf.getBoolean(HAS_INFO_DATE)
     val (infoDateColumn, infoDateFormat) = if (hasInfoDate) {
-      (conf.getString(INFO_COLUMN_NAME), conf.getString(INFO_COLUMN_FORMAT))
+      (conf.getString(INFORMATION_DATE_COLUMN), getInfoDateFormat(conf))
     } else {
       ("", "")
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlColumnType.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlColumnType.scala
@@ -19,7 +19,6 @@ package za.co.absa.pramen.core.sql
 sealed trait SqlColumnType
 
 object SqlColumnType {
-
   case object DATE extends SqlColumnType {
     override val toString: String = "date"
   }
@@ -38,12 +37,11 @@ object SqlColumnType {
 
   def fromString(s: String): Option[SqlColumnType] = {
     s.toLowerCase() match {
-      case DATE.toString => Some(DATE)
+      case DATE.toString     => Some(DATE)
       case DATETIME.toString => Some(DATETIME)
-      case STRING.toString => Some(STRING)
-      case NUMBER.toString => Some(NUMBER)
+      case STRING.toString   => Some(STRING)
+      case NUMBER.toString   => Some(NUMBER)
       case _ => None
     }
   }
-
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
@@ -19,6 +19,5 @@ package za.co.absa.pramen.core.sql
 case class SqlConfig(
                       infoDateColumn: String,
                       infoDateType: SqlColumnType,
-                      dateFormatSql: String,
                       dateFormatApp: String
                     )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -47,15 +47,15 @@ object SqlGenerator {
 
   def fromDriverName(driver: String, sqlConfig: SqlConfig, extraConfig: Config): SqlGenerator = {
     val sqlGenerator = driver match {
-      case "org.postgresql.Driver"                        => new SqlGeneratorPostgreSQL(sqlConfig, extraConfig)
-      case "oracle.jdbc.OracleDriver"                     => new SqlGeneratorOracle(sqlConfig, extraConfig)
-      case "net.sourceforge.jtds.jdbc.Driver"             => new SqlGeneratorMicrosoft(sqlConfig, extraConfig)
-      case "com.microsoft.sqlserver.jdbc.SQLServerDriver" => new SqlGeneratorMicrosoft(sqlConfig, extraConfig)
-      case "com.denodo.vdp.jdbc.Driver"                   => new SqlGeneratorDenodo(sqlConfig, extraConfig)
-      case "com.sas.rio.MVADriver"                        => new SqlGeneratorSas(sqlConfig, extraConfig)
-      case "com.cloudera.hive.jdbc41.HS2Driver"           => new SqlGeneratorHive(sqlConfig, extraConfig)
-      case "com.simba.hive.jdbc41.HS2Driver"              => new SqlGeneratorHive(sqlConfig, extraConfig)
-      case "com.simba.spark.jdbc.Driver"                  => new SqlGeneratorHive(sqlConfig, extraConfig)
+      case "org.postgresql.Driver"                        => new SqlGeneratorPostgreSQL(sqlConfig)
+      case "oracle.jdbc.OracleDriver"                     => new SqlGeneratorOracle(sqlConfig)
+      case "net.sourceforge.jtds.jdbc.Driver"             => new SqlGeneratorMicrosoft(sqlConfig)
+      case "com.microsoft.sqlserver.jdbc.SQLServerDriver" => new SqlGeneratorMicrosoft(sqlConfig)
+      case "com.denodo.vdp.jdbc.Driver"                   => new SqlGeneratorDenodo(sqlConfig)
+      case "com.sas.rio.MVADriver"                        => new SqlGeneratorSas(sqlConfig)
+      case "com.cloudera.hive.jdbc41.HS2Driver"           => new SqlGeneratorHive(sqlConfig)
+      case "com.simba.hive.jdbc41.HS2Driver"              => new SqlGeneratorHive(sqlConfig)
+      case "com.simba.spark.jdbc.Driver"                  => new SqlGeneratorHive(sqlConfig)
       case "org.hsqldb.jdbc.JDBCDriver"                   => new SqlGeneratorHsqlDb(sqlConfig)
       case "com.ibm.db2.jcc.DB2Driver"                    => new SqlGeneratorDb2(sqlConfig)
       case d                                              =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -70,13 +70,19 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"DATE '$dateStr'"
-      case SqlColumnType.DATETIME => s"DATE '$dateStr'"
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"DATE '$dateStr'"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"DATE '$dateStr'"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
-
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -16,13 +16,10 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
-
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class SqlGeneratorDenodo(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-
+class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -55,23 +55,36 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig, extraConfig: Config) extends SqlG
     val dateBeginLit = getDateLiteral(dateBegin)
     val dateEndLit = getDateLiteral(dateEnd)
 
-    val infoDateColumn = sqlConfig.infoDateColumn
+    val dateTypes: Array[SqlColumnType] = Array(SqlColumnType.DATETIME)
+
+    val infoDateColumnAdjusted =
+      if (dateTypes.contains(sqlConfig.infoDateType)) {
+        s"TO_DATE(${sqlConfig.infoDateColumn}, 'YYYY-MM-DD')"
+      } else {
+        sqlConfig.infoDateColumn
+      }
 
     if (dateBeginLit == dateEndLit) {
-      s"$infoDateColumn = $dateBeginLit"
+      s"$infoDateColumnAdjusted = $dateBeginLit"
     } else {
-      s"$infoDateColumn >= $dateBeginLit AND $infoDateColumn <= $dateEndLit"
+      s"$infoDateColumnAdjusted >= $dateBeginLit AND $infoDateColumnAdjusted <= $dateEndLit"
     }
   }
 
   def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"date'$dateStr'"
-      case SqlColumnType.DATETIME => throw new NotImplementedError("DATETIME support for Denodo is not supported yet.")
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"date'$dateStr'"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"date'$dateStr'"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -59,7 +59,7 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig, extraConfig: Config) extends SqlG
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"TO_DATE(${sqlConfig.infoDateColumn}, 'YYYY-MM-DD')"
+        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
       } else {
         sqlConfig.infoDateColumn
       }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
-
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {
@@ -76,7 +75,7 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
         s"date'$dateStr'"
       case SqlColumnType.DATETIME =>
         val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
-        s"TO_DATE('$dateStr', 'YYYY-MM-DD')"
+        s"date'$dateStr'"
       case SqlColumnType.STRING =>
         val dateStr = dateFormatterApp.format(date)
         s"'$dateStr'"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -70,13 +70,19 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.DATETIME => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"date'$dateStr'"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"TO_DATE('$dateStr', 'YYYY-MM-DD')"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.sql.impl.HiveDialect
@@ -37,8 +36,7 @@ object SqlGeneratorHive {
   }
 }
 
-class SqlGeneratorHive(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-
+class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   SqlGeneratorHive.registerDialect

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -79,13 +79,19 @@ class SqlGeneratorHive(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGen
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"to_date('$dateStr')"
-      case SqlColumnType.DATETIME => throw new NotImplementedError("DATETIME support for Denodo is not supported yet.")
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"to_date('$dateStr')"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"to_date('$dateStr')"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -69,12 +69,19 @@ class SqlGeneratorHive(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGen
     val dateBeginLit = getDateLiteral(dateBegin)
     val dateEndLit = getDateLiteral(dateEnd)
 
-    val infoDateColumn = sqlConfig.infoDateColumn
+    val dateTypes: Array[SqlColumnType] = Array(SqlColumnType.DATETIME)
+
+    val infoDateColumnAdjusted =
+      if (dateTypes.contains(sqlConfig.infoDateType)) {
+        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+      } else {
+        sqlConfig.infoDateColumn
+      }
 
     if (dateBeginLit == dateEndLit) {
-      s"$infoDateColumn = $dateBeginLit"
+      s"$infoDateColumnAdjusted = $dateBeginLit"
     } else {
-      s"$infoDateColumn >= $dateBeginLit AND $infoDateColumn <= $dateEndLit"
+      s"$infoDateColumnAdjusted >= $dateBeginLit AND $infoDateColumnAdjusted <= $dateEndLit"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
-
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -70,13 +70,19 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.DATETIME => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"TO_DATE('$dateStr', 'YYYY-MM-DD')"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"TO_DATE('$dateStr', 'YYYY-MM-DD')"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -72,13 +72,19 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig, extraConfig: Config) extends S
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"CONVERT(DATE, '$dateStr')"
-      case SqlColumnType.DATETIME => s"CONVERT(DATE, '$dateStr')"
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"CONVERT(DATE, '$dateStr')"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"CONVERT(DATE, '$dateStr')"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -16,13 +16,10 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
-
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class SqlGeneratorMicrosoft(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-
+class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
@@ -16,14 +16,10 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
-
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class SqlGeneratorOracle(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-  val ORACLE_DATE_PATTERN = "yyyy-MM-dd"
-
+class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {
@@ -96,5 +92,4 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig, extraConfig: Config) extends SqlG
       limit.map(n => s" WHERE ROWNUM <= $n").getOrElse("")
     }
   }
-
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -16,12 +16,10 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
-
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
+class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -22,7 +22,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
   override def getDtable(sql: String): String = {
@@ -72,13 +71,19 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig, extraConfig: Config) extends 
   }
 
   override def getDateLiteral(date: LocalDate): String = {
-    val dateStr = dateFormatterApp.format(date)
-
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.DATETIME => s"TO_DATE('$dateStr', '${sqlConfig.dateFormatSql}')"
-      case SqlColumnType.STRING => s"'$dateStr'"
-      case SqlColumnType.NUMBER => s"$dateStr"
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"date'$dateStr'"
+      case SqlColumnType.DATETIME =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
+        s"date'$dateStr'"
+      case SqlColumnType.STRING =>
+        val dateStr = dateFormatterApp.format(date)
+        s"'$dateStr'"
+      case SqlColumnType.NUMBER =>
+        val dateStr = dateFormatterApp.format(date)
+        s"$dateStr"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -133,10 +133,11 @@ class SqlGeneratorSas(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGene
 
   override def getDateLiteral(date: LocalDate): String = {
     sqlConfig.infoDateType match {
-      case SqlColumnType.DATE   =>
-        val dateStr = dateFormatterOracle.format(date)
+      case SqlColumnType.DATE =>
+        val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
         s"date'$dateStr'"
-      case SqlColumnType.DATETIME => throw new NotImplementedError("DATETIME support for Denodo is not supported yet.")
+      case SqlColumnType.DATETIME =>
+        throw new NotImplementedError("DATETIME support for SAS is not supported yet.")
       case SqlColumnType.STRING =>
         val dateStr = dateFormatterApp.format(date)
         s"'$dateStr'"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.pramen.core.sql
 
-import com.typesafe.config.Config
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.sql.impl.SasDialect
@@ -39,11 +38,8 @@ object SqlGeneratorSas {
   }
 }
 
-class SqlGeneratorSas(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGeneratorBase(sqlConfig) {
-  val ORACLE_DATE_PATTERN = "yyyy-MM-dd"
-
+class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
-  private val dateFormatterOracle = DateTimeFormatter.ofPattern(ORACLE_DATE_PATTERN)
 
   private var connection: Connection = _
 
@@ -150,5 +146,4 @@ class SqlGeneratorSas(sqlConfig: SqlConfig, extraConfig: Config) extends SqlGene
   private def getLimit(limit: Option[Int], hasWhere: Boolean): String = {
     limit.map(n => s" LIMIT $n").getOrElse("")
   }
-
 }

--- a/pramen/core/src/test/resources/test/config/pipeline_v3.conf
+++ b/pramen/core/src/test/resources/test/config/pipeline_v3.conf
@@ -107,8 +107,7 @@ pramen.sources.2 = [
     has.information.date.column = true
     information.date.column = "info_date"
     information.date.type = "string"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   },
 ]
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
@@ -21,11 +21,9 @@ import za.co.absa.pramen.core.sql.{SqlColumnType, SqlConfig}
 object DummySqlConfigFactory {
   def getDummyConfig(infoDateColumn: String = "col",
                      infoDateType: SqlColumnType = SqlColumnType.DATE,
-                     dateFormatSql: String = "YYYY-MM-DD",
                      dateFormatApp: String = "yyyy-MM-dd"
                     ): SqlConfig = SqlConfig(
     infoDateColumn = infoDateColumn,
     infoDateType = infoDateType,
-    dateFormatSql = dateFormatSql,
     dateFormatApp = dateFormatApp)
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/IngestionJobSuite.scala
@@ -73,8 +73,7 @@ class IngestionJobSuite extends AnyWordSpec with SparkTestBase with TextComparis
        |      has.information.date.column = true
        |      information.date.column = "info_date"
        |      information.date.type = "string"
-       |      information.date.app.format = "yyyy-MM-dd"
-       |      information.date.sql.format = "YYYY-MM-DD"
+       |      information.date.format = "yyyy-MM-dd"
        |    },
        |  ]
        | }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/JdbcSourceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/JdbcSourceSuite.scala
@@ -63,8 +63,7 @@ class JdbcSourceSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestB
        |      has.information.date.column = true
        |      information.date.column = "INFO_DATE"
        |      information.date.type = "date"
-       |      information.date.app.format = "yyyy-MM-dd"
-       |      information.date.sql.format = "YYYY-mm-DD"
+       |      information.date.format = "yyyy-MM-dd"
        |      use.jdbc.native = true
        |    },
        |    {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/LocalSparkSourceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/LocalSparkSourceSuite.scala
@@ -26,7 +26,7 @@ import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.TempDirFixture
 import za.co.absa.pramen.core.utils.LocalFsUtils
 
-import java.io.{File, IOException}
+import java.io.File
 import java.nio.file.Paths
 import java.time.LocalDate
 
@@ -68,8 +68,7 @@ class LocalSparkSourceSuite extends AnyWordSpec with BeforeAndAfterAll with Temp
        |      has.information.date.column = true
        |      information.date.column = "INFO_DATE"
        |      information.date.type = "date"
-       |      information.date.app.format = "yyyy-MM-DD"
-       |      information.date.sql.format = "YYYY-mm-DD"
+       |      information.date.format = "yyyy-MM-DD"
        |    },
        |    {
        |      name = "spark2"

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SparkSourceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/SparkSourceSuite.scala
@@ -70,8 +70,7 @@ class SparkSourceSuite extends AnyWordSpec with BeforeAndAfterAll with TempDirFi
        |      has.information.date.column = true
        |      information.date.column = "INFO_DATE"
        |      information.date.type = "date"
-       |      information.date.app.format = "yyyy-MM-DD"
-       |      information.date.sql.format = "YYYY-mm-DD"
+       |      information.date.format = "yyyy-MM-DD"
        |    },
        |    {
        |      name = "spark2"

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
@@ -43,9 +43,36 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |
        |  information.date.column = "FOUNDED"
        |  information.date.type = "date"
-       |  information.date.app.format = "yyyy-MM-dd"
-       |  information.date.sql.format = "YYYY-mm-DD"
+       |  information.date.format = "YYYY-MM-dd"
        |
+       |}
+       |reader_legacy {
+       |  jdbc {
+       |    driver = "$driver"
+       |    connection.string = "$url"
+       |    user = "$user"
+       |    password = "$password"
+       |  }
+       |
+       |  has.information.date.column = true
+       |
+       |  information.date.column = "FOUNDED"
+       |  information.date.type = "date"
+       |  information.date.app.format = "yyyy-MM-DD"
+       |
+       |}
+       |reader_minimal {
+       |  jdbc {
+       |    driver = "$driver"
+       |    connection.string = "$url"
+       |    user = "$user"
+       |    password = "$password"
+       |  }
+       |
+       |  has.information.date.column = true
+       |
+       |  information.date.column = "FOUNDED"
+       |  information.date.type = "date"
        |}""".stripMargin)
 
   override protected def beforeAll(): Unit = {
@@ -63,7 +90,19 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
 
   "TableReaderJdbcNative factory" should {
     "construct a reader object" in {
-      assert(getReader != null)
+      val reader = getReader
+      assert(reader != null)
+      assert(reader.infoDateFormatPattern == "YYYY-MM-dd")
+    }
+
+    "work with legacy config" in {
+      val reader = TableReaderJdbcNative(conf.getConfig("reader_legacy"), "reader_legacy")
+      assert(reader.infoDateFormatPattern == "yyyy-MM-DD")
+    }
+
+    "work with minimal config" in {
+      val reader = TableReaderJdbcNative(conf.getConfig("reader_minimal"), "reader_minimal")
+      assert(reader.infoDateFormatPattern == "yyyy-MM-dd")
     }
 
     "throw an exception if config is missing" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -58,9 +58,35 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
          |
          |  information.date.column = "INFO_DATE"
          |  information.date.type = "number"
-         |  information.date.app.format = "yyyy-MM-DD"
-         |  information.date.sql.format = "YYYY-mm-DD"
+         |  information.date.format = "yyyy-MM-DD"
+         |}
+         |reader_legacy {
+         |  jdbc {
+         |    driver = "$driver"
+         |    connection.string = "$url"
+         |    user = "$user"
+         |    password = "$password"
+         |  }
          |
+         |  has.information.date.column = true
+         |
+         |  information.date.column = "INFO_DATE"
+         |  information.date.type = "date"
+         |  information.date.app.format = "YYYY-MM-dd"
+         |
+         |}
+         |reader_minimal {
+         |  jdbc {
+         |    driver = "$driver"
+         |    connection.string = "$url"
+         |    user = "$user"
+         |    password = "$password"
+         |  }
+         |
+         |  has.information.date.column = true
+         |
+         |  information.date.column = "INFO_DATE"
+         |  information.date.type = "date"
          |}""".stripMargin)
 
     "be able to be constructed properly from config" in {
@@ -75,8 +101,42 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
       assert(jdbc.jdbcConfig.password.contains(password))
       assert(jdbc.infoDateColumn == "INFO_DATE")
       assert(jdbc.infoDateType == "number")
-      assert(jdbc.infoDateFormatApp == "yyyy-MM-DD")
+      assert(jdbc.infoDateFormat == "yyyy-MM-DD")
       assert(!jdbc.hasInfoDate)
+      assert(!jdbc.saveTimestampsAsDates)
+    }
+
+    "be able to be constructed properly from legacy config" in {
+      val reader = TableReaderJdbc(conf.getConfig("reader_legacy"), "reader_legacy")
+
+      val jdbc = reader.getJdbcConfig
+
+      assert(jdbc.jdbcConfig.database.isEmpty)
+      assert(jdbc.jdbcConfig.driver == driver)
+      assert(jdbc.jdbcConfig.primaryUrl.get == url)
+      assert(jdbc.jdbcConfig.user.contains(user))
+      assert(jdbc.jdbcConfig.password.contains(password))
+      assert(jdbc.infoDateColumn == "INFO_DATE")
+      assert(jdbc.infoDateType == "date")
+      assert(jdbc.infoDateFormat == "YYYY-MM-dd")
+      assert(jdbc.hasInfoDate)
+      assert(!jdbc.saveTimestampsAsDates)
+    }
+
+    "be able to be constructed properly from minimal config" in {
+      val reader = TableReaderJdbc(conf.getConfig("reader_minimal"), "reader_minimal")
+
+      val jdbc = reader.getJdbcConfig
+
+      assert(jdbc.jdbcConfig.database.isEmpty)
+      assert(jdbc.jdbcConfig.driver == driver)
+      assert(jdbc.jdbcConfig.primaryUrl.get == url)
+      assert(jdbc.jdbcConfig.user.contains(user))
+      assert(jdbc.jdbcConfig.password.contains(password))
+      assert(jdbc.infoDateColumn == "INFO_DATE")
+      assert(jdbc.infoDateType == "date")
+      assert(jdbc.infoDateFormat == "yyyy-MM-dd")
+      assert(jdbc.hasInfoDate)
       assert(!jdbc.saveTimestampsAsDates)
     }
 
@@ -217,7 +277,7 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
           .withValue("has.information.date.column", ConfigValueFactory.fromAnyRef(true))
           .withValue("information.date.column", ConfigValueFactory.fromAnyRef("info_date"))
           .withValue("information.date.type", ConfigValueFactory.fromAnyRef("string"))
-          .withValue("information.date.app.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
+          .withValue("information.date.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
 
         val reader = TableReaderJdbc(testConfig, "reader")
 
@@ -240,7 +300,7 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
           .withValue("has.information.date.column", ConfigValueFactory.fromAnyRef(true))
           .withValue("information.date.column", ConfigValueFactory.fromAnyRef("info_date"))
           .withValue("information.date.type", ConfigValueFactory.fromAnyRef("string"))
-          .withValue("information.date.app.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
+          .withValue("information.date.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
 
         val reader = TableReaderJdbc(testConfig, "reader")
 
@@ -276,7 +336,7 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
           .withValue("has.information.date.column", ConfigValueFactory.fromAnyRef(true))
           .withValue("information.date.column", ConfigValueFactory.fromAnyRef("info_date"))
           .withValue("information.date.type", ConfigValueFactory.fromAnyRef("string"))
-          .withValue("information.date.app.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
+          .withValue("information.date.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
           .withValue("correct.decimals.in.schema", ConfigValueFactory.fromAnyRef(true))
 
         val reader = TableReaderJdbc(testConfig, "reader")
@@ -311,7 +371,7 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
           .withValue("has.information.date.column", ConfigValueFactory.fromAnyRef(true))
           .withValue("information.date.column", ConfigValueFactory.fromAnyRef("info_date"))
           .withValue("information.date.type", ConfigValueFactory.fromAnyRef("string"))
-          .withValue("information.date.app.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
+          .withValue("information.date.format", ConfigValueFactory.fromAnyRef("yyyy-MM-dd"))
 
         val reader = TableReaderJdbc(testConfig, "reader")
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -76,7 +76,6 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
       assert(jdbc.infoDateColumn == "INFO_DATE")
       assert(jdbc.infoDateType == "number")
       assert(jdbc.infoDateFormatApp == "yyyy-MM-DD")
-      assert(jdbc.infoDateFormatSql == "YYYY-mm-DD")
       assert(!jdbc.hasInfoDate)
       assert(!jdbc.saveTimestampsAsDates)
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -254,6 +254,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val gen = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigDate, config)
     val genStr = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigString, config)
     val genNum = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigNumber, config)
+    val genDateTime = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigDateTime, config)
 
     "generate count queries without date ranges" in {
       assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
@@ -279,6 +280,13 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
           "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
+      "date is in DATETIME format" in {
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+      }
+
       "date is in STRING format" in {
         assert(genStr.getCountQuery("A", date1, date1) ==
           "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
@@ -300,6 +308,13 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
           "SELECT * FROM A WHERE D = date'2020-08-17'")
         assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
           "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+      }
+
+      "date is in DATETIME format" in {
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
@@ -430,6 +445,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val gen = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigDate, config)
     val genStr = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigString, config)
     val genNum = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigNumber, config)
+    val genDateTime = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigDateTime, config)
 
     "generate count queries without date ranges" in {
       assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
@@ -455,6 +471,13 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
           "SELECT COUNT(*) FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
       }
 
+      "date is in DATETIME format" in {
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
+      }
+
       "date is in STRING format" in {
         assert(genStr.getCountQuery("A", date1, date1) ==
           "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
@@ -476,6 +499,13 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
           "SELECT * FROM A WHERE D = to_date('2020-08-17')")
         assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
           "SELECT * FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
+      }
+
+      "date is in DATETIME format" in {
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
       }
 
       "date is in STRING format" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -536,16 +536,16 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged count queries" when {
       "date is in DATE format" in {
         assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
         assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
         assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
         assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
@@ -566,16 +566,16 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged data queries" when {
       "date is in DATE format" in {
         assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
         assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
         assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
         assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
@@ -594,9 +594,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "with limit records" in {
         assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD') LIMIT 100")
+          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
         assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD') LIMIT 100")
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 
@@ -736,9 +736,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged count queries" when {
       "date is in DATE format" in {
         assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = date'2020-08-17'")
         assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
@@ -766,9 +766,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged data queries" when {
       "date is in DATE format" in {
         assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
         assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
@@ -794,9 +794,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "with limit records" in {
         assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD') LIMIT 100")
+          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
         assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD') LIMIT 100")
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -773,9 +773,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "date is in DATETIME format" in {
         assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
         assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
@@ -803,9 +803,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "date is in DATETIME format" in {
         assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
         assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {

--- a/pramen/examples/enceladus_single_config/daily_ingestion.conf
+++ b/pramen/examples/enceladus_single_config/daily_ingestion.conf
@@ -71,8 +71,7 @@ pramen.sources = [
 
     information.date.column = "info_date"
     information.date.type = "date"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   }
 ]
 

--- a/pramen/examples/enceladus_single_config/weekly_ingestion.conf
+++ b/pramen/examples/enceladus_single_config/weekly_ingestion.conf
@@ -72,8 +72,7 @@ pramen.sources = [
 
     information.date.column = "info_date"
     information.date.type = "date"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   }
 ]
 

--- a/pramen/examples/enceladus_sourcing/sources.conf
+++ b/pramen/examples/enceladus_sourcing/sources.conf
@@ -41,8 +41,7 @@ pramen.sources = [
 
     information.date.column = "INFORMATION_DATE"
     information.date.type = "string"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   },
   {
     name = "my_source_snapshots"

--- a/pramen/examples/ingestion_pipeline/ingestion_pipeline.conf
+++ b/pramen/examples/ingestion_pipeline/ingestion_pipeline.conf
@@ -74,9 +74,7 @@ pramen.sources = [
     information.date.column = "info_date"
     information.date.type = "date"
     # Date format in Java format notation
-    information.date.app.format = "yyyy-MM-dd"
-    # Date format in the SQL dialect notation
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   },
   {
     name = "postgre_snapshot"

--- a/pramen/examples/jdbc_sourcing/sources.conf
+++ b/pramen/examples/jdbc_sourcing/sources.conf
@@ -42,7 +42,6 @@ pramen.sources = [
 
     information.date.column = "INFORMATION_DATE"
     information.date.type = "string"
-    information.date.app.format = "yyyy-MM-dd"
-    information.date.sql.format = "YYYY-MM-DD"
+    information.date.format = "yyyy-MM-dd"
   }
 ]


### PR DESCRIPTION
Closes #314

So instead of specifying 2 options:
```hocon
# As Java format 
information.date.app.format = "yyyy-MM-dd"
# As SQL database native format
information.date.sql.format = "YYYY-MM-DD"
```

you can use only this:
```hocon
# As Java format 
information.date.format = "yyyy-MM-dd"
```

Backwards compatibility is retain since `information.date.app.format` is still supported. 