### PR TITLE
#388 Handle OS signals and include thread stack traces in email notifications

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/OsSignalException.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/OsSignalException.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.exceptions
+
+case class OsSignalException(signalName: String,
+                             threadStackTraces: Seq[ThreadStackTrace]) extends RuntimeException(s"The process was interrupted by $signalName.")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/ThreadStackTrace.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/exceptions/ThreadStackTrace.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.exceptions
+
+case class ThreadStackTrace(threadName: String, stackTrace: Array[StackTraceElement])

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -20,14 +20,14 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.notification._
 import za.co.absa.pramen.core.config.Keys.TIMEZONE
-import za.co.absa.pramen.core.exceptions.{CmdFailedException, ProcessFailedException}
+import za.co.absa.pramen.core.exceptions.{CmdFailedException, OsSignalException, ProcessFailedException}
 import za.co.absa.pramen.core.notify.message._
 import za.co.absa.pramen.core.notify.pipeline.PipelineNotificationBuilderHtml.{MIN_MEGABYTES, MIN_RPS_JOB_DURATION_SECONDS, MIN_RPS_RECORDS}
 import za.co.absa.pramen.core.pipeline.TaskRunReason
 import za.co.absa.pramen.core.runner.task.RunStatus._
 import za.co.absa.pramen.core.runner.task.{NotificationFailure, RunStatus, TaskResult}
 import za.co.absa.pramen.core.utils.JvmUtils.getShortExceptionDescription
-import za.co.absa.pramen.core.utils.StringUtils.renderThrowable
+import za.co.absa.pramen.core.utils.StringUtils.{renderMultiStack, renderThrowable}
 import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ConfigUtils, StringUtils, TimeUtils}
 
 import java.time._
@@ -286,6 +286,8 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
         val stdoutMsg = if (stdout.isEmpty) "" else s"""Last <b>stdout</b> lines:\n${stdout.mkString("", EOL, EOL)}"""
         val stderrMsg = if (stderr.isEmpty) "" else s"""Last <b>stderr</b> lines:\n${stderr.mkString("", EOL, EOL)}"""
         s"$msg\n$stdoutMsg\n$stderrMsg"
+      case signalException: OsSignalException =>
+        renderMultiStack(signalException)
       case ex: Throwable                     =>
         renderThrowable(ex)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -20,14 +20,14 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.notification._
 import za.co.absa.pramen.core.config.Keys.TIMEZONE
-import za.co.absa.pramen.core.exceptions.{CmdFailedException, OsSignalException, ProcessFailedException}
+import za.co.absa.pramen.core.exceptions.{CmdFailedException, ProcessFailedException}
 import za.co.absa.pramen.core.notify.message._
 import za.co.absa.pramen.core.notify.pipeline.PipelineNotificationBuilderHtml.{MIN_MEGABYTES, MIN_RPS_JOB_DURATION_SECONDS, MIN_RPS_RECORDS}
 import za.co.absa.pramen.core.pipeline.TaskRunReason
 import za.co.absa.pramen.core.runner.task.RunStatus._
 import za.co.absa.pramen.core.runner.task.{NotificationFailure, RunStatus, TaskResult}
 import za.co.absa.pramen.core.utils.JvmUtils.getShortExceptionDescription
-import za.co.absa.pramen.core.utils.StringUtils.{renderMultiStack, renderThrowable}
+import za.co.absa.pramen.core.utils.StringUtils.renderThrowable
 import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ConfigUtils, StringUtils, TimeUtils}
 
 import java.time._
@@ -286,8 +286,6 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
         val stdoutMsg = if (stdout.isEmpty) "" else s"""Last <b>stdout</b> lines:\n${stdout.mkString("", EOL, EOL)}"""
         val stderrMsg = if (stderr.isEmpty) "" else s"""Last <b>stderr</b> lines:\n${stderr.mkString("", EOL, EOL)}"""
         s"$msg\n$stdoutMsg\n$stderrMsg"
-      case signalException: OsSignalException =>
-        renderMultiStack(signalException)
       case ex: Throwable                     =>
         renderThrowable(ex)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.pramen.core.utils
 
-import za.co.absa.pramen.core.exceptions.OsSignalException
+import za.co.absa.pramen.core.exceptions.{OsSignalException, ThreadStackTrace}
 import za.co.absa.pramen.core.expr.DateExprEvaluator
 
 import java.util.{Base64, StringTokenizer}
@@ -177,12 +177,12 @@ object StringUtils {
     base + cause
   }
 
-  def renderMultiStack(signalException: OsSignalException): String = {
+  def renderThreadDumps(threadStackTraces: Seq[ThreadStackTrace]): String = {
     val threadTitlePadding = "  "
     val stackTracePadding = "    "
-    val base = s"""The process was interrupted by ${signalException.signalName}.\n"""
+    val base = s"""Stack trace of threads at the moment of the interruption:\n"""
 
-    val details = signalException.threadStackTraces.zipWithIndex.map {
+    val details = threadStackTraces.zipWithIndex.map {
       case (threadStackTrace, index) =>
         val threadTitle = s"${threadTitlePadding}Thread $index (${threadStackTrace.threadName}): \n"
         val stackTrace = threadStackTrace.stackTrace

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.pramen.core.utils
 
+import za.co.absa.pramen.core.exceptions.OsSignalException
 import za.co.absa.pramen.core.expr.DateExprEvaluator
 
 import java.util.{Base64, StringTokenizer}
@@ -174,6 +175,22 @@ object StringUtils {
       case _                    => ""
     }
     base + cause
+  }
+
+  def renderMultiStack(signalException: OsSignalException): String = {
+    val threadTitlePadding = "  "
+    val stackTracePadding = "    "
+    val base = s"""The process was interrupted by ${signalException.signalName}.\n"""
+
+    val details = signalException.threadStackTraces.zipWithIndex.map {
+      case (threadStackTrace, index) =>
+        val threadTitle = s"${threadTitlePadding}Thread $index (${threadStackTrace.threadName}): \n"
+        val stackTrace = threadStackTrace.stackTrace
+        val stackTraceStr = s"""${stackTrace.map(s => s"$stackTracePadding$s").mkString("", EOL, EOL)}""".stripMargin
+        threadTitle + stackTraceStr
+    }.mkString("\n")
+
+    base + details
   }
 
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/runner/PipelineRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/runner/PipelineRunner.scala
@@ -20,6 +20,7 @@ import com.typesafe.config.Config
 import za.co.absa.pramen.core.RunnerCommons._
 import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.runner.AppRunner
+import za.co.absa.pramen.core.state.PipelineStateImpl
 import za.co.absa.pramen.core.utils.ConfigUtils
 
 import scala.collection.mutable.ListBuffer
@@ -34,7 +35,7 @@ object PipelineRunner {
   def main(args: Array[String]): Unit = {
     val configs: Seq[Config] = getMainContext(args)
     val isExitCodeEnabled = configs.head.getBoolean(Keys.EXIT_CODE_ENABLED)
-    var overallExitCode = 0
+    var overallExitCode = PipelineStateImpl.EXIT_CODE_SUCCESS
 
     configs.foreach { conf =>
       ConfigUtils.logEffectiveConfigProps(conf, Keys.CONFIG_KEYS_TO_REDACT, Keys.KEYS_TO_REDACT)
@@ -43,7 +44,7 @@ object PipelineRunner {
       overallExitCode |= exitCode
     }
 
-    if (isExitCodeEnabled && overallExitCode != 0) {
+    if (isExitCodeEnabled && overallExitCode != PipelineStateImpl.EXIT_CODE_SUCCESS) {
       System.exit(overallExitCode)
     }
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/state/PipelineStateSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/state/PipelineStateSuite.scala
@@ -91,17 +91,13 @@ class PipelineStateSuite extends AnyWordSpec {
     }
   }
 
-  "protectAgainstDoubleFinish" should {
-    "throw an exception when called twice" in {
+  "alreadyFinished" should {
+    "return true is the application is already in process of finishing" in {
       val stateManager = getMockPipelineState()
 
       stateManager.setSuccess()
 
-      val ex = intercept[IllegalStateException] {
-        stateManager.protectAgainstDoubleFinish()
-      }
-
-      assert(ex.getMessage.contains("Attempt to run post finish tasks multiple times"))
+      assert(stateManager.alreadyFinished())
     }
 
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/StringUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/StringUtilsSuite.scala
@@ -218,9 +218,9 @@ class StringUtilsSuite extends AnyWordSpec {
 
 
       val ex = OsSignalException("SIGTEST", nonDaemonStackTraces)
-      val actual = renderMultiStack(ex)
+      val actual = renderThreadDumps(ex.threadStackTraces)
 
-      assert(actual.startsWith("The process was interrupted by SIGTEST."))
+      assert(actual.startsWith("Stack trace of threads at the moment of the interruption:"))
       assert(actual.contains("  Thread 0"))
       assert(actual.contains("(ScalaTest-dispatcher)"))
       assert(actual.contains("    java.lang.Thread.dumpThreads(Native Method)"))


### PR DESCRIPTION
Closes #388 

If the pipeline is interrupted with Ctrl+C, or kill (SIGTERM), or connection to the terminal is lost (SIGHUP), Pramen will now specify the exact signal received, and include stack traces of all [non-daemon] threads in the email notification.

This is useful when the pipeline is killed due to some kind of deadlock to debug the place where the deadlock happened.

![Screenshot 2024-04-02 at 14 13 16](https://github.com/AbsaOSS/pramen/assets/4082463/712ffa03-b31c-415c-bc00-5267dfeb5975)
