### PR TITLE
Update versions of Scala, Spark and sbt for builds and CI/CD.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,12 @@ jobs:
         with:
           ref: main
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup JDK and sbt
+        uses: actions/setup-java@v4.2.1
         with:
-          java-version: "adopt@1.8"
+          distribution: temurin
+          java-version: 8
+          cache: sbt
 
       - name: Import GPG Key
         run: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -36,10 +36,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: coursier/cache-action@v5
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup JDK and sbt
+        uses: actions/setup-java@v4.2.1
         with:
-          java-version: "adopt@1.8"
+          distribution: temurin
+          java-version: 8
+          cache: sbt
       - name: Build and run unit tests
         working-directory: ./pramen
         run: sbt ++${{matrix.scala}} test -DSPARK_VERSION=${{matrix.spark}}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,16 +18,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11.12, 2.12.18, 2.13.12]
-        spark: [2.4.8, 3.2.4, 3.3.3, 3.4.1]
+        scala: [2.11.12, 2.12.19, 2.13.13]
+        spark: [2.4.8, 3.3.4, 3.4.2, 3.5.1]
         exclude:
           - scala: 2.11.12
-            spark: 3.2.4
+            spark: 3.3.4
           - scala: 2.11.12
-            spark: 3.3.3
+            spark: 3.4.2
           - scala: 2.11.12
-            spark: 3.4.1
-          - scala: 2.13.12
+            spark: 3.5.1
+          - scala: 2.12.19
+            spark: 2.4.8
+          - scala: 2.13.13
             spark: 2.4.8
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
@@ -35,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: coursier/cache-action@v5
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v14
         with:
           java-version: "adopt@1.8"
       - name: Build and run unit tests

--- a/pramen/build.sbt
+++ b/pramen/build.sbt
@@ -20,8 +20,8 @@ import BuildInfoTemplateSettings._
 import com.github.sbt.jacoco.report.JacocoReportSettings
 
 val scala211 = "2.11.12"
-val scala212 = "2.12.18"
-val scala213 = "2.13.12"
+val scala212 = "2.12.19"
+val scala213 = "2.13.13"
 
 ThisBuild / organization := "za.co.absa.pramen"
 

--- a/pramen/examples/combined_example.sh
+++ b/pramen/examples/combined_example.sh
@@ -3,7 +3,7 @@
 # Prerequisites:
 # 1. Download Spark 3.4.1 (Scala 2.12) and install it in /opt/spark/spark-3.4.1 or some other directory
 # 2. At repo_root/pramen, run
-#    sbt -DSPARK_VERSION="3.4.1" ++2.12.18 assembly
+#    sbt -DSPARK_VERSION="3.4.1" ++2.12.19 assembly
 # 3. Run
 #    ./examples/combined_example.sh
 

--- a/pramen/project/Dependencies.scala
+++ b/pramen/project/Dependencies.scala
@@ -50,7 +50,7 @@ object Dependencies {
     "org.apache.httpcomponents" %  "httpclient"                 % httpClientVersion,
     "org.scalatest"             %% "scalatest"                  % scalatestVersion           % Test
   ) ++ Seq(
-    getAbrisDependency(scalaVersion),
+    getAbrisDependency(sparkVersion(scalaVersion)),
     getDeltaDependency(sparkVersion(scalaVersion), isCompile = false, isTest = true)
   )
 

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import sbt.*
 
 object Versions {

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+
 import sbt.*
 
 object Versions {
   val defaultSparkVersionForScala211 = "2.4.8"
-  val defaultSparkVersionForScala212 = "3.3.3"
-  val defaultSparkVersionForScala213 = "3.4.1"
+  val defaultSparkVersionForScala212 = "3.3.4"
+  val defaultSparkVersionForScala213 = "3.4.2"
 
   val typesafeConfigVersion = "1.4.0"
   val postgreSqlDriverVersion = "42.3.8"
@@ -93,13 +94,15 @@ object Versions {
     }
   }
 
-  def getAbrisDependency(scalaVersion: String): ModuleID = {
-    // According to this: https://docs.delta.io/latest/releases.html
-    val abrisVersion = scalaVersion match {
-      case version if version.startsWith("2.11.") => "5.1.1"
-      case version if version.startsWith("2.12.") => "5.1.1"
-      case version if version.startsWith("2.13.") => "6.0.0"
-      case _                                      => throw new IllegalArgumentException(s"Scala $scalaVersion not supported for Abris dependency.")
+  def getAbrisDependency(sparkVersion: String): ModuleID = {
+    // According to this: https://github.com/AbsaOSS/ABRiS?tab=readme-ov-file#supported-versions
+    val abrisVersion = sparkVersion match {
+      case version if version.startsWith("2.4.") => "5.1.1"
+      case version if version.startsWith("3.0.") => "5.1.1"
+      case version if version.startsWith("3.1.") => "5.1.1"
+      case version if version.startsWith("3.2.") => "6.1.1"
+      case version if version.startsWith("3.")   => "6.4.0"
+      case _                                     => throw new IllegalArgumentException(s"Spark $sparkVersion not supported for Abris dependency.")
     }
 
     println(s"Using Abris version $abrisVersion")

--- a/pramen/project/Versions.scala
+++ b/pramen/project/Versions.scala
@@ -99,7 +99,7 @@ object Versions {
       case version if version.startsWith("2.4.") => "5.1.1"
       case version if version.startsWith("3.0.") => "5.1.1"
       case version if version.startsWith("3.1.") => "5.1.1"
-      case version if version.startsWith("3.2.") => "6.1.1"
+      case version if version         == "3.2.0" => "6.1.1"
       case version if version.startsWith("3.")   => "6.4.0"
       case _                                     => throw new IllegalArgumentException(s"Spark $sparkVersion not supported for Abris dependency.")
     }

--- a/pramen/project/build.properties
+++ b/pramen/project/build.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.9.7
+sbt.version=1.9.9


### PR DESCRIPTION
Closes #382

Updates versions to latest patches, and replaces obsolete `setup-scala` plugin so that JDK is latest, not old like this:
![Screenshot 2024-03-22 at 9 19 22](https://github.com/AbsaOSS/pramen/assets/4082463/b13800c0-0df3-4220-8ccb-1d1e8e88b7ca)

With the change:
![Screenshot 2024-03-22 at 9 32 15 1](https://github.com/AbsaOSS/pramen/assets/4082463/d908238b-85d3-4c1f-9e4d-76c21897f585)

