### PR TITLE
#325 Add quoting policy that help validate and quote identifiers that are passed to SQL queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,9 @@ is determined by the pipeline configuration.
     # Useful for auto-retrying ingestion pipelines.
     fail.if.no.data = false
 
-    # One of: auto, always, never 
-    # - When 'auto', input columns that contain non-alphanumeric characters (and underscore) will be quoted.
+    # One of: auto (default), always, never 
+    # - When 'auto', an identifier will be quoted if it contains invalid characters. This includes any characters 
+    #   outside the scope of A-Z, a-z, 0-9, and underscore (_).
     # - When 'always', all input table names and column names will be validated and quoted, if not quoted already.
     # - When 'never', Pramen will use names as configured without changing them.
     # Keep in mind that quoted identifiers are case sensitive in most relational databases.

--- a/README.md
+++ b/README.md
@@ -480,6 +480,10 @@ is determined by the pipeline configuration.
     # Useful for auto-retrying ingestion pipelines.
     fail.if.no.data = false
 
+    # When 'true', all input table names and column names will be validated and quoted, if not quoted already.
+    # Keep in mind that quoted identifiers are case sensitive in most relational databases.
+    validate.and.quote.identifiers = true
+
     # Specifies if tables of the data source have an information date colunn
     has.information.date.column = true
     

--- a/README.md
+++ b/README.md
@@ -480,9 +480,12 @@ is determined by the pipeline configuration.
     # Useful for auto-retrying ingestion pipelines.
     fail.if.no.data = false
 
-    # When 'true', all input table names and column names will be validated and quoted, if not quoted already.
+    # One of: auto, always, never 
+    # - When 'auto', input columns that contain non-alphanumeric characters (and underscore) will be quoted.
+    # - When 'always', all input table names and column names will be validated and quoted, if not quoted already.
+    # - When 'never', Pramen will use names as configured without changing them.
     # Keep in mind that quoted identifiers are case sensitive in most relational databases.
-    validate.and.quote.identifiers = true
+    identifier.quoting.policy = "auto"
 
     # Specifies if tables of the data source have an information date colunn
     has.information.date.column = true

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -211,7 +211,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
         SqlConfig(jdbcReaderConfig.infoDateColumn,
           infoDateType,
           jdbcReaderConfig.infoDateFormat,
-          jdbcReaderConfig.escapeIdentifiers)
+          jdbcReaderConfig.validateAndQuoteIdentifiers)
       case None => throw new IllegalArgumentException(s"Unknown info date type specified (${jdbcReaderConfig.infoDateType}). " +
         s"It should be one of: date, string, number")
     }
@@ -229,16 +229,16 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
     jdbcUrlSelector.logConnectionSettings()
 
     log.info(s"JDBC Reader Configuration:")
-    log.info(s"Has information date column:  ${jdbcReaderConfig.hasInfoDate}")
+    log.info(s"Has information date column:    ${jdbcReaderConfig.hasInfoDate}")
     if (jdbcReaderConfig.hasInfoDate) {
       log.info(s"Info date column name:        ${jdbcReaderConfig.infoDateColumn}")
       log.info(s"Info date column data type:   ${jdbcReaderConfig.infoDateType}")
       log.info(s"Info date format:             ${jdbcReaderConfig.infoDateFormat}")
     }
-    log.info(s"Save timestamp as dates:      ${jdbcReaderConfig.saveTimestampsAsDates}")
-    log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")
-    log.info(s"Escape identifiers:           ${jdbcReaderConfig.escapeIdentifiers}")
-    jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                $n"))
+    log.info(s"Save timestamp as dates:        ${jdbcReaderConfig.saveTimestampsAsDates}")
+    log.info(s"Correct decimals in schemas:    ${jdbcReaderConfig.correctDecimalsInSchema}")
+    log.info(s"Validate and quote identifiers: ${jdbcReaderConfig.validateAndQuoteIdentifiers}")
+    jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                  $n"))
 
     log.info("Extra JDBC reader Spark options:")
     ConfigUtils.renderExtraOptions(extraOptions, JDBC_WORDS_TO_REDACT)(s => log.info(s))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -211,7 +211,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
         SqlConfig(jdbcReaderConfig.infoDateColumn,
           infoDateType,
           jdbcReaderConfig.infoDateFormat,
-          jdbcReaderConfig.validateAndQuoteIdentifiers)
+          jdbcReaderConfig.identifierQuotingPolicy)
       case None => throw new IllegalArgumentException(s"Unknown info date type specified (${jdbcReaderConfig.infoDateType}). " +
         s"It should be one of: date, string, number")
     }
@@ -229,16 +229,16 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
     jdbcUrlSelector.logConnectionSettings()
 
     log.info(s"JDBC Reader Configuration:")
-    log.info(s"Has information date column:    ${jdbcReaderConfig.hasInfoDate}")
+    log.info(s"Has information date column:  ${jdbcReaderConfig.hasInfoDate}")
     if (jdbcReaderConfig.hasInfoDate) {
-      log.info(s"Info date column name:        ${jdbcReaderConfig.infoDateColumn}")
-      log.info(s"Info date column data type:   ${jdbcReaderConfig.infoDateType}")
-      log.info(s"Info date format:             ${jdbcReaderConfig.infoDateFormat}")
+      log.info(s"Info date column name:      ${jdbcReaderConfig.infoDateColumn}")
+      log.info(s"Info date column data type: ${jdbcReaderConfig.infoDateType}")
+      log.info(s"Info date format:           ${jdbcReaderConfig.infoDateFormat}")
     }
-    log.info(s"Save timestamp as dates:        ${jdbcReaderConfig.saveTimestampsAsDates}")
-    log.info(s"Correct decimals in schemas:    ${jdbcReaderConfig.correctDecimalsInSchema}")
-    log.info(s"Validate and quote identifiers: ${jdbcReaderConfig.validateAndQuoteIdentifiers}")
-    jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                  $n"))
+    log.info(s"Save timestamp as dates:      ${jdbcReaderConfig.saveTimestampsAsDates}")
+    log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")
+    log.info(s"Identifier quoting policy:    ${jdbcReaderConfig.identifierQuotingPolicy.name}")
+    jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                $n"))
 
     log.info("Extra JDBC reader Spark options:")
     ConfigUtils.renderExtraOptions(extraOptions, JDBC_WORDS_TO_REDACT)(s => log.info(s))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/QuotingPolicy.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/QuotingPolicy.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.reader.model
+
+sealed trait QuotingPolicy {
+  def name: String
+}
+
+object QuotingPolicy {
+  case object Never extends QuotingPolicy {
+    override def name: String = "never"
+  }
+
+  case object Always extends QuotingPolicy {
+    override def name: String = "always"
+  }
+
+  case object Auto extends QuotingPolicy {
+    override def name: String = "auto"
+  }
+
+  def fromString(s: String): QuotingPolicy = {
+    s.toLowerCase match {
+      case "never" => Never
+      case "always" => Always
+      case "auto" => Auto
+      case _ => throw new IllegalArgumentException(s"Unknown quoting policy: '$s'. Should be one of 'auto' (default), 'never', 'always'.")
+    }
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -32,7 +32,7 @@ case class TableReaderJdbcConfig(
                                   correctDecimalsFixPrecision: Boolean = false,
                                   enableSchemaMetadata: Boolean = false,
                                   useJdbcNative: Boolean = false,
-                                  validateAndQuoteIdentifiers: Boolean = true
+                                  identifierQuotingPolicy: QuotingPolicy = QuotingPolicy.Auto
                                 )
 
 object TableReaderJdbcConfig {
@@ -50,7 +50,7 @@ object TableReaderJdbcConfig {
   val CORRECT_DECIMALS_FIX_PRECISION = "correct.decimals.fix.precision"
   val ENABLE_SCHEMA_METADATA_KEY = "enable.schema.metadata"
   val USE_JDBC_NATIVE = "use.jdbc.native"
-  val VALIDATE_AND_QUOTE_IDENTIFIERS = "validate.and.quote.identifiers"
+  val IDENTIFIER_QUOTING_POLICY = "identifier.quoting.policy"
 
   def load(conf: Config, parent: String = ""): TableReaderJdbcConfig = {
     ConfigUtils.validatePathsExistence(conf, parent, HAS_INFO_DATE :: Nil)
@@ -71,6 +71,10 @@ object TableReaderJdbcConfig {
 
     val infoDateFormat = getInfoDateFormat(conf)
 
+    val identifierQuotingPolicy = ConfigUtils.getOptionString(conf, IDENTIFIER_QUOTING_POLICY)
+      .map(s => QuotingPolicy.fromString(s))
+      .getOrElse(QuotingPolicy.Auto)
+
     TableReaderJdbcConfig(
       jdbcConfig = JdbcConfig.load(conf, parent),
       hasInfoDate = conf.getBoolean(HAS_INFO_DATE),
@@ -83,7 +87,7 @@ object TableReaderJdbcConfig {
       correctDecimalsFixPrecision = ConfigUtils.getOptionBoolean(conf, CORRECT_DECIMALS_FIX_PRECISION).getOrElse(false),
       enableSchemaMetadata = ConfigUtils.getOptionBoolean(conf, ENABLE_SCHEMA_METADATA_KEY).getOrElse(false),
       useJdbcNative = ConfigUtils.getOptionBoolean(conf, USE_JDBC_NATIVE).getOrElse(false),
-      validateAndQuoteIdentifiers = ConfigUtils.getOptionBoolean(conf, VALIDATE_AND_QUOTE_IDENTIFIERS).getOrElse(false)
+      identifierQuotingPolicy = identifierQuotingPolicy
     )
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -32,7 +32,7 @@ case class TableReaderJdbcConfig(
                                   correctDecimalsFixPrecision: Boolean = false,
                                   enableSchemaMetadata: Boolean = false,
                                   useJdbcNative: Boolean = false,
-                                  escapeIdentifiers: Boolean = true
+                                  validateAndQuoteIdentifiers: Boolean = true
                                 )
 
 object TableReaderJdbcConfig {
@@ -50,7 +50,7 @@ object TableReaderJdbcConfig {
   val CORRECT_DECIMALS_FIX_PRECISION = "correct.decimals.fix.precision"
   val ENABLE_SCHEMA_METADATA_KEY = "enable.schema.metadata"
   val USE_JDBC_NATIVE = "use.jdbc.native"
-  val ESCAPE_IDENTIFIERS = "escape.identifiers"
+  val VALIDATE_AND_QUOTE_IDENTIFIERS = "validate.and.quote.identifiers"
 
   def load(conf: Config, parent: String = ""): TableReaderJdbcConfig = {
     ConfigUtils.validatePathsExistence(conf, parent, HAS_INFO_DATE :: Nil)
@@ -83,7 +83,7 @@ object TableReaderJdbcConfig {
       correctDecimalsFixPrecision = ConfigUtils.getOptionBoolean(conf, CORRECT_DECIMALS_FIX_PRECISION).getOrElse(false),
       enableSchemaMetadata = ConfigUtils.getOptionBoolean(conf, ENABLE_SCHEMA_METADATA_KEY).getOrElse(false),
       useJdbcNative = ConfigUtils.getOptionBoolean(conf, USE_JDBC_NATIVE).getOrElse(false),
-      escapeIdentifiers = ConfigUtils.getOptionBoolean(conf, ESCAPE_IDENTIFIERS).getOrElse(true)
+      validateAndQuoteIdentifiers = ConfigUtils.getOptionBoolean(conf, VALIDATE_AND_QUOTE_IDENTIFIERS).getOrElse(false)
     )
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
@@ -16,9 +16,11 @@
 
 package za.co.absa.pramen.core.sql
 
+import za.co.absa.pramen.core.reader.model.QuotingPolicy
+
 case class SqlConfig(
                       infoDateColumn: String,
                       infoDateType: SqlColumnType,
                       dateFormatApp: String,
-                      validateAndQuoteIdentifiers: Boolean
+                      identifierQuotingPolicy: QuotingPolicy
                     )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlConfig.scala
@@ -20,5 +20,5 @@ case class SqlConfig(
                       infoDateColumn: String,
                       infoDateType: SqlColumnType,
                       dateFormatApp: String,
-                      escapeIdentifiers: Boolean
+                      validateAndQuoteIdentifiers: Boolean
                     )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -40,7 +40,7 @@ trait SqlGenerator {
 
   /**
     * This quotes an identifier name with characters specific to SQL dialects.
-    * If the identifier already wrapped, it won't be double wrapped.
+    * If the identifier is already wrapped, it won't be double wrapped.
     * It supports compled identifiers. E.g. '"my_catalog".my table' will be quoted as '"my_catalog"."my table"'.
     */
   def quote(identifier: String): String

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -41,7 +41,7 @@ trait SqlGenerator {
   /**
     * This quotes an identifier name with characters specific to SQL dialects.
     * If the identifier is already wrapped, it won't be double wrapped.
-    * It supports compled identifiers. E.g. '"my_catalog".my table' will be quoted as '"my_catalog"."my table"'.
+    * It supports partially quoted identifiers. E.g. '"my_catalog".my table' will be quoted as '"my_catalog"."my table"'.
     */
   def quote(identifier: String): String
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -41,6 +41,14 @@ trait SqlGenerator {
   /** This validates and escapes an identifier if needed. Escaping does not happen always to maintain backwards compatibility. */
   def escapeIdentifier(identifier: String): String
 
+  /**
+    * This returns characters used for escaping into a mode that allows special characters in identifiers.
+    * For example,
+    *  - in Hive, column name 'my column' should be escaped with back quotes `my column`, in MS SQL Server
+    *  - in MS SQL server square braces are used instead [my column].
+    */
+  def beginEndEscapeChars: (Char, Char)
+
   def requiresConnection: Boolean = false
 
   def setConnection(connection: Connection): Unit = {}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGenerator.scala
@@ -38,16 +38,12 @@ trait SqlGenerator {
   /** Returns the date literal for the dialect of the SQL. */
   def getDateLiteral(date: LocalDate): String
 
-  /** This validates and escapes an identifier if needed. Escaping does not happen always to maintain backwards compatibility. */
-  def escapeIdentifier(identifier: String): String
-
   /**
-    * This returns characters used for escaping into a mode that allows special characters in identifiers.
-    * For example,
-    *  - in Hive, column name 'my column' should be escaped with back quotes `my column`, in MS SQL Server
-    *  - in MS SQL server square braces are used instead [my column].
+    * This quotes an identifier name with characters specific to SQL dialects.
+    * If the identifier already wrapped, it won't be double wrapped.
+    * It supports compled identifiers. E.g. '"my_catalog".my table' will be quoted as '"my_catalog"."my table"'.
     */
-  def beginEndEscapeChars: (Char, Char)
+  def quote(identifier: String): String
 
   def requiresConnection: Boolean = false
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -51,7 +51,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
     splitComplexIdentifier(identifier).map(quoteSingleIdentifier).mkString(".")
   }
 
-  /** This validates and escapes an identifier (table of column name) if needed. Escaping does not happen always to maintain backwards compatibility. */
+  /** This validates and escapes an identifier (table or column name) if needed. Escaping does not happen always to maintain backwards compatibility. */
   final def escape(identifier: String): String = {
     if (needsEscaping(sqlConfig.identifierQuotingPolicy, identifier)) {
       quote(identifier)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -90,7 +90,6 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
 
     while (i < len) {
       val c = trimmedIdentifier(i)
-      val previousChar = if (i == 0) ' ' else trimmedIdentifier(i - 1)
       val nextChar = if (i == len - 1) ' ' else trimmedIdentifier(i + 1)
 
       if (nestingLevel == 0 && c == '.') {
@@ -103,7 +102,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
       if (sameEscapeChar) {
         if (c == escapeBegin) {
           if (nestingLevel == 0) {
-            if (curColumn.length() != 1 && previousChar != escapeBegin && nextChar != escapeBegin)
+            if (curColumn.length() > 1 && i < len - 1 && nextChar != '.')
               throw new IllegalArgumentException(f"Invalid character '$escapeBegin' in the identifier '$identifier', position $i.")
             nestingLevel += 1
           } else

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -26,18 +26,34 @@ import scala.collection.mutable.ListBuffer
 abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
   import SqlGeneratorBase._
 
-  /** This Wraps the column name with escaping characters. The escape logic varies among SQL dialects. */
-  def wrapIdentifier(identifier: String): String
+  /**
+    * This returns characters used for escaping into a mode that allows special characters in identifiers.
+    * For example,
+    *  - in Hive, column name 'my column' should be escaped with back quotes `my column`, in MS SQL Server
+    *  - in MS SQL server square braces are used instead [my column].
+    */
+  def beginEndEscapeChars: (Char, Char)
 
-  /** This validates and escapes the column name is needed. Escaping does not happen always to maintain backwards compatibility. */
-  final override def escapeIdentifier(identifier: String): String = {
-    if (sqlConfig.escapeIdentifiers) {
-      validateIdentifier(identifier)
+  def quoteSingleIdentifier(identifier: String): String = {
+    val (escapeBegin, escapeEnd) = beginEndEscapeChars
 
-      if (identifierNeedsEscaping(identifier)) {
-        splitComplexIdentifier(identifier).map(wrapIdentifier).mkString(".")
-      } else
-        identifier
+    if (identifier.startsWith(s"$escapeBegin") && identifier.endsWith(s"$escapeEnd")) {
+      identifier
+    } else {
+      s"$escapeBegin$identifier$escapeEnd"
+    }
+  }
+
+  final def quote(identifier: String): String = {
+    validateIdentifier(identifier)
+    splitComplexIdentifier(identifier).map(quoteSingleIdentifier).mkString(".")
+  }
+
+
+  /** This validates and escapes an identifier (table of column name) if needed. Escaping does not happen always to maintain backwards compatibility. */
+  final def escape(identifier: String): String = {
+    if (sqlConfig.validateAndQuoteIdentifiers) {
+      quote(identifier)
     } else {
       identifier
     }
@@ -51,7 +67,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
     if (columns.isEmpty) {
       "*"
     } else {
-      columns.map(col => escapeIdentifier(col)) .mkString(", ")
+      columns.map(col => escape(col)) .mkString(", ")
     }
   }
 
@@ -120,58 +136,17 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
     * This escapes the information date column properly.
     */
   final protected def infoDateColumn: String = {
-    escapeIdentifier(sqlConfig.infoDateColumn)
+    escape(sqlConfig.infoDateColumn)
   }
 }
 
 object SqlGeneratorBase {
   val forbiddenCharacters = ";'\\"
-  val normalCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_."
-  val sqlKeywords: Set[String] = Set(
-    "ABORT", "ABS", "ABSOLUTE", "ACCESS", "ADMIN", "AFTER", "AGGREGATE", "ALIAS", "ALL", "ALLOCATE",
-    "ALSO", "ALTER", "ALWAYS", "ANALYSE", "ANALYZE", "AND", "ANY", "ARE", "ARRAY", "AS", "ASC", "ASENSITIVE", "ASSERTION",
-    "AT", "ATOMIC", "ATTRIBUTE", "ATTRIBUTES", "AUTHORIZATION", "BACKWARD", "BEFORE", "BEGIN", "BETWEEN", "BIGINT", "BINARY",
-    "BIT", "BITVAR", "BLOB", "BOOLEAN", "BOTH", "BY", "CACHE", "CALL", "CALLED", "CARDINALITY", "CASCADE", "CASCADED",
-    "CASE", "CAST", "CATALOG", "CATALOG_NAME", "CHAIN", "CHAR", "CHARACTER", "CHARACTERISTICS", "CHARACTERS", "CHARACTER_LENGTH",
-    "CHARACTER_SET_CATALOG", "CHARACTER_SET_NAME", "CHARACTER_SET_SCHEMA", "CHAR_LENGTH", "CHECK", "CHECKED", "CHECKPOINT",
-    "CLASS", "CLASS_ORIGIN", "CLOSE", "CLUSTER", "COALESCE", "COLLATE", "COLLATION", "COLLATION_CATALOG", "COLLATION_NAME",
-    "COLLATION_SCHEMA", "COLLECT", "COLUMN", "COLUMN_NAME", "COMMAND_FUNCTION", "COMMAND_FUNCTION_CODE", "COMMENT",
-    "COMMIT", "COMMITTED", "COMPLETION", "CONDITION", "CONNECT", "CONSTRAINT", "CONSTRAINTS", "CONTAINS", "CONTINUE",
-    "CONVERT", "COPY", "CORR", "COUNT", "CREATE", "CREATEDB", "CREATEROLE", "CREATEUSER", "CROSS", "CURRENT", "CURRENT_DATE",
-    "CURRENT_PATH", "CURRENT_ROLE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR", "CURSOR_NAME", "DATA",
-    "DATABASE", "DATE", "DATETIME", "DAY", "DEALLOCATE", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DEFAULTS", "DEGREE",
-    "DELETE", "DELIMITER", "DELIMITERS", "DESC", "DESCRIBE", "DESCRIPTOR", "DESTROY", "DICTIONARY", "DISABLE", "DISCONNECT",
-    "DISTINCT", "DO", "DOMAIN", "DOUBLE", "DROP", "EACH", "ELEMENT", "ELSE", "ENABLE", "ENCODING", "ENCRYPTED", "END",
-    "EQUALS", "ESCAPE", "EVERY", "EXCEPT", "EXCEPTION", "EXCLUDE", "EXCLUDING", "EXEC", "EXECUTE", "EXISTS", "EXP",
-    "EXPLAIN", "EXTERNAL", "EXTRACT", "FALSE", "FETCH", "FILTER", "FINAL", "FIRST", "FOR", "FORCE", "FREE", "FROM",
-    "FUNCTION", "GET", "GLOBAL", "GO", "GOTO", "GRANT", "GRANTED", "GROUP", "HANDLER", "HAVING", "HOLD", "HOST", "HOUR",
-    "IDENTITY", "ILIKE", "IMMEDIATE", "IN", "INCREMENT", "INDEX", "INNER", "INOUT", "INPUT", "INSENSITIVE", "INSERT", "INSTANCE",
-    "INSTEAD", "INTERSECT", "INTERSECTION", "INTERVAL", "INTO", "INVOKER", "IS", "ISNULL", "JOIN", "KEY", "KEY_MEMBER",
-    "KEY_TYPE", "LANGUAGE", "LAST", "LEAST", "LEFT", "LENGTH", "LESS", "LEVEL", "LIKE", "LIMIT", "LOAD", "LOCAL", "LOCALTIME",
-    "LOCALTIMESTAMP", "LOCATION", "LOCK", "LOGIN", "MATCH", "MAX", "MAXVALUE", "MEMBER", "MERGE", "METHOD", "MIN", "MINUTE",
-    "MODE", "MODIFIES", "MODIFY", "MODULE", "MONTH", "MORE", "MOVE", "NATIONAL", "NATURAL", "NESTING", "NEW", "NEXT", "NO",
-    "NOLOCK", "NOLOGIN", "NONE", "NORMALIZE", "NORMALIZED", "NOSUPERUSER", "NOT", "NOTHING", "NOTIFY", "NOTNULL", "NOWAIT",
-    "NULL", "NULLABLE", "NULLIF", "NULLS", "OBJECT", "OF", "OFF", "OFFSET", "OIDS", "OLD", "ON", "ONLY", "OPEN", "OPERATION",
-    "OPTION", "OPTIONS", "OR", "ORDER", "ORDERING", "OUT", "OUTPUT", "OVER", "OWNER", "PARAMETER", "PARAMETERS",
-    "PARTIAL", "PARTITION", "PASSWORD", "PATH", "POWER", "PRECEDING", "PRECISION", "PREFIX", "PREPARE", "PRESERVE", "PRIMARY",
-    "PRIOR", "PRIVILEGES", "PUBLIC", "QUOTE", "RANGE", "RANK", "READ", "READS", "RECURSIVE", "REF", "REFERENCES", "REFERENCING",
-    "RELATIVE", "RELEASE", "RENAME", "REPLACE", "RESET", "RESTART", "RESTRICT", "RESULT", "RETURN", "RETURNS", "REVOKE",
-    "RIGHT", "ROLE", "ROLLBACK", "ROW", "ROWS", "ROW_COUNT", "ROW_NUMBER", "RULE", "SAVEPOINT", "SCALE", "SCHEMA", "SCHEMA_NAME",
-    "SCOPE", "SCROLL", "SEARCH", "SECOND", "SECTION", "SECURITY", "SELECT", "SELF", "SENSITIVE", "SEQUENCE", "SERIALIZABLE",
-    "SERVER_NAME", "SESSION", "SESSION_USER", "SET", "SETOF", "SETS", "SHARE", "SHOW", "SIZE", "SOME", "SOURCE", "SPACE",
-    "SQL", "SQLCODE", "SQLERROR", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "STABLE", "START", "STATE", "STATEMENT", "STATIC",
-    "STATISTICS", "STDIN", "STDOUT", "STORAGE", "STRICT", "STRUCTURE", "STYLE", "SUBSTRING", "SUM", "SUPERUSER", "SYMMETRIC",
-    "SYSID", "SYSTEM", "SYSTEM_USER", "TABLE", "TABLESPACE", "TABLE_NAME", "TEMP", "TEMPLATE", "TEMPORARY", "TERMINATE",
-    "THAN", "THEN", "TIES", "TIME", "TIMESTAMP", "TIMEZONE_MINUTE", "TO", "TOAST", "TRAILING", "TRANSACTION")
 
   final def validateIdentifier(identifier: String): Unit = {
     identifier.foreach { c =>
       if (forbiddenCharacters.contains(c) || c.toInt < 32)
         throw new IllegalArgumentException(f"The character '$c' (0x${c.toInt}%02X) cannot be used as part of column name in '$identifier'.")
     }
-  }
-
-  final def identifierNeedsEscaping(identifier: String): Boolean = {
-    identifier.length < 2 || !identifier.forall(c => normalCharacters.contains(c)) || sqlKeywords.contains(identifier.toUpperCase)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorBase.scala
@@ -31,7 +31,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
   /**
     * This returns characters used for escaping into a mode that allows special characters in identifiers.
     * For example,
-    *  - in Hive, column name 'my column' should be escaped with back quotes `my column`, in MS SQL Server
+    *  - in Hive, column name 'my column' should be escaped with back quotes `my column`,
     *  - in MS SQL server square braces are used instead [my column].
     */
   def beginEndEscapeChars: (Char, Char)
@@ -46,7 +46,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
     }
   }
 
-  final def quote(identifier: String): String = {
+  override final def quote(identifier: String): String = {
     validateIdentifier(identifier)
     splitComplexIdentifier(identifier).map(quoteSingleIdentifier).mkString(".")
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -33,21 +33,21 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) AS T"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) tbl"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -33,21 +33,21 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -33,21 +33,21 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) AS t"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -39,6 +39,8 @@ object SqlGeneratorHive {
 class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('`', '`')
+
   SqlGeneratorHive.registerDialect
 
   override def getDtable(sql: String): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -48,21 +48,21 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -99,14 +99,6 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("`") && identifier.endsWith("`")) {
-      identifier
-    } else {
-      s"`$identifier`"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) t"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -33,21 +33,21 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -34,21 +34,21 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
   }
 
   def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WITH (NOLOCK)"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)} WITH (NOLOCK)"
   }
 
   def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS CNT FROM ${escapeIdentifier(tableName)} WITH (NOLOCK) WHERE $where"
+    s"SELECT COUNT(*) AS CNT FROM ${escape(tableName)} WITH (NOLOCK) WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WITH (NOLOCK)"
+    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escape(tableName)} WITH (NOLOCK)"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WITH (NOLOCK) WHERE $where"
+    s"SELECT ${getLimit(limit)}${columnExpr(columns)} FROM ${escape(tableName)} WITH (NOLOCK) WHERE $where"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -88,14 +88,6 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("[") && identifier.endsWith("]")) {
-      identifier
-    } else {
-      s"[$identifier]"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -23,6 +23,8 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
   private val isIso = sqlConfig.dateFormatApp.toLowerCase.startsWith("yyyy-mm-dd")
 
+  override val beginEndEscapeChars: (Char, Char) = ('[', ']')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) AS tbl"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
@@ -33,21 +33,21 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
   }
 
   def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) FROM ${escape(tableName)}"
   }
 
   def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) FROM ${escape(tableName)} WHERE $where"
   }
 
   def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit, hasWhere = false)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit, hasWhere = false)}"
   }
 
   def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit, hasWhere = true)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit, hasWhere = true)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql)"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter
 class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\"', '\"')
+
   override def getDtable(sql: String): String = {
     if (sql.exists(_ == ' ')) {
       s"($sql) t"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -33,21 +33,21 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
   }
 
   override def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) FROM ${escape(tableName)}"
   }
 
   override def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) FROM ${escape(tableName)} WHERE $where"
   }
 
   override def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)}${getLimit(limit)}"
   }
 
   override def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${columnExpr(columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit)}"
+    s"SELECT ${columnExpr(columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit)}"
   }
 
   override def getWhere(dateBegin: LocalDate, dateEnd: LocalDate): String = {
@@ -84,15 +84,6 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
       case SqlColumnType.NUMBER =>
         val dateStr = dateFormatterApp.format(date)
         s"$dateStr"
-    }
-  }
-
-  override final def wrapIdentifier(identifier: String): String = {
-    if (identifier.startsWith("\"") && identifier.endsWith("\"")) {
-      identifier
-    } else {
-      val q = "\""
-      s"$q$identifier$q"
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -41,6 +41,8 @@ object SqlGeneratorSas {
 class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) {
   private val dateFormatterApp = DateTimeFormatter.ofPattern(sqlConfig.dateFormatApp)
 
+  override val beginEndEscapeChars: (Char, Char) = ('\'', '\'')
+
   private var connection: Connection = _
 
   SqlGeneratorSas.registerDialect

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -60,28 +60,28 @@ class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
   }
 
   def getCountQuery(tableName: String): String = {
-    s"SELECT COUNT(*) AS cnt 'cnt' FROM ${escapeIdentifier(tableName)}"
+    s"SELECT COUNT(*) AS cnt 'cnt' FROM ${escape(tableName)}"
   }
 
   def getCountQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT COUNT(*) AS cnt 'cnt' FROM ${escapeIdentifier(tableName)} WHERE $where"
+    s"SELECT COUNT(*) AS cnt 'cnt' FROM ${escape(tableName)} WHERE $where"
   }
 
   def getDataQuery(tableName: String, columns: Seq[String], limit: Option[Int]): String = {
-    s"SELECT ${getColumnSql(tableName, columns)} FROM ${escapeIdentifier(tableName)}${getLimit(limit, hasWhere = false)}"
+    s"SELECT ${getColumnSql(tableName, columns)} FROM ${escape(tableName)}${getLimit(limit, hasWhere = false)}"
   }
 
   def getDataQuery(tableName: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String], limit: Option[Int]): String = {
     val where = getWhere(infoDateBegin, infoDateEnd)
-    s"SELECT ${getColumnSql(tableName, columns)} FROM ${escapeIdentifier(tableName)} WHERE $where${getLimit(limit, hasWhere = true)}"
+    s"SELECT ${getColumnSql(tableName, columns)} FROM ${escape(tableName)} WHERE $where${getLimit(limit, hasWhere = true)}"
   }
 
   private def getColumnSql(tableName: String, columns: Seq[String]): String = {
     if (columns.isEmpty) {
-      getColumns(tableName).map(name => s"${escapeIdentifier(name)} '${escapeIdentifier(name)}'").mkString(", ")
+      getColumns(tableName).map(name => s"${escape(name)} '${escape(name)}'").mkString(", ")
     } else {
-      columns.map(escapeIdentifier).mkString(", ")
+      columns.map(escape).mkString(", ")
     }
   }
 
@@ -143,8 +143,12 @@ class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
     }
   }
 
-  override final def wrapIdentifier(columnName: String): String = {
-    s"'$columnName'n"
+  override final def quoteSingleIdentifier(identifier: String): String = {
+    if (identifier.startsWith(".") && identifier.toLowerCase.endsWith("n")) {
+      identifier
+    } else {
+      s"'$identifier'n"
+    }
   }
 
   private def getLimit(limit: Option[Int], hasWhere: Boolean): String = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
@@ -22,10 +22,10 @@ object DummySqlConfigFactory {
   def getDummyConfig(infoDateColumn: String = "col",
                      infoDateType: SqlColumnType = SqlColumnType.DATE,
                      dateFormatApp: String = "yyyy-MM-dd",
-                     escapeIdentifiers: Boolean = true
+                     escapeIdentifiers: Boolean = false
                     ): SqlConfig = SqlConfig(
     infoDateColumn = infoDateColumn,
     infoDateType = infoDateType,
     dateFormatApp = dateFormatApp,
-    escapeIdentifiers = escapeIdentifiers)
+    validateAndQuoteIdentifiers = escapeIdentifiers)
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/DummySqlConfigFactory.scala
@@ -16,16 +16,17 @@
 
 package za.co.absa.pramen.core.mocks
 
+import za.co.absa.pramen.core.reader.model.QuotingPolicy
 import za.co.absa.pramen.core.sql.{SqlColumnType, SqlConfig}
 
 object DummySqlConfigFactory {
   def getDummyConfig(infoDateColumn: String = "col",
                      infoDateType: SqlColumnType = SqlColumnType.DATE,
                      dateFormatApp: String = "yyyy-MM-dd",
-                     escapeIdentifiers: Boolean = false
+                     identifierQuotingPolicy: QuotingPolicy = QuotingPolicy.Auto
                     ): SqlConfig = SqlConfig(
     infoDateColumn = infoDateColumn,
     infoDateType = infoDateType,
     dateFormatApp = dateFormatApp,
-    validateAndQuoteIdentifiers = escapeIdentifiers)
+    identifierQuotingPolicy = identifierQuotingPolicy)
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/QuotingPolicySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/QuotingPolicySuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.reader
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.reader.model._
+
+class QuotingPolicySuite extends AnyWordSpec {
+    "QuotingPolicy.fromString" should {
+      "return Never for 'never'" in {
+        assert(QuotingPolicy.fromString("never") == QuotingPolicy.Never)
+        assert(QuotingPolicy.fromString("never").name == "never")
+      }
+
+      "return Always for 'always'" in {
+        assert(QuotingPolicy.fromString("always") == QuotingPolicy.Always)
+        assert(QuotingPolicy.fromString("always").name == "always")
+      }
+
+      "return Auto for 'auto'" in {
+        assert(QuotingPolicy.fromString("auto") == QuotingPolicy.Auto)
+        assert(QuotingPolicy.fromString("auto").name == "auto")
+      }
+
+      "throw an exception for an unknown quoting policy" in {
+        assertThrows[IllegalArgumentException] {
+          QuotingPolicy.fromString("unknown")
+        }
+      }
+    }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -23,7 +23,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.api.Query
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.RelationalDbFixture
-import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
+import za.co.absa.pramen.core.reader.model.{QuotingPolicy, TableReaderJdbcConfig}
 import za.co.absa.pramen.core.reader.{JdbcUrlSelector, TableReaderJdbc}
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.sql.SqlGeneratorHsqlDb
@@ -59,6 +59,8 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
          |  information.date.column = "INFO_DATE"
          |  information.date.type = "number"
          |  information.date.format = "yyyy-MM-DD"
+         |
+         |  identifier.quoting.policy = "never"
          |}
          |reader_legacy {
          |  jdbc {
@@ -73,7 +75,6 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
          |  information.date.column = "INFO_DATE"
          |  information.date.type = "date"
          |  information.date.app.format = "YYYY-MM-dd"
-         |
          |}
          |reader_minimal {
          |  jdbc {
@@ -216,6 +217,8 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
         reader.getWithRetry("company", isDataQuery = true, 2) { df =>
           assert(!df.isEmpty)
         }
+
+        assert(jdbcTableReaderConfig.identifierQuotingPolicy == QuotingPolicy.Never)
       }
 
       "pass the exception when out of retries" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -29,12 +29,12 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
   import za.co.absa.pramen.core.sql.SqlGenerator._
 
-  private val sqlConfigDate = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "DD")
-  private val sqlConfigEscape = DummySqlConfigFactory.getDummyConfig(infoDateColumn = "Info date")
-  private val sqlConfigDateTime = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATETIME, infoDateColumn = "DD")
-  private val sqlConfigString = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, infoDateColumn = "DD")
-  private val sqlConfigNumber = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.NUMBER, infoDateColumn = "DD", dateFormatApp = "yyyyMMdd")
-  private val columns = Seq("AA", "DD", "Column with spaces")
+  private val sqlConfigDate = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "D")
+  private val sqlConfigEscape = DummySqlConfigFactory.getDummyConfig(infoDateColumn = "Info date", escapeIdentifiers = true)
+  private val sqlConfigDateTime = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATETIME, infoDateColumn = "D")
+  private val sqlConfigString = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, infoDateColumn = "D")
+  private val sqlConfigNumber = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.NUMBER, infoDateColumn = "D", dateFormatApp = "yyyyMMdd")
+  private val columns = Seq("A", "D", "Column with spaces")
 
   private val date1 = LocalDate.of(2020, 8, 17)
   private val date2 = LocalDate.of(2020, 8, 30)
@@ -74,41 +74,41 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("oracle.jdbc.OracleDriver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
+      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
    "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(gen.getDataQuery("A", columns, None) == "SELECT A, D, Column with spaces FROM A")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA WHERE ROWNUM <= 100")
+      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A WHERE ROWNUM <= 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -121,44 +121,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE TO_DATE(DD, 'YYYY-MM-DD') = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE TO_DATE(DD, 'YYYY-MM-DD') >= date'2020-08-17' AND TO_DATE(DD, 'YYYY-MM-DD') <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE TO_DATE(D, 'YYYY-MM-DD') = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE TO_DATE(D, 'YYYY-MM-DD') >= date'2020-08-17' AND TO_DATE(D, 'YYYY-MM-DD') <= date'2020-08-30'")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17' AND ROWNUM <= 100")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' AND ROWNUM <= 100")
+        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17' AND ROWNUM <= 100")
+        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' AND ROWNUM <= 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("AA") == "AA")
+        assert(gen.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -166,9 +166,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
-      "escape each subfields separately" in {
-        val actual = gen.escapeIdentifier("System User.\"Table Name\"")
+    "quote" should {
+      "quote each subfields separately" in {
+        val actual = gen.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
@@ -179,61 +179,61 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genDate = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigDate, config)
     val genDateTime = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigDateTime, config)
     val genStr = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigString, config)
-    val genStr2 = fromDriverName("net.sourceforge.jtds.jdbc.Driver", DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, dateFormatApp = "yyyyMMdd",  infoDateColumn = "DD"), config)
+    val genStr2 = fromDriverName("net.sourceforge.jtds.jdbc.Driver", DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.STRING, dateFormatApp = "yyyyMMdd",  infoDateColumn = "D"), config)
     val genNum = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigNumber, config)
     val genEscaped = fromDriverName("net.sourceforge.jtds.jdbc.Driver", sqlConfigEscape, config)
-    val genEscaped2 = fromDriverName("net.sourceforge.jtds.jdbc.Driver",  DummySqlConfigFactory.getDummyConfig(infoDateColumn = "[Info date]"), config)
+    val genEscaped2 = fromDriverName("net.sourceforge.jtds.jdbc.Driver",  DummySqlConfigFactory.getDummyConfig(infoDateColumn = "[Info date]", escapeIdentifiers = true), config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK)")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK)")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA WITH (NOLOCK)")
+      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A WITH (NOLOCK)")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, [Column with spaces] FROM AA WITH (NOLOCK)")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT [A], [D], [Column with spaces] FROM [A] WITH (NOLOCK)")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT TOP 100 * FROM AA WITH (NOLOCK)")
+      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT TOP 100 * FROM A WITH (NOLOCK)")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
     }
 
       "date is in STRING ISO format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING non ISO format" in {
-        assert(genStr2.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = '20200817'")
-        assert(genStr2.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= '20200817' AND DD <= '20200830'")
+        assert(genStr2.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = '20200817'")
+        assert(genStr2.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= '20200817' AND D <= '20200830'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WITH (NOLOCK) WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -253,51 +253,51 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING ISO format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) = CONVERT(DATE, '2020-08-17')")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE CONVERT(DATE, DD) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, DD) <= CONVERT(DATE, '2020-08-30')")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING non-ISO format" in {
-        assert(genStr2.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = '20200817'")
-        assert(genStr2.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= '20200817' AND DD <= '20200830'")
+        assert(genStr2.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D = '20200817'")
+        assert(genStr2.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D >= '20200817' AND D <= '20200830'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WITH (NOLOCK) WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WITH (NOLOCK) WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT TOP 100 * FROM AA WITH (NOLOCK) WHERE DD = CONVERT(DATE, '2020-08-17')")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT TOP 100 * FROM AA WITH (NOLOCK) WHERE DD >= CONVERT(DATE, '2020-08-17') AND DD <= CONVERT(DATE, '2020-08-30')")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT TOP 100 * FROM A WITH (NOLOCK) WHERE D = CONVERT(DATE, '2020-08-17')")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT TOP 100 * FROM A WITH (NOLOCK) WHERE D >= CONVERT(DATE, '2020-08-17') AND D <= CONVERT(DATE, '2020-08-30')")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("AA") == "AA")
+        assert(genDate.getDtable("A") == "A")
       }
 
       "wrapped query with alias for SQL queries " in {
@@ -305,9 +305,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
+    "quote" should {
       "escape each subfields separately" in {
-        val actual = genDate.escapeIdentifier("System User.[Table Name]")
+        val actual = genDate.quote("System User.[Table Name]")
 
         assert(actual == "[System User].[Table Name]")
       }
@@ -372,48 +372,48 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("com.denodo.vdp.jdbc.Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
+      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT \"A\", \"D\", \"Column with spaces\" FROM \"A\"")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA")
+      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -426,44 +426,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("AA") == "AA")
+        assert(gen.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -471,9 +471,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
-      "escape each subfields separately" in {
-        val actual = gen.escapeIdentifier("System User.\"Table Name\"")
+    "quote" should {
+      "quote each subfields separately" in {
+        val actual = gen.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
@@ -550,7 +550,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     genNum.setConnection(connection)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) AS cnt 'cnt' FROM AA")
+      assert(gen.getCountQuery("A") == "SELECT COUNT(*) AS cnt 'cnt' FROM A")
     }
 
     "generate data queries without date ranges" in {
@@ -558,7 +558,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("company", columns, None) == "SELECT AA, DD, 'Column with spaces'n FROM company")
+      assert(genEscaped.getDataQuery("company", columns, None) == "SELECT 'A'n, 'D'n, 'Column with spaces'n FROM 'company'n")
     }
 
     "generate data queries with limit clause date ranges" in {
@@ -567,29 +567,29 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = date'2020-08-17'")
-        assert(gen.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(gen.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = date'2020-08-17'")
+        assert(gen.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS cnt 'cnt' FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS cnt 'cnt' FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "date is in DATETIME format" in {
         assertThrows[UnsupportedOperationException] {
-          genDateTime.getDataQuery("AA", date1, date1, Nil, None)
+          genDateTime.getDataQuery("A", date1, date1, Nil, None)
         }
       }
 
@@ -604,36 +604,36 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     "generate ranged data queries" when {
       "date is in DATE format" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = date'2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17'")
         assert(gen.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
         assert(genStr.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = '2020-08-17'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = '2020-08-17'")
         assert(genStr.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
         assert(genNum.getDataQuery("company", date1, date1, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = 20200817")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = 20200817")
         assert(genNum.getDataQuery("company", date1, date2, Nil, None) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= 20200817 AND DD <= 20200830")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
         assert(gen.getDataQuery("company", date1, date1, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD = date'2020-08-17' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D = date'2020-08-17' LIMIT 100")
         assert(gen.getDataQuery("company", date1, date2, Nil, Some(100)) ==
-          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
+          "SELECT ID 'ID', NAME 'NAME', DESCRIPTION 'DESCRIPTION', EMAIL 'EMAIL', FOUNDED 'FOUNDED', LAST_UPDATED 'LAST_UPDATED', INFO_DATE 'INFO_DATE' FROM company WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("AA") == "AA")
+        assert(gen.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -648,51 +648,51 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genNum = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigNumber, config)
     val genDateTime = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigDateTime, config)
     val genEscaped = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", sqlConfigEscape, config)
-    val genEscaped2 = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", DummySqlConfigFactory.getDummyConfig(infoDateColumn = "`Info date`"), config)
+    val genEscaped2 = fromDriverName("com.cloudera.hive.jdbc41.HS2Driver", DummySqlConfigFactory.getDummyConfig(infoDateColumn = "`Info date`", escapeIdentifiers = true), config)
 
     "generate count queries without date ranges" in {
-      assert(gen.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
+      assert(gen.getCountQuery("A") == "SELECT COUNT(*) FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(gen.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(gen.getDataQuery("AA", columns, None) == "SELECT AA, DD, `Column with spaces` FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT `A`, `D`, `Column with spaces` FROM `A`")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(gen.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
+      assert(gen.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(gen.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = to_date('2020-08-17')")
-        assert(gen.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30')")
+        assert(gen.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = to_date('2020-08-17')")
+        assert(gen.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = to_date('2020-08-17')")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= to_date('2020-08-17') AND CAST(DD AS DATE) <= to_date('2020-08-30')")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -712,44 +712,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = to_date('2020-08-17')")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30')")
+        assert(gen.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = to_date('2020-08-17')")
+        assert(gen.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = to_date('2020-08-17')")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= to_date('2020-08-17') AND CAST(DD AS DATE) <= to_date('2020-08-30')")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = to_date('2020-08-17')")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= to_date('2020-08-17') AND CAST(D AS DATE) <= to_date('2020-08-30')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(gen.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = to_date('2020-08-17') LIMIT 100")
-        assert(gen.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= to_date('2020-08-17') AND DD <= to_date('2020-08-30') LIMIT 100")
+        assert(gen.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = to_date('2020-08-17') LIMIT 100")
+        assert(gen.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= to_date('2020-08-17') AND D <= to_date('2020-08-30') LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(gen.getDtable("AA") == "(AA) tbl")
+        assert(gen.getDtable("A") == "(A) tbl")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -757,9 +757,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
+    "quote" should {
       "escape each subfields separately" in {
-        val actual = gen.escapeIdentifier("System User.`Table Name`")
+        val actual = gen.quote("System User.`Table Name`")
 
         assert(actual == "`System User`.`Table Name`")
       }
@@ -774,48 +774,48 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("org.postgresql.Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) FROM AA")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT \"A\", \"D\", \"Column with spaces\" FROM \"A\"")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
+      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = date'2020-08-17'")
-        assert(genDate.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(genDate.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = date'2020-08-17'")
+        assert(genDate.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -828,44 +828,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("AA") == "AA")
+        assert(genDate.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -873,9 +873,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
-      "escape each subfields separately" in {
-        val actual = genDate.escapeIdentifier("System User.\"Table Name\"")
+    "quote" should {
+      "quote each subfields separately" in {
+        val actual = genDate.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
@@ -890,48 +890,48 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("com.ibm.db2.jcc.DB2Driver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT \"A\", \"D\", \"Column with spaces\" FROM \"A\"")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
+      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = DATE '2020-08-17'")
-        assert(genDate.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30'")
+        assert(genDate.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = DATE '2020-08-17'")
+        assert(genDate.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) = DATE '2020-08-17'")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) >= DATE '2020-08-17' AND CAST(DD AS DATE) <= DATE '2020-08-30'")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = DATE '2020-08-17'")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= DATE '2020-08-17' AND CAST(D AS DATE) <= DATE '2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -944,44 +944,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = DATE '2020-08-17'")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30'")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = DATE '2020-08-17'")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = DATE '2020-08-17'")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= DATE '2020-08-17' AND CAST(DD AS DATE) <= DATE '2020-08-30'")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = DATE '2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= DATE '2020-08-17' AND CAST(D AS DATE) <= DATE '2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = DATE '2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= DATE '2020-08-17' AND DD <= DATE '2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = DATE '2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= DATE '2020-08-17' AND D <= DATE '2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("AA") == "AA")
+        assert(genDate.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -989,9 +989,9 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
-      "escape each subfields separately" in {
-        val actual = genDate.escapeIdentifier("System User.\"Table Name\"")
+    "quote" should {
+      "quote each subfields separately" in {
+        val actual = genDate.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
@@ -1006,48 +1006,48 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("org.hsqldb.jdbc.JDBCDriver", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT \"A\", \"D\", \"Column with spaces\" FROM \"A\"")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
+      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
-        assert(genDate.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND DD <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+        assert(genDate.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+        assert(genDate.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(DD AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -1060,44 +1060,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND DD <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(DD AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = TO_DATE('2020-08-17', 'YYYY-MM-DD')")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND CAST(D AS DATE) <= TO_DATE('2020-08-30', 'YYYY-MM-DD')")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = TO_DATE('2020-08-17', 'YYYY-MM-DD') LIMIT 100")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND DD <= TO_DATE('2020-08-30', 'YYYY-MM-DD') LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = TO_DATE('2020-08-17', 'YYYY-MM-DD') LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= TO_DATE('2020-08-17', 'YYYY-MM-DD') AND D <= TO_DATE('2020-08-30', 'YYYY-MM-DD') LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("AA") == "AA")
+        assert(genDate.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -1105,22 +1105,22 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
+    "quote" should {
       "escape each subfields separately" in {
-        val actual = genDate.escapeIdentifier("System User.\"Table Name\"")
+        val actual = genDate.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
 
       "throw an exception if a column contains a single quote" in {
         assertThrows[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC ' DEF")
+          genDate.quote("ABC ' DEF")
         }
       }
 
       "throw an exception if a column contains a semicolon" in {
         assertThrows[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC ; DEF")
+          genDate.quote("ABC ; DEF")
         }
       }
     }
@@ -1134,48 +1134,48 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
     val genEscaped = fromDriverName("generic", sqlConfigEscape, config)
 
     "generate count queries without date ranges" in {
-      assert(genDate.getCountQuery("AA") == "SELECT COUNT(*) AS CNT FROM AA")
+      assert(genDate.getCountQuery("A") == "SELECT COUNT(*) AS CNT FROM A")
     }
 
     "generate data queries without date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, None) == "SELECT * FROM AA")
+      assert(genDate.getDataQuery("A", Nil, None) == "SELECT * FROM A")
     }
 
     "generate data queries when list of columns is specified" in {
-      assert(genDate.getDataQuery("AA", columns, None) == "SELECT AA, DD, \"Column with spaces\" FROM AA")
+      assert(genEscaped.getDataQuery("A", columns, None) == "SELECT \"A\", \"D\", \"Column with spaces\" FROM \"A\"")
     }
 
     "generate data queries with limit clause date ranges" in {
-      assert(genDate.getDataQuery("AA", Nil, Some(100)) == "SELECT * FROM AA LIMIT 100")
+      assert(genDate.getDataQuery("A", Nil, Some(100)) == "SELECT * FROM A LIMIT 100")
     }
 
     "generate ranged count queries" when {
       "date is in DATE format" in {
-        assert(genDate.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = date'2020-08-17'")
-        assert(genDate.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(genDate.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = date'2020-08-17'")
+        assert(genDate.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getCountQuery("AA", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD = 20200817")
-        assert(genNum.getCountQuery("AA", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getCountQuery("A", date1, date1) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D = 20200817")
+        assert(genNum.getCountQuery("A", date1, date2) ==
+          "SELECT COUNT(*) AS CNT FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "the table name and column name need to be escaped" in {
@@ -1188,44 +1188,44 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
     "generate ranged data queries" when {
       "date is in DATE format" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17'")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30'")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17'")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30'")
       }
 
       "date is in DATETIME format" in {
-        assert(genDateTime.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) = date'2020-08-17'")
-        assert(genDateTime.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE CAST(DD AS DATE) >= date'2020-08-17' AND CAST(DD AS DATE) <= date'2020-08-30'")
+        assert(genDateTime.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) = date'2020-08-17'")
+        assert(genDateTime.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE CAST(D AS DATE) >= date'2020-08-17' AND CAST(D AS DATE) <= date'2020-08-30'")
       }
 
       "date is in STRING format" in {
-        assert(genStr.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = '2020-08-17'")
-        assert(genStr.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= '2020-08-17' AND DD <= '2020-08-30'")
+        assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = '2020-08-17'")
+        assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= '2020-08-17' AND D <= '2020-08-30'")
       }
 
       "date is in NUMBER format" in {
-        assert(genNum.getDataQuery("AA", date1, date1, Nil, None) ==
-          "SELECT * FROM AA WHERE DD = 20200817")
-        assert(genNum.getDataQuery("AA", date1, date2, Nil, None) ==
-          "SELECT * FROM AA WHERE DD >= 20200817 AND DD <= 20200830")
+        assert(genNum.getDataQuery("A", date1, date1, Nil, None) ==
+          "SELECT * FROM A WHERE D = 20200817")
+        assert(genNum.getDataQuery("A", date1, date2, Nil, None) ==
+          "SELECT * FROM A WHERE D >= 20200817 AND D <= 20200830")
       }
 
       "with limit records" in {
-        assert(genDate.getDataQuery("AA", date1, date1, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD = date'2020-08-17' LIMIT 100")
-        assert(genDate.getDataQuery("AA", date1, date2, Nil, Some(100)) ==
-          "SELECT * FROM AA WHERE DD >= date'2020-08-17' AND DD <= date'2020-08-30' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date1, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D = date'2020-08-17' LIMIT 100")
+        assert(genDate.getDataQuery("A", date1, date2, Nil, Some(100)) ==
+          "SELECT * FROM A WHERE D >= date'2020-08-17' AND D <= date'2020-08-30' LIMIT 100")
       }
     }
 
     "getDtable" should {
       "return the original table when a table is provided" in {
-        assert(genDate.getDtable("AA") == "AA")
+        assert(genDate.getDtable("A") == "A")
       }
 
       "wrapped query without alias for SQL queries " in {
@@ -1233,31 +1233,31 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
       }
     }
 
-    "escapeIdentifier" should {
-      "escape each subfields separately" in {
-        val actual = genDate.escapeIdentifier("System User.\"Table Name\"")
+    "quote" should {
+      "quote each subfields separately" in {
+        val actual = genDate.quote("System User.\"Table Name\"")
 
         assert(actual == "\"System User\".\"Table Name\"")
       }
 
       "escape should not escape if turned off by config" in {
-        val sql = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "DD", escapeIdentifiers = false)
+        val sql = DummySqlConfigFactory.getDummyConfig(infoDateType = SqlColumnType.DATE, infoDateColumn = "D", escapeIdentifiers = false)
         val genDate = fromDriverName("generic", sql, config)
 
-        val actual = genDate.escapeIdentifier("System User.\"Table Name\"")
+        val actual = genDate.asInstanceOf[SqlGeneratorBase].escape("System User.\"Table Name\"")
 
         assert(actual == "System User.\"Table Name\"")
       }
 
       "throw an exception if a column contains a single quote" in {
         assertThrows[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC ' DEF")
+          genDate.quote("ABC ' DEF")
         }
       }
 
       "throw an exception if a column contains a semicolon" in {
         val ex = intercept[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC ; DEF")
+          genDate.quote("ABC ; DEF")
         }
 
         assert(ex.getMessage == "The character ';' (0x3B) cannot be used as part of column name in 'ABC ; DEF'.")
@@ -1265,13 +1265,13 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "throw an exception if a column contains a back slash" in {
         assertThrows[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC \\n DEF")
+          genDate.quote("ABC \\n DEF")
         }
       }
 
       "throw an exception if a column contains a new line" in {
         assertThrows[IllegalArgumentException] {
-          genDate.escapeIdentifier("ABC \n DEF")
+          genDate.quote("ABC \n DEF")
         }
       }
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -510,10 +510,20 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
         assert(actual == Seq("\"System User.Table Name\""))
       }
 
-      "handle escaped quotes" in {
-        val actual = gen.asInstanceOf[SqlGeneratorBase].splitComplexIdentifier("\"System \"\"User\"\".Table Name\"")
+      "handle escaped 2 quotes (maybe support this eventually)" in {
+        val ex = intercept[IllegalArgumentException] {
+          gen.asInstanceOf[SqlGeneratorBase].splitComplexIdentifier("\"System \"\"User\"\".Table Name\"")
+        }
 
-        assert(actual == Seq("\"System \"\"User\"\".Table Name\""))
+        assert(ex.getMessage == "Invalid character '\"' in the identifier '\"System \"\"User\"\".Table Name\"', position 9.")
+      }
+
+      "handle escaped 3 quotes (this is never supported)" in {
+        val ex = intercept[IllegalArgumentException] {
+          gen.asInstanceOf[SqlGeneratorBase].splitComplexIdentifier("\"System \"\"\"User\"\"\".Table Name\"")
+        }
+
+        assert(ex.getMessage == "Invalid character '\"' in the identifier '\"System \"\"\"User\"\"\".Table Name\"', position 9.")
       }
 
       "throw an exception if quotes are found inside an identifier" in {
@@ -537,7 +547,7 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
           gen.asInstanceOf[SqlGeneratorBase].splitComplexIdentifier("System User.Table Name\"")
         }
 
-        assert(ex.getMessage.contains("Invalid character '\"' in the identifier 'System User.Table Name\"'"))
+        assert(ex.getMessage.contains("Found not matching '\"' in the identifier 'System User.Table Name\"'."))
       }
     }
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -28,6 +28,8 @@ import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.utils.JdbcSparkUtils
 import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
 
+import java.sql.ResultSet
+
 class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with RelationalDbFixture with TextComparisonFixture {
   import spark.implicits._
 
@@ -216,6 +218,56 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
         assert(actualVarchar == expectedVarchar)
       }
+    }
+
+    "test SQL injesction" in {
+      val conn = getConnection
+      //val st: PreparedStatement = conn.prepareStatement("SELECT 1 FROM COMPANY;drop table company;SELECT * FROM COMPANY")
+      val st = conn.createStatement()
+
+      //st.setString(1, "1; drop table company;")
+      //st.setString(1, "description")
+
+      val metadata = conn.getMetaData
+
+      try {
+        val resultSet = metadata.getTables(null, null, "COMPANY", null)
+        try {
+          println(s"${resultSet.getMetaData.getColumnName(1)}  ${resultSet.getMetaData.getColumnName(2)}   ${resultSet.getMetaData.getColumnName(3)}")
+          while(resultSet.next()) {
+
+            println(s"${resultSet.getString(1)}  ${resultSet.getString(2)}   ${resultSet.getString(3)}")
+          }
+        }
+        catch {
+          case _: Throwable =>
+            println("crap")
+        }
+        finally
+          if (resultSet != null) resultSet.close()
+      }
+
+      println(st.toString)
+
+      val rs: ResultSet = st.executeQuery("SELECT * FROM company")
+
+      while(rs.next()) {
+        println(rs.getString(1))
+      }
+      rs.close()
+      st.close()
+//
+//      println("--------------")
+//      val st1: Statement = conn.createStatement()
+//
+//      val rs1: ResultSet = st1.executeQuery("SELECT * FROM COMPANY")
+//      while(rs1.next()) {
+//        println(rs1.getString(1))
+//      }
+//      rs1.close()
+//      st1.close()
+
+      conn.close()
     }
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -28,8 +28,6 @@ import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.utils.JdbcSparkUtils
 import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
 
-import java.sql.ResultSet
-
 class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with RelationalDbFixture with TextComparisonFixture {
   import spark.implicits._
 
@@ -218,56 +216,6 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
         assert(actualVarchar == expectedVarchar)
       }
-    }
-
-    "test SQL injesction" in {
-      val conn = getConnection
-      //val st: PreparedStatement = conn.prepareStatement("SELECT 1 FROM COMPANY;drop table company;SELECT * FROM COMPANY")
-      val st = conn.createStatement()
-
-      //st.setString(1, "1; drop table company;")
-      //st.setString(1, "description")
-
-      val metadata = conn.getMetaData
-
-      try {
-        val resultSet = metadata.getTables(null, null, "COMPANY", null)
-        try {
-          println(s"${resultSet.getMetaData.getColumnName(1)}  ${resultSet.getMetaData.getColumnName(2)}   ${resultSet.getMetaData.getColumnName(3)}")
-          while(resultSet.next()) {
-
-            println(s"${resultSet.getString(1)}  ${resultSet.getString(2)}   ${resultSet.getString(3)}")
-          }
-        }
-        catch {
-          case _: Throwable =>
-            println("crap")
-        }
-        finally
-          if (resultSet != null) resultSet.close()
-      }
-
-      println(st.toString)
-
-      val rs: ResultSet = st.executeQuery("SELECT * FROM company")
-
-      while(rs.next()) {
-        println(rs.getString(1))
-      }
-      rs.close()
-      st.close()
-//
-//      println("--------------")
-//      val st1: Statement = conn.createStatement()
-//
-//      val rs1: ResultSet = st1.executeQuery("SELECT * FROM COMPANY")
-//      while(rs1.next()) {
-//        println(rs1.getString(1))
-//      }
-//      rs1.close()
-//      st1.close()
-
-      conn.close()
     }
   }
 


### PR DESCRIPTION
Closes #325

The PR removes the check of input table name of column name against the list of keywords because it cannot be exhausting, but adds the user the option to control how thorough the quoting policy will be. If quoting is enables ('auto' or 'always') validation of identifiers are mandatory.

The new option:
```hocon
# One of: auto, always, never 
# - When 'auto', input columns that contain non-alphanumeric characters (and underscore) will be quoted.
# - When 'always', all input table names and column names will be validated and quoted, if not quoted already.
# - When 'never', Pramen will use names as configured without changing them.
# Keep in mind that quoted identifiers are case sensitive in most relational databases.
identifier.quoting.policy = "auto"
``` 
