### PR TITLE
#375 Add workaround for timestamp overflows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,10 @@ is determined by the pipeline configuration.
 
       # (Optional) The timeout for connecting to the JDBC host.
       connection.timeout = 60
+
+      # (Optional) For built-in JDBC connector the default behavior is sanitize timestemp fields
+      # by bounding to the range of 0001-01-01 ... 9999-12-31. This behavior can be switched off like this
+      sanitize.timestamps = false
       
       # Any option passed as 'option.' will be passed to the JDBC driver. Example:
       #option.database = "test_db"

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/JdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/JdbcConfig.scala
@@ -30,6 +30,7 @@ case class JdbcConfig(
                        password: Option[String] = None,
                        retries: Option[Int] = None,
                        connectionTimeoutSeconds: Option[Int] = None,
+                       sanitizeTimestamps: Boolean = true,
                        extraOptions: Map[String, String] = Map.empty[String, String]
                      )
 
@@ -44,6 +45,7 @@ object JdbcConfig {
   val JDBC_PASSWORD = "jdbc.password"
   val JDBC_RETRIES = "jdbc.retries"
   val JDBC_CONNECTION_TIMEOUT = "jdbc.connection.timeout"
+  val JDBC_SANITIZE_TIMESTAMPS = "jdbc.sanitize.timestamps"
   val JDBC_EXTRA_OPTIONS_PREFIX = "jdbc.option"
 
   def load(conf: Config, parent: String = ""): JdbcConfig = {
@@ -72,6 +74,7 @@ object JdbcConfig {
       password = ConfigUtils.getOptionString(conf, JDBC_PASSWORD),
       retries = ConfigUtils.getOptionInt(conf, JDBC_RETRIES),
       connectionTimeoutSeconds = ConfigUtils.getOptionInt(conf, JDBC_CONNECTION_TIMEOUT),
+      sanitizeTimestamps = ConfigUtils.getOptionBoolean(conf, JDBC_SANITIZE_TIMESTAMPS).getOrElse(true),
       extraOptions = ConfigUtils.getExtraOptions(conf, JDBC_EXTRA_OPTIONS_PREFIX)
     )
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -89,13 +89,13 @@ object JdbcNativeUtils {
 
     // Executing the query
     val rs = getResultSet(jdbcConfig, url, query)
-    val driverIterator = new ResultSetToRowIterator(rs)
+    val driverIterator = new ResultSetToRowIterator(rs, jdbcConfig.sanitizeTimestamps)
     val schema = JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
 
     driverIterator.close()
 
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {
-      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q))
+      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q), jdbcConfig.sanitizeTimestamps)
     })
 
     spark.createDataFrame(rdd, schema)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
@@ -136,9 +136,9 @@ class ResultSetToRowIterator(rs: ResultSet, sanitizeTimestamps: Boolean) extends
 }
 
 object ResultSetToRowIterator {
-  val MAX_SAFE_TIMESTAMP_MILLI: Long = LocalDateTime.of(9999, 12, 31, 23, 59, 59).toEpochSecond(ZoneOffset.UTC) * 1000
+  val MAX_SAFE_TIMESTAMP_MILLI: Long = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999999999).toInstant(ZoneOffset.UTC).toEpochMilli
   val MAX_SAFE_TIMESTAMP = new Timestamp(MAX_SAFE_TIMESTAMP_MILLI)
 
-  val MIN_SAFE_TIMESTAMP_MILLI: Long = LocalDateTime.of(1, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1000
+  val MIN_SAFE_TIMESTAMP_MILLI: Long = LocalDateTime.of(1, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli
   val MIN_SAFE_TIMESTAMP = new Timestamp(MIN_SAFE_TIMESTAMP_MILLI)
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
@@ -24,7 +24,7 @@ import java.sql.Types._
 import java.sql.{ResultSet, Timestamp}
 import java.time.{LocalDateTime, ZoneOffset}
 
-class ResultSetToRowIterator(rs: ResultSet) extends Iterator[Row] {
+class ResultSetToRowIterator(rs: ResultSet, sanitizeTimestamps: Boolean) extends Iterator[Row] {
   import ResultSetToRowIterator._
 
   private var didHasNext = false
@@ -121,13 +121,17 @@ class ResultSetToRowIterator(rs: ResultSet) extends Iterator[Row] {
   }
 
   private[core] def sanitizeTimestamp(timestamp: Timestamp): Timestamp = {
-    val timeMilli = timestamp.getTime
-    if (timeMilli > MAX_SAFE_TIMESTAMP_MILLI)
-      MAX_SAFE_TIMESTAMP
-    else if (timeMilli < MIN_SAFE_TIMESTAMP_MILLI)
-      MIN_SAFE_TIMESTAMP
-    else
-    timestamp
+    if (sanitizeTimestamps) {
+      val timeMilli = timestamp.getTime
+      if (timeMilli > MAX_SAFE_TIMESTAMP_MILLI)
+        MAX_SAFE_TIMESTAMP
+      else if (timeMilli < MIN_SAFE_TIMESTAMP_MILLI)
+        MIN_SAFE_TIMESTAMP
+      else
+        timestamp
+    } else {
+      timestamp
+    }
   }
 }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
@@ -55,6 +55,7 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |  }
        |
        |  has.information.date.column = true
+       |  jdbc.sanitize.timestamps = false
        |
        |  information.date.column = "FOUNDED"
        |  information.date.type = "date"
@@ -98,11 +99,13 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
     "work with legacy config" in {
       val reader = TableReaderJdbcNative(conf.getConfig("reader_legacy"), "reader_legacy")
       assert(reader.infoDateFormatPattern == "yyyy-MM-DD")
+      assert(!reader.getJdbcConfig.sanitizeTimestamps)
     }
 
     "work with minimal config" in {
       val reader = TableReaderJdbcNative(conf.getConfig("reader_minimal"), "reader_minimal")
       assert(reader.infoDateFormatPattern == "yyyy-MM-dd")
+      assert(reader.getJdbcConfig.sanitizeTimestamps)
     }
 
     "throw an exception if config is missing" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
@@ -196,7 +196,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
   "sanitizeTimestamp" should {
     // From Spark:
     // https://github.com/apache/spark/blob/ad8ac17dbdfa763236ab3303eac6a3115ba710cc/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala#L457
-    val minTimeStamp = -62135596800000L
+    val minTimestamp = -62135596800000L
     val maxTimestamp = 253402300799999L
 
     // Variable names come from PostgreSQL "constant field docs":
@@ -225,10 +225,10 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
 
       val fixedTs = iterator.sanitizeTimestamp(timestamp)
 
-      assert(fixedTs.getTime == minTimeStamp)
+      assert(fixedTs.getTime == minTimestamp)
     }
 
-    "convert overflowed value to null" in {
+    "convert overflowed value to the maximum value supported" in {
       val iterator = new ResultSetToRowIterator(resultSet, true)
       val timestamp = Timestamp.from(Instant.ofEpochMilli(1000000000000000L))
 


### PR DESCRIPTION
Closes #375 

This PR makes Pamen built-in JDBC reader sanitize timestamps, having them in year ranges 1...9999.

This automatically solves PostgreSQL infinity timestamp issue, and possible other issues without sacrificing features much.

This is how the PostgreSql table with infinities looks like (displayed in GMT+2 time zone):
![Screenshot 2024-03-19 at 14 22 31](https://github.com/AbsaOSS/pramen/assets/4082463/d2be9dc7-8e86-4b6a-9cf7-fa84fcff11d5)
