### PR TITLE
#376 Add support for 'input.table' when JDBC Native is used with supported SQL dialects.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.reader
+
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.TableReader
+import za.co.absa.pramen.api.sql.{SqlColumnType, SqlConfig}
+import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
+import za.co.absa.pramen.core.sql.SqlGeneratorLoader
+import za.co.absa.pramen.core.utils.ConfigUtils
+import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
+
+abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
+                                   jdbcUrlSelector: JdbcUrlSelector,
+                                   conf: Config) extends TableReader {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  protected val jdbcRetries: Int = jdbcReaderConfig.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
+  protected val extraOptions: Map[String, String] = ConfigUtils.getExtraOptions(conf, "option")
+
+  private[core] lazy val sqlGen = {
+    val gen = SqlGeneratorLoader.getSqlGenerator(jdbcReaderConfig.jdbcConfig.driver, getSqlConfig)
+
+    if (gen.requiresConnection) {
+      val (connection, _) = jdbcUrlSelector.getWorkingConnection(jdbcRetries)
+      gen.setConnection(connection)
+    }
+    gen
+  }
+
+  private[core] def getSqlConfig: SqlConfig = {
+    val dateFieldType = SqlColumnType.fromString(jdbcReaderConfig.infoDateType)
+    dateFieldType match {
+      case Some(infoDateType) =>
+        SqlConfig(jdbcReaderConfig.infoDateColumn,
+          infoDateType,
+          jdbcReaderConfig.infoDateFormat,
+          jdbcReaderConfig.identifierQuotingPolicy,
+          jdbcReaderConfig.sqlGeneratorClass,
+          ConfigUtils.getExtraConfig(conf, "sql"))
+      case None => throw new IllegalArgumentException(s"Unknown info date type specified (${jdbcReaderConfig.infoDateType}). " +
+        s"It should be one of: date, string, number")
+    }
+  }
+
+  protected def logConfiguration(): Unit = {
+    jdbcUrlSelector.logConnectionSettings()
+
+    log.info(s"JDBC Reader Configuration:")
+    log.info(s"Has information date column:  ${jdbcReaderConfig.hasInfoDate}")
+    if (jdbcReaderConfig.hasInfoDate) {
+      log.info(s"Info date column name:      ${jdbcReaderConfig.infoDateColumn}")
+      log.info(s"Info date column data type: ${jdbcReaderConfig.infoDateType}")
+      log.info(s"Info date format:           ${jdbcReaderConfig.infoDateFormat}")
+    }
+    log.info(s"Save timestamp as dates:      ${jdbcReaderConfig.saveTimestampsAsDates}")
+    log.info(s"Correct decimals in schemas:  ${jdbcReaderConfig.correctDecimalsInSchema}")
+    log.info(s"Identifier quoting policy:    ${jdbcReaderConfig.identifierQuotingPolicy.name}")
+    jdbcReaderConfig.limitRecords.foreach(n => log.info(s"Limit records:                $n"))
+
+    log.info("Extra JDBC reader Spark options:")
+    ConfigUtils.renderExtraOptions(extraOptions, JDBC_WORDS_TO_REDACT)(s => log.info(s))
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -72,9 +72,9 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
 
   private[core] def getSqlDataQuery(table: String, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String]): String = {
     if (jdbcReaderConfig.hasInfoDate) {
-      sqlGen.getDataQuery(table, infoDateBegin, infoDateEnd, columns, None)
+      sqlGen.getDataQuery(table, infoDateBegin, infoDateEnd, columns, jdbcReaderConfig.limitRecords)
     } else {
-      sqlGen.getDataQuery(table, columns, None)
+      sqlGen.getDataQuery(table, columns, jdbcReaderConfig.limitRecords)
     }
   }
 

--- a/pramen/core/src/test/resources/test/config/integration_ingestion_native.conf
+++ b/pramen/core/src/test/resources/test/config/integration_ingestion_native.conf
@@ -1,0 +1,75 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These variables are expected to be set up by the test suite
+#base.path = "/tmp"
+#jdbc.url = "jdbc:..."
+#jdbc.user = "some_user"
+#jdbc.password = "some_password"
+
+
+pramen {
+  pipeline.name = "Ingestion infinity"
+
+  temporary.directory = ${base.path}/temp
+
+  bookkeeping.enabled = false
+  stop.spark.session = false
+}
+
+pramen.metastore {
+  tables = [
+    {
+      name = "table1"
+      format = "parquet"
+      path = ${base.path}/table1
+    }
+  ]
+}
+
+pramen.sources = [
+  {
+    name = "jdbc_source"
+    factory.class = "za.co.absa.pramen.core.source.JdbcSource"
+
+    jdbc = {
+      driver = "org.hsqldb.jdbc.JDBCDriver"
+      url = ${jdbc.url}
+      user = ${jdbc.user}
+      password = ${jdbc.password}
+    }
+
+    fail.if.no.data = true
+    has.information.date.column = false
+    enable.schema.metadata = true
+
+    use.jdbc.native = true
+  }
+]
+
+pramen.operations = [
+  {
+    name = "Ingestion Job"
+    type = "ingestion"
+
+    schedule.type = "daily"
+    source = "jdbc_source"
+    info.date.expr = "@runDate"
+    tables = [
+      {
+        input.table = "company"
+        output.metastore.table = "table1"
+      },
+    ]
+  }
+]

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/JdbcNativeTableLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/JdbcNativeTableLongSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.integration
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.runner.AppRunner
+import za.co.absa.pramen.core.samples.RdbExampleTable
+import za.co.absa.pramen.core.utils.ResourceUtils
+
+import java.time.LocalDate
+
+class JdbcNativeTableLongSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with TempDirFixture with TextComparisonFixture with RelationalDbFixture {
+  private val infoDate = LocalDate.of(2021, 2, 18)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    RdbExampleTable.Company.initTable(getConnection)
+  }
+
+  override protected def afterAll(): Unit = {
+    RdbExampleTable.Company.dropTable(getConnection)
+    super.afterAll()
+  }
+
+
+  "JDBC native pipeline" should {
+    "support input.table setting" in {
+      withTempDirectory("postgre_inf") { tempDir =>
+        val table1Path = new Path(new Path(tempDir, "table1"), s"pramen_info_date=$infoDate")
+
+        val conf = getConfig(tempDir)
+        val exitCode = AppRunner.runPipeline(conf)
+        assert(exitCode == 0)
+
+        val resultDf = spark.read.parquet(table1Path.toString)
+
+        assert(resultDf.count() == 4)
+      }
+    }
+  }
+
+  def getConfig(basePath: String): Config = {
+    val configContents = ResourceUtils.getResourceString("/test/config/integration_ingestion_native.conf")
+    val basePathEscaped = basePath.replace("\\", "\\\\")
+
+    val conf = ConfigFactory.parseString(
+      s"""base.path = "$basePathEscaped"
+         |pramen.runtime.is.rerun = true
+         |pramen.current.date = "$infoDate"
+         |jdbc.url="$url"
+         |jdbc.user="$user"
+         |jdbc.password="$password"
+         |
+         |$configContents
+         |""".stripMargin
+    ).withFallback(ConfigFactory.load())
+      .resolve()
+
+    conf
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
@@ -71,9 +71,17 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |  }
        |
        |  has.information.date.column = false
+       |}
+       |reader_limit {
+       |  jdbc {
+       |    driver = "$driver"
+       |    connection.string = "$url"
+       |    user = "$user"
+       |    password = "$password"
+       |  }
        |
-       |  information.date.column = "FOUNDED"
-       |  information.date.type = "date"
+       |  has.information.date.column = false
+       |  limit.records = 100
        |}""".stripMargin)
 
   override protected def beforeAll(): Unit = {
@@ -284,6 +292,14 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
       val actual = reader.getSqlDataQuery("table1", infoDateBegin, infoDateEnd, Nil)
 
       assert(actual == "SELECT * FROM table1")
+    }
+
+    "return a query without with limits" in {
+      val reader = TableReaderJdbcNative(conf.getConfig("reader_limit"), "reader_limit")
+
+      val actual = reader.getSqlDataQuery("table1", infoDateBegin, infoDateEnd, Nil)
+
+      assert(actual == "SELECT * FROM table1 LIMIT 100")
     }
   }
 }


### PR DESCRIPTION
Closes #376 

This PR allow usage of `input.table="db_tatble"` together with `use.jdbc.native=true`.

In order to avoid code dublication, some pieces of code from `TableReaderJdbc` and `TableReaderJdbcNative` is extracted into a common base abstract class `TableReaderJdbcBase`.
