### PR TITLE
#324 Make string to date conversion for MS SQL Server queries graceful.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -55,9 +55,10 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlCo
     val dateBeginLit = getDateLiteral(dateBegin)
     val dateEndLit = getDateLiteral(dateEnd)
 
-    val infoDateColumnAdjusted = if (sqlConfig.infoDateType == SqlColumnType.DATETIME ||
-      (sqlConfig.infoDateType == SqlColumnType.STRING && isIso)) {
+    val infoDateColumnAdjusted = if (sqlConfig.infoDateType == SqlColumnType.DATETIME) {
       s"CONVERT(DATE, $infoDateColumn)"
+    } else if (sqlConfig.infoDateType == SqlColumnType.STRING && isIso) {
+      s"(CASE WHEN ISDATE($infoDateColumn) = 1 THEN CONVERT(DATE, $infoDateColumn) ELSE NULL END)"
     } else {
       infoDateColumn
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/sql/SqlGeneratorSuite.scala
@@ -218,9 +218,10 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "date is in STRING ISO format" in {
         assert(genStr.getCountQuery("A", date1, date1) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) = CONVERT(DATE, '2020-08-17')")
         assert(genStr.getCountQuery("A", date1, date2) ==
-          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
+          "SELECT COUNT(*) AS CNT FROM A WITH (NOLOCK) WHERE (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) >= CONVERT(DATE, '2020-08-17') " +
+            "AND (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING non ISO format" in {
@@ -269,9 +270,10 @@ class SqlGeneratorSuite extends AnyWordSpec with RelationalDbFixture {
 
       "date is in STRING ISO format" in {
         assert(genStr.getDataQuery("A", date1, date1, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) = CONVERT(DATE, '2020-08-17')")
+          "SELECT * FROM A WITH (NOLOCK) WHERE (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) = CONVERT(DATE, '2020-08-17')")
         assert(genStr.getDataQuery("A", date1, date2, Nil, None) ==
-          "SELECT * FROM A WITH (NOLOCK) WHERE CONVERT(DATE, D) >= CONVERT(DATE, '2020-08-17') AND CONVERT(DATE, D) <= CONVERT(DATE, '2020-08-30')")
+          "SELECT * FROM A WITH (NOLOCK) WHERE (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) >= CONVERT(DATE, '2020-08-17') " +
+            "AND (CASE WHEN ISDATE(D) = 1 THEN CONVERT(DATE, D) ELSE NULL END) <= CONVERT(DATE, '2020-08-30')")
       }
 
       "date is in STRING non-ISO format" in {


### PR DESCRIPTION
Closes #324

The expression is chosen such so it is supported by all MS SQL Server flavors.

This is only applicable if the info date column is a varchar(). If the input column is datetime, the current CONVERT() works just fine.

Tested end to end.