### PR TITLE
#317 Escape column names in SQL queries when it contains non-alphanumeric characters or a possible keyword.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -35,7 +35,11 @@ trait SqlGenerator {
 
   def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String
 
+  /** Returns the date literal for the dialect of the SQL. */
   def getDateLiteral(date: LocalDate): String
+
+  /** This validates and escapes an identifier if needed. Escaping does not happen always to maintain backwards compatibility. */
+  def escapeIdentifier(identifier: String): String
 
   def requiresConnection: Boolean = false
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -22,6 +22,20 @@ package za.co.absa.pramen.core.sql
   * @param sqlConfig A SQL generator configuration
   */
 abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
+  import SqlGeneratorBase._
+
+  /** This Wraps the column name with escaping characters. The escape logic varies among SQL dialects. */
+  def wrapIdentifier(identifier: String): String
+
+  /** This validates and escapes the column name is needed. Escaping does not happen always to maintain backwards compatibility. */
+  final override def escapeIdentifier(identifier: String): String = {
+    validateIdentifier(identifier)
+
+    if (identifierNeedsEscaping(identifier))
+      wrapIdentifier(identifier)
+    else
+      identifier
+  }
 
   /**
     * An expression for the list of configured columns.
@@ -31,8 +45,66 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
     if (columns.isEmpty) {
       "*"
     } else {
-      columns.mkString(", ")
+      columns.map(col => escapeIdentifier(col)) .mkString(", ")
     }
   }
 
+  /**
+    * This escapes the information date column properly.
+    */
+  final protected def infoDateColumn: String = {
+    escapeIdentifier(sqlConfig.infoDateColumn)
+  }
+}
+
+object SqlGeneratorBase {
+  val forbiddenCharacters = ";`'\"[](){}<>="
+  val normalCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+  val sqlKeywords: Set[String] = Set(
+    "ABORT", "ABS", "ABSOLUTE", "ACCESS", "ADMIN", "AFTER", "AGGREGATE", "ALIAS", "ALL", "ALLOCATE",
+    "ALSO", "ALTER", "ALWAYS", "ANALYSE", "ANALYZE", "AND", "ANY", "ARE", "ARRAY", "AS", "ASC", "ASENSITIVE", "ASSERTION",
+    "AT", "ATOMIC", "ATTRIBUTE", "ATTRIBUTES", "AUTHORIZATION", "BACKWARD", "BEFORE", "BEGIN", "BETWEEN", "BIGINT", "BINARY",
+    "BIT", "BITVAR", "BLOB", "BOOLEAN", "BOTH", "BY", "CACHE", "CALL", "CALLED", "CARDINALITY", "CASCADE", "CASCADED",
+    "CASE", "CAST", "CATALOG", "CATALOG_NAME", "CHAIN", "CHAR", "CHARACTER", "CHARACTERISTICS", "CHARACTERS", "CHARACTER_LENGTH",
+    "CHARACTER_SET_CATALOG", "CHARACTER_SET_NAME", "CHARACTER_SET_SCHEMA", "CHAR_LENGTH", "CHECK", "CHECKED", "CHECKPOINT",
+    "CLASS", "CLASS_ORIGIN", "CLOSE", "CLUSTER", "COALESCE", "COLLATE", "COLLATION", "COLLATION_CATALOG", "COLLATION_NAME",
+    "COLLATION_SCHEMA", "COLLECT", "COLUMN", "COLUMN_NAME", "COMMAND_FUNCTION", "COMMAND_FUNCTION_CODE", "COMMENT",
+    "COMMIT", "COMMITTED", "COMPLETION", "CONDITION", "CONNECT", "CONSTRAINT", "CONSTRAINTS", "CONTAINS", "CONTINUE",
+    "CONVERT", "COPY", "CORR", "COUNT", "CREATE", "CREATEDB", "CREATEROLE", "CREATEUSER", "CROSS", "CURRENT", "CURRENT_DATE",
+    "CURRENT_PATH", "CURRENT_ROLE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR", "CURSOR_NAME", "DATA",
+    "DATABASE", "DATE", "DATETIME", "DAY", "DEALLOCATE", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DEFAULTS", "DEGREE",
+    "DELETE", "DELIMITER", "DELIMITERS", "DESC", "DESCRIBE", "DESCRIPTOR", "DESTROY", "DICTIONARY", "DISABLE", "DISCONNECT",
+    "DISTINCT", "DO", "DOMAIN", "DOUBLE", "DROP", "EACH", "ELEMENT", "ELSE", "ENABLE", "ENCODING", "ENCRYPTED", "END",
+    "EQUALS", "ESCAPE", "EVERY", "EXCEPT", "EXCEPTION", "EXCLUDE", "EXCLUDING", "EXEC", "EXECUTE", "EXISTS", "EXP",
+    "EXPLAIN", "EXTERNAL", "EXTRACT", "FALSE", "FETCH", "FILTER", "FINAL", "FIRST", "FOR", "FORCE", "FREE", "FROM",
+    "FUNCTION", "GET", "GLOBAL", "GO", "GOTO", "GRANT", "GRANTED", "GROUP", "HANDLER", "HAVING", "HOLD", "HOST", "HOUR",
+    "IDENTITY", "ILIKE", "IMMEDIATE", "IN", "INCREMENT", "INDEX", "INNER", "INOUT", "INPUT", "INSENSITIVE", "INSERT", "INSTANCE",
+    "INSTEAD", "INTERSECT", "INTERSECTION", "INTERVAL", "INTO", "INVOKER", "IS", "ISNULL", "JOIN", "KEY", "KEY_MEMBER",
+    "KEY_TYPE", "LANGUAGE", "LAST", "LEAST", "LEFT", "LENGTH", "LESS", "LEVEL", "LIKE", "LIMIT", "LOAD", "LOCAL", "LOCALTIME",
+    "LOCALTIMESTAMP", "LOCATION", "LOCK", "LOGIN", "MATCH", "MAX", "MAXVALUE", "MEMBER", "MERGE", "METHOD", "MIN", "MINUTE",
+    "MODE", "MODIFIES", "MODIFY", "MODULE", "MONTH", "MORE", "MOVE", "NATIONAL", "NATURAL", "NESTING", "NEW", "NEXT", "NO",
+    "NOLOCK", "NOLOGIN", "NONE", "NORMALIZE", "NORMALIZED", "NOSUPERUSER", "NOT", "NOTHING", "NOTIFY", "NOTNULL", "NOWAIT",
+    "NULL", "NULLABLE", "NULLIF", "NULLS", "OBJECT", "OF", "OFF", "OFFSET", "OIDS", "OLD", "ON", "ONLY", "OPEN", "OPERATION",
+    "OPTION", "OPTIONS", "OR", "ORDER", "ORDERING", "OUT", "OUTPUT", "OVER", "OWNER", "PARAMETER", "PARAMETERS",
+    "PARTIAL", "PARTITION", "PASSWORD", "PATH", "POWER", "PRECEDING", "PRECISION", "PREFIX", "PREPARE", "PRESERVE", "PRIMARY",
+    "PRIOR", "PRIVILEGES", "PUBLIC", "QUOTE", "RANGE", "RANK", "READ", "READS", "RECURSIVE", "REF", "REFERENCES", "REFERENCING",
+    "RELATIVE", "RELEASE", "RENAME", "REPLACE", "RESET", "RESTART", "RESTRICT", "RESULT", "RETURN", "RETURNS", "REVOKE",
+    "RIGHT", "ROLE", "ROLLBACK", "ROW", "ROWS", "ROW_COUNT", "ROW_NUMBER", "RULE", "SAVEPOINT", "SCALE", "SCHEMA", "SCHEMA_NAME",
+    "SCOPE", "SCROLL", "SEARCH", "SECOND", "SECTION", "SECURITY", "SELECT", "SELF", "SENSITIVE", "SEQUENCE", "SERIALIZABLE",
+    "SERVER_NAME", "SESSION", "SESSION_USER", "SET", "SETOF", "SETS", "SHARE", "SHOW", "SIZE", "SOME", "SOURCE", "SPACE",
+    "SQL", "SQLCODE", "SQLERROR", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "STABLE", "START", "STATE", "STATEMENT", "STATIC",
+    "STATISTICS", "STDIN", "STDOUT", "STORAGE", "STRICT", "STRUCTURE", "STYLE", "SUBSTRING", "SUM", "SUPERUSER", "SYMMETRIC",
+    "SYSID", "SYSTEM", "SYSTEM_USER", "TABLE", "TABLESPACE", "TABLE_NAME", "TEMP", "TEMPLATE", "TEMPORARY", "TERMINATE",
+    "THAN", "THEN", "TIES", "TIME", "TIMESTAMP", "TIMEZONE_MINUTE", "TO", "TOAST", "TRAILING", "TRANSACTION")
+
+  final def validateIdentifier(identifier: String): Unit = {
+    identifier.foreach { c =>
+      if (forbiddenCharacters.contains(c))
+        throw new IllegalArgumentException(s"The character '$c' cannot be used as part of column name in '$identifier'.")
+    }
+  }
+
+  final def identifierNeedsEscaping(identifier: String): Boolean = {
+    identifier.length < 2 || !identifier.forall(c => normalCharacters.contains(c)) || sqlKeywords.contains(identifier.toUpperCase)
+  }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -58,8 +58,8 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
 }
 
 object SqlGeneratorBase {
-  val forbiddenCharacters = ";`'\"[](){}<>="
-  val normalCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+  val forbiddenCharacters = ";'\""
+  val normalCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_."
   val sqlKeywords: Set[String] = Set(
     "ABORT", "ABS", "ABSOLUTE", "ACCESS", "ADMIN", "AFTER", "AGGREGATE", "ALIAS", "ALL", "ALLOCATE",
     "ALSO", "ALTER", "ALWAYS", "ANALYSE", "ANALYZE", "AND", "ANY", "ARE", "ARRAY", "AS", "ASC", "ASENSITIVE", "ASSERTION",

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -31,21 +31,21 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM $tableName"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -31,21 +31,21 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM $tableName"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -31,21 +31,21 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM $tableName"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -46,21 +46,21 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM $tableName"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -71,9 +71,9 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -98,6 +98,10 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    s"`$columnName`"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -100,8 +100,12 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
     }
   }
 
-  override final def wrapIdentifier(columnName: String): String = {
-    s"`$columnName`"
+  override final def wrapIdentifier(identifier: String): String = {
+    if (identifier.startsWith("`") && identifier.endsWith("`")) {
+      identifier
+    } else {
+      s"`$identifier`"
+    }
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -31,21 +31,21 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS C1 FROM $tableName"
+    s"SELECT COUNT(*) AS C1 FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS C1 FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) AS C1 FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -31,12 +31,12 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS C1 FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS C1 FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -31,21 +31,21 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
   }
 
   def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM $tableName WITH (NOLOCK)"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WITH (NOLOCK)"
   }
 
   def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM $tableName WITH (NOLOCK) WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WITH (NOLOCK) WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM $tableName WITH (NOLOCK)"
+    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WITH (NOLOCK)"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM $tableName WITH (NOLOCK) WHERE $where"
+    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WITH (NOLOCK) WHERE $where"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CONVERT(DATE, ${sqlConfig.infoDateColumn})"
+        s"CONVERT(DATE, $infoDateColumn)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,10 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    s"[$columnName]"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
@@ -31,21 +31,21 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM $tableName"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
   }
 
   def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit, hasWhere = false)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit, hasWhere = false)}"
   }
 
   def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit, hasWhere = true)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit, hasWhere = true)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"TO_DATE(${sqlConfig.infoDateColumn}, 'YYYY-MM-DD')"
+        s"TO_DATE($infoDateColumn, 'YYYY-MM-DD')"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int], hasWhere: Boolean): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -31,21 +31,21 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM $tableName"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM $tableName WHERE $where"
+    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM $tableName${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM $tableName WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -56,9 +56,9 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
 
     val infoDateColumnAdjusted =
       if (dateTypes.contains(sqlConfig.infoDateType)) {
-        s"CAST(${sqlConfig.infoDateColumn} AS DATE)"
+        s"CAST($infoDateColumn AS DATE)"
       } else {
-        sqlConfig.infoDateColumn
+        infoDateColumn
       }
 
     if (dateBeginLit == dateEndLit) {
@@ -83,6 +83,11 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
     }
+  }
+
+  override final def wrapIdentifier(columnName: String): String = {
+    val q = "\""
+    s"$q$columnName$q"
   }
 
   private def getLimit(limit: Option[Int]): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -131,7 +131,7 @@ class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
         val dateStr = DateTimeFormatter.ISO_LOCAL_DATE.format(date)
         s"date'$dateStr'"
       case SqlColumnType.DATETIME =>
-        throw new NotImplementedError("DATETIME support for SAS is not supported yet.")
+        throw new UnsupportedOperationException("DATETIME support for SAS is not supported yet.")
       case SqlColumnType.STRING =>
         val dateStr = dateFormatterApp.format(date)
         s"'$dateStr'"

--- a/pramen/core/src/test/resources/test/config/integration_inner_source.conf
+++ b/pramen/core/src/test/resources/test/config/integration_inner_source.conf
@@ -1,0 +1,100 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variable is expected to be set up by the test suite
+#base.path = "/tmp"
+
+pramen {
+  pipeline.name = "Integration test with a file-based source"
+
+  temporary.directory = ${base.path}/temp
+
+  bookkeeping.enabled = false
+  stop.spark.session = false
+}
+
+pramen.metastore {
+  tables = [
+    {
+      name = "table1"
+      description = "Table 1"
+      format = "parquet"
+      path = ${base.path}/table1
+    },
+    {
+      name = "table2"
+      description = "Table 2"
+      format = "parquet"
+      path = ${base.path}/table2
+    }
+  ]
+}
+
+pramen.sources.1 = [
+  {
+    name = "spark_source"
+    factory.class = "za.co.absa.pramen.core.source.SparkSource"
+
+    array.list = ["a", "b", "c"]
+
+    format = "csv"
+
+    option {
+      header = true
+    }
+  }
+]
+
+pramen.operations = [
+  {
+    name = "Sourcing from a CSV file"
+    type = "ingestion"
+    schedule.type = "daily"
+
+    source = "spark_source"
+
+    info.date.expr = "@runDate"
+
+    tables = [
+      {
+        input.path = ${base.path}
+        output.metastore.table = table1
+      }
+    ]
+
+  },
+  {
+    name = "Running the inner source transformer"
+    type = "transformation"
+
+    class = "za.co.absa.pramen.core.mocks.transformer.InnerSourceTransformer"
+    schedule.type = "daily"
+
+    output.table = "table2"
+
+    inner.pramen.sources = ${pramen.sources}
+
+    dependencies = [
+      {
+        tables = [ table1 ]
+        date.from = "@infoDate"
+        optional = true # Since no bookkeeping available the table will be seen as empty for the dependency manager
+      }
+    ]
+
+    option {
+      source = "spark_source"
+      config.key = "inner"
+    }
+  }
+]

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/InnerSourceLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/InnerSourceLongSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.integration
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.runner.AppRunner
+import za.co.absa.pramen.core.utils.{FsUtils, ResourceUtils}
+
+import java.time.LocalDate
+
+class InnerSourceLongSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
+  private val infoDate = LocalDate.of(2021, 2, 18)
+
+  "Inner transformer should" should {
+    val expected =
+      """{"value":"a"}
+        |{"value":"b"}
+        |{"value":"c"}
+        |""".stripMargin
+
+    "be able to access inner source configuration" in {
+      withTempDirectory("integration_inner_source") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        fsUtils.writeFile(new Path(tempDir, "landing_file1.csv"), "id,name\n1,John\n2,Jack\n3,Jill\n")
+
+        val conf = getConfig(tempDir)
+
+        val exitCode = AppRunner.runPipeline(conf)
+
+        assert(exitCode == 0)
+
+        val table2Path = new Path(new Path(tempDir, "table2"), s"pramen_info_date=$infoDate")
+
+        assert(fsUtils.exists(table2Path))
+
+        val df = spark.read.parquet(table2Path.toString)
+        val actual = df.orderBy("value").toJSON.collect().mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+  }
+
+  def getConfig(basePath: String): Config = {
+    val configContents = ResourceUtils.getResourceString("/test/config/integration_inner_source.conf")
+    val basePathEscaped = basePath.replace("\\", "\\\\")
+
+    val conf = ConfigFactory.parseString(
+      s"""base.path = "$basePathEscaped"
+         |pramen.runtime.is.rerun = true
+         |pramen.current.date = "$infoDate"
+         |$configContents
+         |""".stripMargin
+    ).withFallback(ConfigFactory.load())
+      .resolve()
+
+    conf
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/transformer/InnerSourceTransformer.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/transformer/InnerSourceTransformer.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.mocks.transformer
+
+import com.typesafe.config.Config
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.{MetastoreReader, Reason, Transformer}
+import za.co.absa.pramen.core.source.SourceManager
+import za.co.absa.pramen.core.utils.ConfigUtils
+
+import java.time.LocalDate
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+/**
+  * This transformer does not have dependencies, but always generates some data.
+  */
+class InnerSourceTransformer(conf: Config) extends Transformer {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override def validate(metastore: MetastoreReader,
+                        infoDate: LocalDate,
+                        options: Map[String, String]): Reason = {
+    Reason.Ready
+  }
+
+  override def run(metastore: MetastoreReader, infoDate: LocalDate, options: Map[String, String]): DataFrame = {
+    implicit val spark: SparkSession = SparkSession.builder().getOrCreate()
+
+    import spark.implicits._
+
+    val sourceName = options("source")
+
+    val sourceConfig = conf.getConfig(options("config.key"))
+
+    log.info(ConfigUtils.renderEffectiveConfigHocon(sourceConfig))
+
+    val src = SourceManager.getSourceByName(sourceName, sourceConfig, None)
+
+    val ar = src.config.getStringList("array.list").asScala.toList
+
+    ar.toDF("value")
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -29,11 +29,12 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
   import za.co.absa.pramen.core.sql.SqlGenerator._
 
-  private val sqlConfigDate = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "D")
-  private val sqlConfigDateTime = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATETIME, infoDateColumn = "D")
-  private val sqlConfigString = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, infoDateColumn = "D")
-  private val sqlConfigNumber = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.NUMBER, infoDateColumn = "D", dateFormatApp = "yyyyMMdd")
-  private val columns = Seq("A", "D", "CAST(E, DATE) AS E")
+  private val sqlConfigDate = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "DD")
+  private val sqlConfigEscape = DummySqlConfigFactory.getDummyConfig(infoDateColumn = "Info date")
+  private val sqlConfigDateTime = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATETIME, infoDateColumn = "DD")
+  private val sqlConfigString = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, infoDateColumn = "DD")
+  private val sqlConfigNumber = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.NUMBER, infoDateColumn = "DD", dateFormatApp = "yyyyMMdd")
+  private val columns = Seq("AA", "DD", "Column with spaces")
 
   private val date1 = LocalDate.of(2020, 8, 17)
   private val date2 = LocalDate.of(2020, 8, 30)
@@ -69,79 +70,87 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val gen = fromDriverName("oracle.jdbc.OracleDriver", sqlConfigDate, config)
     val genStr = fromDriverName("oracle.jdbc.OracleDriver", sqlConfigString, config)
     val genNum = fromDriverName("oracle.jdbc.OracleDriver", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("oracle.jdbc.OracleDriver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
+      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
    "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A WHERE ROWNUM <= 100")
+      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA WHERE ROWNUM <= 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" = date'2020-08-17'")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" >= date'2020-08-17' AND \"Info date\" <= date'2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17' AND ROWNUM <= 100")
-        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' AND ROWNUM <= 100")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17' AND ROWNUM <= 100")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' AND ROWNUM <= 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("A") == "A")
+        assert(gen.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -155,93 +164,101 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genDateTime = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigDateTime, config)
     val genStr = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigString, config)
     val genNum = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK)")
+      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK)")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A WITH (NOLOCK)")
+      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA WITH (NOLOCK)")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A WITH (NOLOCK)")
+      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, [Column with spaces] FROM AA WITH (NOLOCK)")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT TOP 100 * FROM A WITH (NOLOCK)")
+      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT TOP 100 * FROM AA WITH (NOLOCK)")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
     }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM [Input Table] WITH (NOLOCK) WHERE [Info date] = CONVERT(DATE, '2020-08-17')")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM [Input Table] WITH (NOLOCK) WHERE [Info date] >= CONVERT(DATE, '2020-08-17') AND [Info date] <= CONVERT(DATE, '2020-08-30')")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT TOP 100 * FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT TOP 100 * FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT TOP 100 * FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT TOP 100 * FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("A") == "A")
+        assert(genDate.getDtable("AA") == "AA")
       }
 
       "wrapped query with alias for SQL queries " in {
@@ -255,93 +272,101 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genStr = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigString, config)
     val genNum = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigNumber, config)
     val genDateTime = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigDateTime, config)
+    val genEscaped = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
+      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A")
+      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" = date'2020-08-17'")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" >= date'2020-08-17' AND \"Info date\" <= date'2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("A") == "A")
+        assert(gen.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -356,13 +381,14 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val gen = fromDriverName("com.sas.rio.MVADriver", sqlConfigDate, config)
     val genStr = fromDriverName("com.sas.rio.MVADriver", sqlConfigString, config)
     val genNum = fromDriverName("com.sas.rio.MVADriver", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("com.sas.rio.MVADriver", sqlConfigEscape, config)
 
     gen.setConnection(connection)
     genStr.setConnection(connection)
     genNum.setConnection(connection)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("A") == "SELECT COUNT(*) AS cnt 'cnt' FROM A")
+      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) AS cnt 'cnt' FROM AA")
     }
 
     "generate data queries without date ranges" in {
@@ -370,7 +396,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("company", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM company")
+      assert(gen.getDataQuery("company", columns, None) == "SELECT AA, DD, 'Column with spaces'n FROM company")
     }
 
     "generate data queries with limit clause date ranges" in {
@@ -379,60 +405,67 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = date'2020-08-17'")
-        assert(gen.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(gen.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = date'2020-08-17'")
+        assert(gen.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM 'Input Table'n WHERE 'Info date'n = date'2020-08-17'")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM 'Input Table'n WHERE 'Info date'n >= date'2020-08-17' AND 'Info date'n <= date'2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = date'2020-08-17'")
         assert(gen.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
         assert(genStr.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = '2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = '2020-08-17'")
         assert(genStr.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
         assert(genNum.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = 20200817")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = 20200817")
         assert(genNum.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= 20200817 AND D <= 20200830")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = date'2020-08-17' LIMIT 100")
         assert(gen.getDataQuery("company", date1, date2, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("A") == "A")
+        assert(gen.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -446,93 +479,101 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genStr = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigString, config)
     val genNum = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigNumber, config)
     val genDateTime = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigDateTime, config)
+    val genEscaped = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
+      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, `Column with spaces` FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
+      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = to_date('2020-08-17')")
-        assert(gen.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
+        assert(gen.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = to_date('2020-08-17')")
+        assert(gen.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= to_date('2020-08-17') AND CAST(DD AS DATE) <= to_date('2020-08-30')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) FROM `Input Table` WHERE `Info date` = to_date('2020-08-17')")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) FROM `Input Table` WHERE `Info date` >= to_date('2020-08-17') AND `Info date` <= to_date('2020-08-30')")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = to_date('2020-08-17')")
-        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = to_date('2020-08-17')")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= to_date('2020-08-17') AND CAST(DD AS DATE) <= to_date('2020-08-30')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = to_date('2020-08-17') LIMIT 100")
-        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30') LIMIT 100")
+        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = to_date('2020-08-17') LIMIT 100")
+        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30') LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("A") == "(A) tbl")
+        assert(gen.getDtable("AA") == "(AA) tbl")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -546,93 +587,101 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genDateTime = fromDriverName("org.postgresql.Driver", sqlConfigDateTime, config)
     val genStr = fromDriverName("org.postgresql.Driver", sqlConfigString, config)
     val genNum = fromDriverName("org.postgresql.Driver", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("org.postgresql.Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) FROM A")
+      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
+      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
-        assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(genDate.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
+        assert(genDate.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" = date'2020-08-17'")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) FROM \"Input Table\" WHERE \"Info date\" >= date'2020-08-17' AND \"Info date\" <= date'2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17'")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("A") == "A")
+        assert(genDate.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -646,93 +695,101 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genDateTime = fromDriverName("com.ibm.db2.jcc.DB2Driver", sqlConfigDateTime, config)
     val genStr = fromDriverName("com.ibm.db2.jcc.DB2Driver", sqlConfigString, config)
     val genNum = fromDriverName("com.ibm.db2.jcc.DB2Driver", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("com.ibm.db2.jcc.DB2Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
+      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
+      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = DATE '2020-08-17'")
-        assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30'")
+        assert(genDate.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = DATE '2020-08-17'")
+        assert(genDate.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = DATE '2020-08-17'")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= DATE '2020-08-17' AND CAST(D AS DATE) <= DATE '2020-08-30'")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) = DATE '2020-08-17'")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) >= DATE '2020-08-17' AND CAST(DD AS DATE) <= DATE '2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("Input Table", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM \"Input Table\" WHERE \"Info date\" = DATE '2020-08-17'")
+        assert(genEscaped.getCountQuery("Input Table", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM \"Input Table\" WHERE \"Info date\" >= DATE '2020-08-17' AND \"Info date\" <= DATE '2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = DATE '2020-08-17'")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30'")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = DATE '2020-08-17'")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = DATE '2020-08-17'")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= DATE '2020-08-17' AND CAST(D AS DATE) <= DATE '2020-08-30'")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) = DATE '2020-08-17'")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= DATE '2020-08-17' AND CAST(DD AS DATE) <= DATE '2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = DATE '2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = DATE '2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("A") == "A")
+        assert(genDate.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -746,97 +803,143 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genDateTime = fromDriverName("generic", sqlConfigDateTime, config)
     val genStr = fromDriverName("generic", sqlConfigString, config)
     val genNum = fromDriverName("generic", sqlConfigNumber, config)
+    val genEscaped = fromDriverName("generic", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
+      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
+      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("A", columns, None) == "SELECT A, D, CAST(E, DATE) AS E FROM A")
+      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
+      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = date'2020-08-17'")
-        assert(genDate.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(genDate.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = date'2020-08-17'")
+        assert(genDate.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
-        assert(genNum.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getCountQuery("AA", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = 20200817")
+        assert(genNum.getCountQuery("AA", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+      }
+
+      "the table name and column name need to be escaped" in {
+        assert(genEscaped.getCountQuery("SELECT", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM \"SELECT\" WHERE \"Info date\" = date'2020-08-17'")
+        assert(genEscaped.getCountQuery("SELECT", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM \"SELECT\" WHERE \"Info date\" >= date'2020-08-17' AND \"Info date\" <= date'2020-08-30'")
       }
     }
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17'")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = '2020-08-17'")
-        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
+        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = '2020-08-17'")
+        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WHERE D = 20200817")
-        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
+        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
+          "SELECT * FROM AA WHERE DD = 20200817")
+        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
+          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD = date'2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("A") == "A")
+        assert(genDate.getDtable("AA") == "AA")
       }
 
       "wrapped query without alias for SQL queries " in {
         assert(genDate.getDtable("SELECT A FROM B") == "(SELECT A FROM B) AS t")
+      }
+    }
+
+    "escapeIdentifier" should {
+      "throw an exception if a column contains a single quote" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC ' DEF")
+        }
+      }
+
+      "throw an exception if a column contains a double quote" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC \" DEF")
+        }
+      }
+
+      "throw an exception if a column contains a back quote" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC ` DEF")
+        }
+      }
+
+      "throw an exception if a column contains a semicolon" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC ; DEF")
+        }
+      }
+
+      "throw an exception if a column contains an opening square bracket" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC [ DEF")
+        }
+      }
+
+      "throw an exception if a column contains a closing square bracket" in {
+        assertThrows[IllegalArgumentException] {
+          genDate.escapeIdentifier("ABC ] DEF")
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #317