### PR TITLE
#366 Track raw files at sources and in the metastore by size instead by count

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
@@ -18,6 +18,7 @@ package za.co.absa.pramen.core.runner.jobrunner
 
 import com.github.yruslan.channel.{Channel, ReadChannel}
 import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.exceptions.FatalErrorWrapper
@@ -103,7 +104,8 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
   }
 
   private[core] def sendFailure(ex: Throwable, job: Job, isTransient: Boolean): Unit = {
-    completedJobsChannel.send((job, TaskResult(job, RunStatus.Failed(ex), None, applicationId, isTransient, Nil, Nil, Nil) :: Nil, false))
+    completedJobsChannel.send((job, TaskResult(job, RunStatus.Failed(ex), None, applicationId, isTransient,
+      job.outputTable.format.isInstanceOf[DataFormat.Raw], Nil, Nil, Nil) :: Nil, false))
   }
 
   private[core] def runJob(job: Job): Boolean = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -20,6 +20,7 @@ import com.github.yruslan.channel.Channel
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.app.AppContext
 import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, ValidationException}
 import za.co.absa.pramen.core.pipeline.{Job, JobDependency, OperationType}
@@ -124,7 +125,8 @@ class OrchestratorImpl extends Orchestrator {
       val isTransient = job.outputTable.format.isTransient
       val isFailure = hasNonPassiveNonOptionalDeps(job, missingTables)
 
-      val taskResult = TaskResult(job, RunStatus.MissingDependencies(isFailure, missingTables), None, applicationId, isTransient, Nil, Nil, Nil)
+      val taskResult = TaskResult(job, RunStatus.MissingDependencies(isFailure, missingTables), None, applicationId,
+        isTransient, job.outputTable.format.isInstanceOf[DataFormat.Raw], Nil, Nil, Nil)
 
       state.addTaskCompletion(taskResult :: Nil)
     })

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskResult.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskResult.scala
@@ -25,6 +25,7 @@ case class TaskResult(
                        runInfo: Option[RunInfo],
                        applicationId: String,
                        isTransient: Boolean,
+                       isRawFilesJob: Boolean,
                        schemaChanges: Seq[SchemaDifference],
                        dependencyWarnings: Seq[DependencyWarning],
                        notificationTargetErrors: Seq[NotificationFailure]

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/SparkSource.scala
@@ -57,7 +57,7 @@ class SparkSource(val format: Option[String],
       case _: Query.Sql     => Array.empty[String]
       case Query.Path(path) =>
         val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, path)
-        fsUtils.getHadoopFiles(new Path(path))
+        fsUtils.getHadoopFiles(new Path(path)).map(_.getPath.toString).sorted
       case other            => throw new IllegalArgumentException(s"'${other.name}' is not supported by the Spark source. Use 'path', 'table' or 'sql' instead.")
     }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/FsUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/FsUtils.scala
@@ -676,7 +676,7 @@ class FsUtils(conf: Configuration, pathBase: String) {
     *
     * The glob pattern is supported. Maximum depth of recursivity is 1.
     */
-  def getHadoopFiles(path: Path, includeHiddenFiles: Boolean = false): Array[String] = {
+  def getHadoopFiles(path: Path, includeHiddenFiles: Boolean = false): Array[FileStatus] = {
     val fileFilter = if (includeHiddenFiles) anyFileFilter else hiddenFileFilter
 
     val stats: Array[FileStatus] = fs.globStatus(path, fileFilter)
@@ -694,7 +694,7 @@ class FsUtils(conf: Configuration, pathBase: String) {
       }
     })
 
-    allFiles.map(_.getPath.toString).toArray[String]
+    allFiles.toArray[FileStatus]
   }
 
   /**
@@ -704,7 +704,7 @@ class FsUtils(conf: Configuration, pathBase: String) {
     *
     * The glob pattern is supported. Maximum depth of recursivity is 1.
     */
-  def getHadoopFilesCaseInsensitive(path: Path, includeHiddenFiles: Boolean = false): Array[String] = {
+  def getHadoopFilesCaseInsensitive(path: Path, includeHiddenFiles: Boolean = false): Array[FileStatus] = {
     def containsWildcard(input: String): Boolean = {
       val wildcardPattern = "[*?{}!]".r
         wildcardPattern.findFirstIn(input).isDefined
@@ -735,7 +735,7 @@ class FsUtils(conf: Configuration, pathBase: String) {
         }
       })
 
-      allFiles.map(_.getPath.toString).toArray[String]
+      allFiles.toArray[FileStatus]
     }
   }
 

--- a/pramen/core/src/test/resources/test/notify/test_pipeline_email_body_complex.txt
+++ b/pramen/core/src/test/resources/test/notify/test_pipeline_email_body_complex.txt
@@ -114,7 +114,7 @@
 <th>Record Count</th>
 <th>Elapsed Time</th>
 <th>Size</th>
-<th>RPS</th>
+<th>Throughput</th>
 <th>Saved at</th>
 <th>Status</th>
 <th>Reason</th></tr></thead>
@@ -125,7 +125,7 @@
 <td style="text-align:right">20000 (+10000)</td>
 <td style="text-align:center">01:14:04</td>
 <td style="text-align:right">97 KiB</td>
-<td class="tdwarn" style="text-align:right">4</td>
+<td class="tdwarn" style="text-align:right">4 r/s</td>
 <td style="text-align:center">1970-01-01 03:34 +0200</td>
 <td class="tdwarn" style="text-align:center">Warning</td>
 <td>Test warning</td></tr></tbody>

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/RunStatusFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/RunStatusFactory.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.mocks
+
+import za.co.absa.pramen.core.pipeline.TaskRunReason
+import za.co.absa.pramen.core.runner.task.RunStatus
+
+object RunStatusFactory {
+  def getDummySuccess(recordCountOld: Option[Long] = None,
+                      recordCount: Long = 1000,
+                      sizeBytes: Option[Long] = None,
+                      reason: TaskRunReason = TaskRunReason.New,
+                      filesRead: Seq[String] = Nil,
+                      filesWritten: Seq[String] = Nil,
+                      hiveTablesUpdated: Seq[String] = Nil,
+                      warnings: Seq[String] = Nil): RunStatus.Succeeded = {
+    RunStatus.Succeeded(recordCountOld,
+      recordCount,
+      sizeBytes,
+      reason,
+      filesRead,
+      filesWritten,
+      hiveTablesUpdated,
+      warnings)
+  }
+
+  def getDummyFailure(ex: Throwable = new RuntimeException("Dummy failure")): RunStatus.Failed = {
+    RunStatus.Failed(ex)
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/TaskResultFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/TaskResultFactory.scala
@@ -29,6 +29,7 @@ object TaskResultFactory {
                          runInfo: Option[RunInfo] = Some(RunInfo(LocalDate.of(2022, 2, 18), Instant.ofEpochSecond(1234), Instant.ofEpochSecond(5678))),
                          applicationId: String = "app_123",
                          isTransient: Boolean = false,
+                         isRawFilesJob: Boolean = false,
                          schemaDifferences: Seq[SchemaDifference] = Nil,
                          dependencyWarnings: Seq[DependencyWarning] = Nil,
                          notificationTargetErrors: Seq[NotificationFailure] = Nil): TaskResult = {
@@ -37,6 +38,7 @@ object TaskResultFactory {
       runInfo,
       applicationId,
       isTransient,
+      isRawFilesJob,
       schemaDifferences,
       dependencyWarnings,
       notificationTargetErrors)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/runner/ConcurrentJobRunnerSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/runner/ConcurrentJobRunnerSpy.scala
@@ -74,7 +74,7 @@ class ConcurrentJobRunnerSpy(includeFails: Boolean = false,
         RunStatus.NoData(isNoDataFailure)
       }
 
-      val taskResult = TaskResult(job, status, Some(RunInfo(infoDate, started, finished)), "app_123", isTransient = false, Nil, Nil, Nil)
+      val taskResult = TaskResult(job, status, Some(RunInfo(infoDate, started, finished)), "app_123", isTransient = false, isRawFilesJob = false, Nil, Nil, Nil)
 
       completedJobsChannel.send((job, taskResult :: Nil, taskResult.runStatus.isInstanceOf[RunStatus.Succeeded] || taskResult.runStatus == RunStatus.NotRan))
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/TaskCompletedSuite.scala
@@ -39,6 +39,7 @@ class TaskCompletedSuite extends AnyWordSpec {
         Some(RunInfo(infoDate, now.minusSeconds(10), now)),
         "app_123",
         isTransient = false,
+        isRawFilesJob = false,
         Nil,
         Nil,
         Nil)
@@ -72,6 +73,7 @@ class TaskCompletedSuite extends AnyWordSpec {
         None,
         "app_123",
         isTransient = false,
+        isRawFilesJob = false,
         Nil,
         Nil,
         Nil)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/FsUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/FsUtilsSuite.scala
@@ -908,7 +908,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFiles(innerPath)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("data1.bin"))
+        assert(files.head.getPath.toString.endsWith("data1.bin"))
       }
     }
 
@@ -944,7 +944,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
 
         assert(filesByPath.isEmpty)
         assert(filesWithMask.length == 1)
-        assert(filesWithMask.head.endsWith("data1.bin"))
+        assert(filesWithMask.head.getPath.toString.endsWith("data1.bin"))
       }
     }
 
@@ -960,7 +960,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFiles(innerPath)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("data1.bin"))
+        assert(files.head.getPath.toString.endsWith("data1.bin"))
       }
     }
 
@@ -977,7 +977,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFiles(innerFile)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("data1.bin"))
+        assert(files.head.getPath.toString.endsWith("data1.bin"))
       }
     }
   }
@@ -1006,6 +1006,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         createBinFile(innerPath.toString, "_data3.BiN", 100)
 
         val files = fsUtils.getHadoopFilesCaseInsensitive(filePattern, includeHiddenFiles = true)
+          .map(_.getPath.toString)
 
         assert(files.length == 3)
         assert(files.exists(_.endsWith("Adata1.BIN")))
@@ -1029,7 +1030,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFilesCaseInsensitive(filePattern)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("Adata1.BiN"))
+        assert(files.head.getPath.toString.endsWith("Adata1.BiN"))
       }
     }
 
@@ -1045,7 +1046,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFilesCaseInsensitive(innerPath)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("data1.bin"))
+        assert(files.head.getPath.toString.endsWith("data1.bin"))
       }
     }
 
@@ -1062,7 +1063,7 @@ class FsUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture {
         val files = fsUtils.getHadoopFilesCaseInsensitive(innerFile)
 
         assert(files.length == 1)
-        assert(files.head.endsWith("data1.bin"))
+        assert(files.head.getPath.toString.endsWith("data1.bin"))
       }
     }
   }


### PR DESCRIPTION
Closes #366 

Since the choice of what info to track spreads across all pipeline, and can't be solved on the source level of  `RawFileSource`, I decided to always track files by size, and not make it optional.

We we need to track raw files in a different way in the future, will add an option then.

Here is how notifications that involve file landing jobs look like:
![Screenshot 2024-03-13 at 11 45 12](https://github.com/AbsaOSS/pramen/assets/4082463/972b0292-5314-4025-a4aa-47fd83e0ad64)

