### PR TITLE
#520 Add ability to run incremental transformers and sinks

### DIFF
--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/DataFormat.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/DataFormat.scala
@@ -23,6 +23,8 @@ sealed trait DataFormat {
   def isTransient: Boolean
 
   def isLazy: Boolean
+
+  def isRaw: Boolean
 }
 
 object DataFormat {
@@ -32,6 +34,8 @@ object DataFormat {
     override val isTransient: Boolean = false
 
     override val isLazy: Boolean = false
+
+    override val isRaw: Boolean = false
   }
 
   case class Delta(query: Query, recordsPerPartition: Option[Long]) extends DataFormat {
@@ -40,6 +44,8 @@ object DataFormat {
     override val isTransient: Boolean = false
 
     override val isLazy: Boolean = false
+
+    override val isRaw: Boolean = false
   }
 
   // This format is used for metatables which are just files and can only be used for further sourcing
@@ -49,6 +55,8 @@ object DataFormat {
     override val isTransient: Boolean = false
 
     override val isLazy: Boolean = false
+
+    override val isRaw: Boolean = true
   }
 
   // This format is used for tables that exist only for the duration of the process, and is not persisted
@@ -58,6 +66,8 @@ object DataFormat {
     override val isTransient: Boolean = true
 
     override val isLazy: Boolean = false
+
+    override val isRaw: Boolean = false
   }
 
   // This format is used for tables are calculated only if requested, and is not persisted
@@ -67,6 +77,8 @@ object DataFormat {
     override val isTransient: Boolean = true
 
     override val isLazy: Boolean = true
+
+    override val isRaw: Boolean = false
   }
 
   // This format is used for metatables which do not support persistence, e.g. for sink or transfer jobs
@@ -76,5 +88,7 @@ object DataFormat {
     override val isTransient: Boolean = false
 
     override val isLazy: Boolean = false
+
+    override val isRaw: Boolean = false
   }
 }

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/sql/SqlGeneratorBase.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/sql/SqlGeneratorBase.scala
@@ -216,7 +216,7 @@ abstract class SqlGeneratorBase(sqlConfig: SqlConfig) extends SqlGenerator {
 }
 
 object SqlGeneratorBase {
-  val MAX_STRING_OFFSET_CHARACTERS = 64
+  val MAX_STRING_OFFSET_CHARACTERS = 128
 
   val forbiddenCharacters = ";'\\"
   val normalCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_."

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -147,6 +147,9 @@ pramen {
   initial.sourcing.date.weekly.expr = "@runDate - 6"
   initial.sourcing.date.monthly.expr = "beginOfMonth(@runDate)"
 
+  # If true, Prmen always adds 'pramen_batchid' column, even for non-incremental pipelines
+  always.add.batchid.column = false
+
   # Pramen can stop the Spark session at the end of execution. This can help cleanly finalize running
   # jobs started from 'spark-submit'. But when running on Databriks this results in the job failure.
   # Use it with caution.

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -147,7 +147,7 @@ pramen {
   initial.sourcing.date.weekly.expr = "@runDate - 6"
   initial.sourcing.date.monthly.expr = "beginOfMonth(@runDate)"
 
-  # If true, Prmen always adds 'pramen_batchid' column, even for non-incremental pipelines
+  # If true, Pramen always adds 'pramen_batchid' column, even for non-incremental pipelines
   always.add.batchid.column = false
 
   # Pramen can stop the Spark session at the end of execution. This can help cleanly finalize running

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/AppContextImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/AppContextImpl.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import za.co.absa.pramen.api.MetadataManager
 import za.co.absa.pramen.core.PramenImpl
-import za.co.absa.pramen.core.app.config.InfoDateConfig
+import za.co.absa.pramen.core.app.config.{InfoDateConfig, RuntimeConfig}
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.lock.{TokenLockFactory, TokenLockFactoryAllow}
@@ -57,7 +57,7 @@ object AppContextImpl {
 
     val (bookkeeper, tokenLockFactory, journal, metadataManager, closable) = Bookkeeper.fromConfig(appConfig.bookkeepingConfig, appConfig.runtimeConfig, batchId)
 
-    val metastore: Metastore = MetastoreImpl.fromConfig(conf, appConfig.infoDateDefaults, bookkeeper, metadataManager, batchId)
+    val metastore: Metastore = MetastoreImpl.fromConfig(conf, appConfig.runtimeConfig, appConfig.infoDateDefaults, bookkeeper, metadataManager, batchId)
 
     PramenImpl.instance.asInstanceOf[PramenImpl].setMetadataManager(metadataManager)
     PramenImpl.instance.asInstanceOf[PramenImpl].setWorkflowConfig(conf)
@@ -83,8 +83,9 @@ object AppContextImpl {
     val appConfig = AppConfig.fromConfig(conf)
 
     val metadataManager = new MetadataManagerNull(isPersistenceEnabled = false)
+    val runtimeConfig = RuntimeConfig.default
 
-    val metastore: Metastore = MetastoreImpl.fromConfig(conf, infoDateConfig, bookkeeper, metadataManager, 0L)
+    val metastore: Metastore = MetastoreImpl.fromConfig(conf, runtimeConfig, infoDateConfig, bookkeeper, metadataManager, 0L)
 
     val appContext = new AppContextImpl(
       appConfig,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
@@ -42,6 +42,7 @@ case class RuntimeConfig(
                           parallelTasks: Int,
                           stopSparkSession: Boolean,
                           allowEmptyPipeline: Boolean,
+                          alwaysAddBatchIdColumn: Boolean,
                           historicalRunMode: RunMode,
                           sparkAppDescriptionTemplate: Option[String]
                         )
@@ -67,6 +68,7 @@ object RuntimeConfig {
   val STOP_SPARK_SESSION = "pramen.stop.spark.session"
   val VERBOSE = "pramen.verbose"
   val ALLOW_EMPTY_PIPELINE = "pramen.allow.empty.pipeline"
+  val ALWAYS_ADD_BATCHID_COLUMN = "pramen.always.add.batchid.column"
   val SPARK_APP_DESCRIPTION_TEMPLATE = "pramen.job.description.template"
 
   def fromConfig(conf: Config): RuntimeConfig = {
@@ -130,6 +132,7 @@ object RuntimeConfig {
     }
 
     val allowEmptyPipeline = ConfigUtils.getOptionBoolean(conf, ALLOW_EMPTY_PIPELINE).getOrElse(false)
+    val alwaysAddBatchIdColumn = ConfigUtils.getOptionBoolean(conf, ALWAYS_ADD_BATCHID_COLUMN).getOrElse(false)
     val sparkAppDescriptionTemplate = ConfigUtils.getOptionString(conf, SPARK_APP_DESCRIPTION_TEMPLATE)
 
     RuntimeConfig(
@@ -147,6 +150,7 @@ object RuntimeConfig {
       parallelTasks = parallelTasks,
       stopSparkSession = conf.getBoolean(STOP_SPARK_SESSION),
       allowEmptyPipeline,
+      alwaysAddBatchIdColumn,
       runMode,
       sparkAppDescriptionTemplate
     )
@@ -168,6 +172,7 @@ object RuntimeConfig {
       parallelTasks = 1,
       stopSparkSession = true,
       allowEmptyPipeline = false,
+      alwaysAddBatchIdColumn = false,
       historicalRunMode = RunMode.CheckUpdates,
       sparkAppDescriptionTemplate = None
     )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
@@ -151,4 +151,25 @@ object RuntimeConfig {
       sparkAppDescriptionTemplate
     )
   }
+
+  def default: RuntimeConfig = {
+    RuntimeConfig(
+      isDryRun = false,
+      isRerun = false,
+      runTables = Seq.empty,
+      isUndercover = false,
+      useLocks = true,
+      checkOnlyLateData = false,
+      checkOnlyNewData = true,
+      emailIfNoChanges = false,
+      runDate = LocalDate.now(),
+      runDateTo = None,
+      isInverseOrder = false,
+      parallelTasks = 1,
+      stopSparkSession = true,
+      allowEmptyPipeline = false,
+      historicalRunMode = RunMode.CheckUpdates,
+      sparkAppDescriptionTemplate = None
+    )
+  }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperJdbc.scala
@@ -33,7 +33,7 @@ class BookkeeperJdbc(db: Database, batchId: Long) extends BookkeeperBase(true) {
   import za.co.absa.pramen.core.utils.FutureImplicits._
 
   private val log = LoggerFactory.getLogger(this.getClass)
-  private val offsetManagement = new OffsetManagerJdbc(db, batchId)
+  private val offsetManagement = new OffsetManagerCached(new OffsetManagerJdbc(db, batchId))
 
   override val bookkeepingEnabled: Boolean = true
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetCommitRequest.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetCommitRequest.scala
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.core.metastore
+package za.co.absa.pramen.core.bookkeeper
 
-import za.co.absa.pramen.api.MetastoreReader
+import za.co.absa.pramen.api.offset.OffsetValue
 
-trait MetastoreReaderCore extends MetastoreReader {
-  def commitIncrementalStage(): Unit
-}
+import java.time.{Instant, LocalDate}
+
+case class OffsetCommitRequest(
+                                table: String,
+                                infoDate: LocalDate,
+                                minOffset: OffsetValue,
+                                maxOffset: OffsetValue,
+                                createdAt: Instant
+                              )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
@@ -80,6 +80,11 @@ trait OffsetManager {
   def commitRerun(request: DataOffsetRequest, minOffset: OffsetValue, maxOffset: OffsetValue): Unit
 
   /**
+    * Combines both startWriteOffsets() and commitOffsets() into one operation when it is applicable.
+    */
+  def postCommittedRecord(table: String, infoDate: LocalDate, minOffset: OffsetValue, maxOffset: OffsetValue): Unit
+
+  /**
     * Rolls back an offset request
     */
   def rollbackOffsets(request: DataOffsetRequest): Unit

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
@@ -82,7 +82,7 @@ trait OffsetManager {
   /**
     * Combines both startWriteOffsets() and commitOffsets() into one operation when it is applicable.
     */
-  def postCommittedRecord(table: String, infoDate: LocalDate, minOffset: OffsetValue, maxOffset: OffsetValue): Unit
+  def postCommittedRecords(commitRequests: Seq[OffsetCommitRequest]): Unit
 
   /**
     * Rolls back an offset request

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManager.scala
@@ -18,7 +18,7 @@ package za.co.absa.pramen.core.bookkeeper
 
 import za.co.absa.pramen.api.offset.DataOffset.UncommittedOffset
 import za.co.absa.pramen.api.offset.{DataOffset, OffsetType, OffsetValue}
-import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest}
+import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest, OffsetCommitRequest}
 
 import java.time.LocalDate
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.bookkeeper
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.offset.DataOffset.UncommittedOffset
 import za.co.absa.pramen.api.offset.{DataOffset, OffsetType, OffsetValue}
-import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest}
+import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest, OffsetCommitRequest}
 
 import java.time.LocalDate
 import scala.collection.mutable

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
@@ -40,12 +40,17 @@ class OffsetManagerCached(offsetManager: OffsetManager) extends OffsetManager {
   }
 
   def getMaxInfoDateAndOffset(table: String, onlyForInfoDate: Option[LocalDate]): Option[DataOffsetAggregated] = synchronized {
+    val tbl = onlyForInfoDate match {
+      case Some(date) => s"'$table' for '$date'"
+      case None => s"'$table'"
+    }
+
     if (aggregatedOffsetsCache.contains((table, onlyForInfoDate))) {
-      log.info(s"Got min/max offsets for '$table' from cache.")
+      log.info(s"Got min/max offsets for $tbl from cache.")
       aggregatedOffsetsCache((table, onlyForInfoDate))
     } else {
       val value = offsetManager.getMaxInfoDateAndOffset(table, onlyForInfoDate)
-      log.info(s"Got min/max offsets for '$table' from the database. Saving to cache...")
+      log.info(s"Got min/max offsets for $tbl from the database. Saving to cache...")
       aggregatedOffsetsCache += (table, onlyForInfoDate) -> value
       value
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerCached.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.bookkeeper
+
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.offset.DataOffset.UncommittedOffset
+import za.co.absa.pramen.api.offset.{DataOffset, OffsetType, OffsetValue}
+import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest}
+
+import java.time.LocalDate
+import scala.collection.mutable
+
+/**
+  * The offset manager decorator handles caching or repeated queries.
+  */
+class OffsetManagerCached(offsetManager: OffsetManager) extends OffsetManager {
+  private val log = LoggerFactory.getLogger(this.getClass)
+  private val aggregatedOffsetsCache = new mutable.HashMap[(String, Option[LocalDate]), Option[DataOffsetAggregated]]
+
+  def getOffsets(table: String, infoDate: LocalDate): Array[DataOffset] = {
+    offsetManager.getOffsets(table, infoDate)
+  }
+
+  def getUncommittedOffsets(table: String, onlyForInfoDate: Option[LocalDate]): Array[UncommittedOffset] = {
+    offsetManager.getUncommittedOffsets(table, onlyForInfoDate)
+  }
+
+  def getMaxInfoDateAndOffset(table: String, onlyForInfoDate: Option[LocalDate]): Option[DataOffsetAggregated] = synchronized {
+    if (aggregatedOffsetsCache.contains((table, onlyForInfoDate))) {
+      log.info(s"Got min/max offsets for '$table' from cache.")
+      aggregatedOffsetsCache((table, onlyForInfoDate))
+    } else {
+      val value = offsetManager.getMaxInfoDateAndOffset(table, onlyForInfoDate)
+      log.info(s"Got min/max offsets for '$table' from the database. Saving to cache...")
+      aggregatedOffsetsCache += (table, onlyForInfoDate) -> value
+      value
+    }
+  }
+
+  def startWriteOffsets(table: String, infoDate: LocalDate, offsetType: OffsetType): DataOffsetRequest = {
+    offsetManager.startWriteOffsets(table, infoDate, offsetType)
+  }
+
+  def commitOffsets(request: DataOffsetRequest, minOffset: OffsetValue, maxOffset: OffsetValue): Unit = {
+    offsetManager.commitOffsets(request, minOffset, maxOffset)
+
+    this.synchronized {
+      aggregatedOffsetsCache --= aggregatedOffsetsCache.keys.filter(_._1 == request.tableName)
+    }
+  }
+
+  def commitRerun(request: DataOffsetRequest, minOffset: OffsetValue, maxOffset: OffsetValue): Unit = {
+    this.synchronized {
+      aggregatedOffsetsCache --= aggregatedOffsetsCache.keys.filter(_._1 == request.tableName)
+    }
+
+    offsetManager.commitRerun(request, minOffset, maxOffset)
+  }
+
+  def postCommittedRecords(commitRequests: Seq[OffsetCommitRequest]): Unit = {
+    offsetManager.postCommittedRecords(commitRequests)
+
+    val updatedTables = commitRequests.map(_.table).toSet
+    this.synchronized {
+      aggregatedOffsetsCache --= aggregatedOffsetsCache.keys.filter(k => updatedTables.contains(k._1))
+    }
+  }
+
+  def rollbackOffsets(request: DataOffsetRequest): Unit = {
+    offsetManager.rollbackOffsets(request)
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
@@ -116,13 +116,15 @@ class OffsetManagerJdbc(db: Database, batchId: Long) extends OffsetManager {
     ).execute()
   }
 
-  override def postCommittedRecord(table: String, infoDate: LocalDate, minOffset: OffsetValue, maxOffset: OffsetValue): Unit = {
-    val createdAt = Instant.now()
+  override def postCommittedRecords(commitRequests: Seq[OffsetCommitRequest]): Unit = {
+    val committedAt = Instant.now()
 
-    val record = OffsetRecord(table, infoDate.toString, minOffset.dataType.dataTypeString, minOffset.valueString, maxOffset.valueString, batchId, createdAt.toEpochMilli, Some(createdAt.toEpochMilli))
+    val records = commitRequests.map { req =>
+      OffsetRecord(req.table, req.infoDate.toString, req.minOffset.dataType.dataTypeString, req.minOffset.valueString, req.maxOffset.valueString, batchId, req.createdAt.toEpochMilli, Some(committedAt.toEpochMilli))
+    }
 
     db.run(
-      OffsetRecords.records += record
+      OffsetRecords.records ++= records
     ).execute()
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
@@ -116,6 +116,16 @@ class OffsetManagerJdbc(db: Database, batchId: Long) extends OffsetManager {
     ).execute()
   }
 
+  override def postCommittedRecord(table: String, infoDate: LocalDate, minOffset: OffsetValue, maxOffset: OffsetValue): Unit = {
+    val createdAt = Instant.now()
+
+    val record = OffsetRecord(table, infoDate.toString, minOffset.dataType.dataTypeString, minOffset.valueString, maxOffset.valueString, batchId, createdAt.toEpochMilli, Some(createdAt.toEpochMilli))
+
+    db.run(
+      OffsetRecords.records += record
+    ).execute()
+  }
+
   override def rollbackOffsets(request: DataOffsetRequest): Unit = {
     db.run(
       OffsetRecords.records

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
@@ -57,7 +57,6 @@ class OffsetManagerJdbc(db: Database, batchId: Long) extends OffsetManager {
   }
 
   override def getMaxInfoDateAndOffset(table: String, onlyForInfoDate: Option[LocalDate]): Option[DataOffsetAggregated] = {
-    // ToDo Consider adding a caching layer for this
     val maxInfoDateOpt = onlyForInfoDate.orElse(getMaximumInfoDate(table))
 
     try {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerJdbc.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.pramen.core.bookkeeper
 
-import org.slf4j.LoggerFactory
 import slick.jdbc.H2Profile.api._
 import za.co.absa.pramen.api.offset.DataOffset.UncommittedOffset
 import za.co.absa.pramen.api.offset.{DataOffset, OffsetType, OffsetValue}
@@ -28,8 +27,6 @@ import scala.util.control.NonFatal
 
 class OffsetManagerJdbc(db: Database, batchId: Long) extends OffsetManager {
   import za.co.absa.pramen.core.utils.FutureImplicits._
-
-  private val log = LoggerFactory.getLogger(this.getClass)
 
   override def getOffsets(table: String, infoDate: LocalDate): Array[DataOffset] = {
     val offsets = getOffsetRecords(table, infoDate)
@@ -60,6 +57,7 @@ class OffsetManagerJdbc(db: Database, batchId: Long) extends OffsetManager {
   }
 
   override def getMaxInfoDateAndOffset(table: String, onlyForInfoDate: Option[LocalDate]): Option[DataOffsetAggregated] = {
+    // ToDo Consider adding a caching layer for this
     val maxInfoDateOpt = onlyForInfoDate.orElse(getMaximumInfoDate(table))
 
     try {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/OffsetManagerUtils.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.bookkeeper
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.{col, max, min}
+import org.apache.spark.sql.types.StringType
+import za.co.absa.pramen.api.offset.{OffsetType, OffsetValue}
+import za.co.absa.pramen.api.sql.SqlGeneratorBase
+
+object OffsetManagerUtils {
+  def getMinMaxValueFromData(df: DataFrame, offsetColumn: String, offsetType: OffsetType): Option[(OffsetValue, OffsetValue)] = {
+    if (df.isEmpty) {
+      None
+    } else {
+      val row = df.agg(min(offsetType.getSparkCol(col(offsetColumn)).cast(StringType)),
+          max(offsetType.getSparkCol(col(offsetColumn))).cast(StringType))
+        .collect()(0)
+
+      val minValue = OffsetValue.fromString(offsetType.dataTypeString, row(0).asInstanceOf[String]).getOrElse(throw new IllegalArgumentException(s"Can't parse offset: ${row(0)}"))
+      val maxValue = OffsetValue.fromString(offsetType.dataTypeString, row(1).asInstanceOf[String]).getOrElse(throw new IllegalArgumentException(s"Can't parse offset: ${row(1)}"))
+
+      SqlGeneratorBase.validateOffsetValue(minValue)
+      SqlGeneratorBase.validateOffsetValue(maxValue)
+
+      Some(minValue, maxValue)
+    }
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetCommitRequest.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetCommitRequest.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.core.bookkeeper
+package za.co.absa.pramen.core.bookkeeper.model
 
 import za.co.absa.pramen.api.offset.OffsetValue
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetRecords.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetRecords.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.bookkeeper.model
 import slick.jdbc.H2Profile.api._
 
 class OffsetRecords(tag: Tag) extends Table[OffsetRecord](tag, "offsets") {
-  def pramenTableName = column[String]("table_name", O.Length(200))
+  def pramenTableName = column[String]("table_name", O.Length(256))
   def infoDate = column[String]("info_date", O.Length(20))
   def dataType = column[String]("data_type", O.Length(20))
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetRecords.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/model/OffsetRecords.scala
@@ -19,11 +19,13 @@ package za.co.absa.pramen.core.bookkeeper.model
 import slick.jdbc.H2Profile.api._
 
 class OffsetRecords(tag: Tag) extends Table[OffsetRecord](tag, "offsets") {
-  def pramenTableName = column[String]("table_name", O.Length(128))
+  def pramenTableName = column[String]("table_name", O.Length(200))
   def infoDate = column[String]("info_date", O.Length(20))
   def dataType = column[String]("data_type", O.Length(20))
-  def minOffset = column[String]("min_offset", O.Length(64))
-  def maxOffset = column[String]("max_offset", O.Length(64))
+
+  def minOffset = column[String]("min_offset", O.Length(128))
+
+  def maxOffset = column[String]("max_offset", O.Length(128))
   def batchId = column[Long]("batch_id")
   def createdAt = column[Long]("created_at")
   def committedAt = column[Option[Long]]("committed_at")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import za.co.absa.pramen.api._
 import za.co.absa.pramen.api.status.TaskRunReason
-import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode, TrackingTable}
 import za.co.absa.pramen.core.utils.hive.HiveHelper
 
 import java.time.LocalDate
@@ -55,6 +55,8 @@ trait Metastore {
   def getStats(tableName: String, infoDate: LocalDate): MetaTableStats
 
   def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, readMode: ReaderMode): MetastoreReader
+
+  def addTrackingTables(trackingTables: Seq[TrackingTable])
 
   def commitIncrementalTables(): Unit
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import za.co.absa.pramen.api._
 import za.co.absa.pramen.api.status.TaskRunReason
-import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
 import za.co.absa.pramen.core.utils.hive.HiveHelper
 
 import java.time.LocalDate
@@ -54,7 +54,7 @@ trait Metastore {
 
   def getStats(tableName: String, infoDate: LocalDate): MetaTableStats
 
-  def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean, commitChanges: Boolean, isPostProcessing: Boolean): MetastoreReader
+  def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, readMode: ReaderMode): MetastoreReader
 
   def commitIncrementalTables(): Unit
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
@@ -55,4 +55,8 @@ trait Metastore {
   def getStats(tableName: String, infoDate: LocalDate): MetaTableStats
 
   def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean, incrementalDryRun: Boolean, isPostProcessing: Boolean): MetastoreReader
+
+  def commitIncrementalTables(): Unit
+
+  def rollbackIncrementalTables(): Unit
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
@@ -54,7 +54,7 @@ trait Metastore {
 
   def getStats(tableName: String, infoDate: LocalDate): MetaTableStats
 
-  def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean, incrementalDryRun: Boolean, isPostProcessing: Boolean): MetastoreReader
+  def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean, commitChanges: Boolean, isPostProcessing: Boolean): MetastoreReader
 
   def commitIncrementalTables(): Unit
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/Metastore.scala
@@ -54,5 +54,5 @@ trait Metastore {
 
   def getStats(tableName: String, infoDate: LocalDate): MetaTableStats
 
-  def getMetastoreReader(tables: Seq[String], infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean): MetastoreReader
+  def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, runReason: TaskRunReason, isIncremental: Boolean, incrementalDryRun: Boolean, isPostProcessing: Boolean): MetastoreReader
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -278,7 +278,6 @@ class MetastoreImpl(appConfig: Config,
         if (readMode != ReaderMode.Batch) {
           val om = bookkeeper.getOffsetManager
           val minMax = om.getMaxInfoDateAndOffset(trackingName, Option(infoDate))
-          val batchIdValue = OffsetValue.IntegralValue(batchId)
           log.info(s"Starting offset commit for output table '$trackingName' for '$infoDate'.")
           val trackingTable = TrackingTable(
             Thread.currentThread().getId,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -400,7 +400,7 @@ class MetastoreImpl(appConfig: Config,
         val df = getTable(trackingTable.inputTable, Option(trackingTable.infoDate), Option(trackingTable.infoDate))
         getMinMaxOffsetFromMetastoreDf(df, trackingTable.batchIdColumn, trackingTable.currentMaxOffset) match {
           case Some((minOffset, maxOffset)) =>
-            log.info(s"Commited offsets for table '${trackingTable.trackingName}' for '${trackingTable.infoDate}' with min='${minOffset.valueString}', max='${maxOffset.valueString}'.")
+            log.info(s"Committed offsets for table '${trackingTable.trackingName}' for '${trackingTable.infoDate}' with min='${minOffset.valueString}', max='${maxOffset.valueString}'.")
             Some(OffsetCommitRequest(
               trackingTable.trackingName,
               trackingTable.infoDate,
@@ -414,7 +414,7 @@ class MetastoreImpl(appConfig: Config,
         }
       } else {
         val minOffset = trackingTable.currentMinOffset.getOrElse(batchIdValue)
-        log.info(s"Commited offsets for table '${trackingTable.trackingName}' for '${trackingTable.infoDate}' with min='${minOffset.valueString}', max='$batchId'.")
+        log.info(s"Committed offsets for table '${trackingTable.trackingName}' for '${trackingTable.infoDate}' with min='${minOffset.valueString}', max='$batchId'.")
         Some(OffsetCommitRequest(
           trackingTable.trackingName,
           trackingTable.infoDate,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -396,7 +396,7 @@ class MetastoreImpl(appConfig: Config,
 
     val commitRequests = trackingTables.flatMap { trackingTable =>
       val tableDef = getTableDef(trackingTable.inputTable)
-      if (tableDef.format.isInstanceOf[DataFormat.Raw]) {
+      if (tableDef.format.isRaw) {
         val df = getTable(trackingTable.inputTable, Option(trackingTable.infoDate), Option(trackingTable.infoDate))
         getMinMaxOffsetFromMetastoreDf(df, trackingTable.batchIdColumn, trackingTable.currentMaxOffset) match {
           case Some((minOffset, maxOffset)) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -27,7 +27,8 @@ import za.co.absa.pramen.api.offset.{DataOffset, OffsetType, OffsetValue}
 import za.co.absa.pramen.api.status.TaskRunReason
 import za.co.absa.pramen.core.app.config.InfoDateConfig.DEFAULT_DATE_FORMAT
 import za.co.absa.pramen.core.app.config.{InfoDateConfig, RuntimeConfig}
-import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, OffsetCommitRequest, OffsetManagerUtils}
+import za.co.absa.pramen.core.bookkeeper.model.OffsetCommitRequest
+import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, OffsetManagerUtils}
 import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode, TrackingTable}
 import za.co.absa.pramen.core.metastore.peristence.{MetastorePersistence, TransientJobManager}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -327,8 +327,6 @@ class MetastoreImpl(appConfig: Config,
           throw new IllegalArgumentException(s"Table '$tableName' does not contain column '${tableDef.batchIdColumn}' needed for incremental processing.")
         }
 
-        // ToDo Handle uncommitted offsets
-
         val offsets = om.getMaxInfoDateAndOffset(trackingName, Option(infoDate))
 
         val df = offsets match {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderBase.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore
+
+import org.apache.spark.sql.DataFrame
+import za.co.absa.pramen.api.offset.DataOffset
+import za.co.absa.pramen.api.status.TaskRunReason
+import za.co.absa.pramen.api.{MetaTableDef, MetaTableRunInfo, MetadataManager, MetastoreReader}
+import za.co.absa.pramen.core.bookkeeper.Bookkeeper
+import za.co.absa.pramen.core.metastore.model.MetaTable
+
+import java.time.{Instant, LocalDate}
+
+abstract class MetastoreReaderBase(metastore: Metastore,
+                                   metadata: MetadataManager,
+                                   bookkeeper: Bookkeeper,
+                                   tables: Seq[String],
+                                   infoDate: LocalDate,
+                                   runReason: TaskRunReason) extends MetastoreReader {
+  override def getTable(tableName: String, infoDateFrom: Option[LocalDate], infoDateTo: Option[LocalDate]): DataFrame = {
+    validateTable(tableName)
+    val from = infoDateFrom.orElse(Option(infoDate))
+    val to = infoDateTo.orElse(Option(infoDate))
+    metastore.getTable(tableName, from, to)
+  }
+
+  override def getLatest(tableName: String, until: Option[LocalDate]): DataFrame = {
+    validateTable(tableName)
+    val untilDate = until.orElse(Option(infoDate))
+    metastore.getLatest(tableName, untilDate)
+  }
+
+  override def getLatestAvailableDate(tableName: String, until: Option[LocalDate]): Option[LocalDate] = {
+    validateTable(tableName)
+    val untilDate = until.orElse(Option(infoDate))
+    bookkeeper.getLatestProcessedDate(tableName, untilDate)
+  }
+
+  override def isDataAvailable(tableName: String, from: Option[LocalDate], until: Option[LocalDate]): Boolean = {
+    validateTable(tableName)
+    val fromDate = from.orElse(Option(infoDate))
+    val untilDate = until.orElse(Option(infoDate))
+    metastore.isDataAvailable(tableName, fromDate, untilDate)
+  }
+
+  override def getOffsets(table: String, infoDate: LocalDate): Array[DataOffset] = {
+    val om = bookkeeper.getOffsetManager
+
+    om.getOffsets(table, infoDate)
+  }
+
+  override def getTableDef(tableName: String): MetaTableDef = {
+    validateTable(tableName)
+
+    MetaTable.getMetaTableDef(metastore.getTableDef(tableName))
+  }
+
+  override def getTableRunInfo(tableName: String, infoDate: LocalDate): Option[MetaTableRunInfo] = {
+    bookkeeper.getLatestDataChunk(tableName, infoDate, infoDate)
+      .map(chunk =>
+        MetaTableRunInfo(tableName, LocalDate.parse(chunk.infoDate), chunk.inputRecordCount, chunk.outputRecordCount, Instant.ofEpochSecond(chunk.jobStarted), Instant.ofEpochSecond(chunk.jobFinished))
+      )
+  }
+
+  override def getRunReason: TaskRunReason = {
+    runReason
+  }
+
+  override def metadataManager: MetadataManager = metadata
+
+  protected def validateTable(tableName: String): Unit = {
+    if (!tables.contains(tableName)) {
+      throw new TableNotConfigured(s"Attempt accessing non-dependent table: $tableName")
+    }
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderBatchImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderBatchImpl.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore
+
+import org.apache.spark.sql.DataFrame
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.MetadataManager
+import za.co.absa.pramen.api.status.TaskRunReason
+import za.co.absa.pramen.core.bookkeeper.Bookkeeper
+
+import java.time.LocalDate
+
+class MetastoreReaderBatchImpl(metastore: Metastore,
+                               metadataManager: MetadataManager,
+                               bookkeeper: Bookkeeper,
+                               tables: Seq[String],
+                               infoDate: LocalDate,
+                               runReason: TaskRunReason) extends MetastoreReaderBase(metastore, metadataManager, bookkeeper, tables, infoDate, runReason) {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  override def getCurrentBatch(tableName: String): DataFrame = {
+    log.info(s"Getting daily data for table '$tableName' at '$infoDate'...")
+    metastore.getTable(tableName, Option(infoDate), Option(infoDate))
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
@@ -19,5 +19,5 @@ package za.co.absa.pramen.core.metastore
 import za.co.absa.pramen.api.MetastoreReader
 
 trait MetastoreReaderCore extends MetastoreReader {
-  def commitIncremental(): Unit
+  def commitIncremental(isTransient: Boolean): Unit
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
@@ -19,5 +19,7 @@ package za.co.absa.pramen.core.metastore
 import za.co.absa.pramen.api.MetastoreReader
 
 trait MetastoreReaderCore extends MetastoreReader {
+  def commitTable(tableName: String, trackingName: String): Unit
+
   def commitIncrementalStage(): Unit
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore
+
+import za.co.absa.pramen.api.MetastoreReader
+
+trait MetastoreReaderCore extends MetastoreReader {
+  def commitIncremental(): Unit
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderCore.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.metastore
 import za.co.absa.pramen.api.MetastoreReader
 
 trait MetastoreReaderCore extends MetastoreReader {
-  def commitTable(tableName: String, trackingName: String): Unit
+  def commitOutputTable(tableName: String, trackingName: String): Unit
 
   def commitIncrementalStage(): Unit
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderIncremental.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderIncremental.scala
@@ -18,8 +18,8 @@ package za.co.absa.pramen.core.metastore
 
 import za.co.absa.pramen.api.MetastoreReader
 
-trait MetastoreReaderCore extends MetastoreReader {
-  def commitOutputTable(tableName: String, trackingName: String): Unit
+trait MetastoreReaderIncremental extends MetastoreReader {
+  def commitIncrementalOutputTable(tableName: String, trackingName: String): Unit
 
   def commitIncrementalStage(): Unit
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderIncrementalImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreReaderIncrementalImpl.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.col
+import org.slf4j.LoggerFactory
+import za.co.absa.pramen.api.MetadataManager
+import za.co.absa.pramen.api.status.TaskRunReason
+import za.co.absa.pramen.core.bookkeeper.Bookkeeper
+import za.co.absa.pramen.core.metastore.model.{ReaderMode, TrackingTable}
+
+import java.time.{Instant, LocalDate}
+import scala.collection.mutable.ListBuffer
+
+class MetastoreReaderIncrementalImpl(metastore: Metastore,
+                                     metadataManager: MetadataManager,
+                                     bookkeeper: Bookkeeper,
+                                     tables: Seq[String],
+                                     outputTable: String,
+                                     infoDate: LocalDate,
+                                     runReason: TaskRunReason,
+                                     readMode: ReaderMode,
+                                     isRerun: Boolean)
+  extends MetastoreReaderBase(metastore, metadataManager, bookkeeper, tables, infoDate, runReason)
+    with MetastoreReaderIncremental {
+
+  private val log = LoggerFactory.getLogger(this.getClass)
+  private val trackingTables = new ListBuffer[TrackingTable]
+
+  override def getCurrentBatch(tableName: String): DataFrame = {
+    validateTable(tableName)
+    if (readMode == ReaderMode.IncrementalPostProcessing && !isRerun) {
+      log.info(s"Getting the current batch for table '$tableName' at '$infoDate'...")
+      metastore.getBatch(tableName, infoDate, None)
+    } else if ((readMode == ReaderMode.IncrementalValidation || readMode == ReaderMode.IncrementalRun) && !isRerun) {
+      log.info(s"Getting the current incremental chunk for table '$tableName' at '$infoDate'...")
+      getIncremental(tableName, infoDate)
+    } else {
+      log.info(s"Getting daily data for table '$tableName' at '$infoDate'...")
+      metastore.getTable(tableName, Option(infoDate), Option(infoDate))
+    }
+  }
+
+  override def commitIncrementalOutputTable(tableName: String, trackingName: String): Unit = {
+    if (readMode != ReaderMode.Batch) {
+      val om = bookkeeper.getOffsetManager
+      val minMax = om.getMaxInfoDateAndOffset(trackingName, Option(infoDate))
+      log.info(s"Starting offset commit for output table '$trackingName' for '$infoDate'.")
+      val trackingTable = TrackingTable(
+        Thread.currentThread().getId,
+        tableName,
+        outputTable,
+        trackingName,
+        "",
+        minMax.map(_.minimumOffset),
+        minMax.map(_.maximumOffset),
+        infoDate,
+        Instant.now()
+      )
+
+      trackingTables += trackingTable
+    }
+  }
+
+  override def commitIncrementalStage(): Unit = {
+    metastore.addTrackingTables(trackingTables.toSeq)
+    trackingTables.clear()
+  }
+
+  private def getIncremental(tableName: String, infoDate: LocalDate): DataFrame = {
+    val commitChanges = readMode == ReaderMode.IncrementalRun
+    val trackingName = s"$tableName->$outputTable"
+
+    getIncrementalDf(tableName, trackingName, infoDate, commitChanges)
+  }
+
+  private def getIncrementalDf(tableName: String, trackingName: String, infoDate: LocalDate, commit: Boolean): DataFrame = {
+    val tableDef = metastore.getTableDef(tableName)
+    val om = bookkeeper.getOffsetManager
+    val tableDf = metastore.getTable(tableName, Option(infoDate), Option(infoDate))
+    val offsets = om.getMaxInfoDateAndOffset(trackingName, Option(infoDate))
+
+    val df = if (tableDf.isEmpty) {
+      tableDf
+    } else {
+      if (!tableDf.schema.exists(_.name == tableDef.batchIdColumn)) {
+        log.error(tableDf.schema.treeString)
+        throw new IllegalArgumentException(s"Table '$tableName' does not contain column '${tableDef.batchIdColumn}' needed for incremental processing.")
+      }
+
+      offsets match {
+        case Some(values) =>
+          log.info(s"Getting incremental table '$trackingName' for '$infoDate', column '${tableDef.batchIdColumn}' > ${values.maximumOffset.valueString}")
+          tableDf.filter(col(tableDef.batchIdColumn) > values.maximumOffset.getSparkLit)
+        case None =>
+          log.info(s"Getting incremental table '$trackingName' for '$infoDate''")
+          tableDf
+      }
+    }
+
+    if (commit && !trackingTables.exists(t => t.trackingName == trackingName && t.infoDate == infoDate)) {
+      log.info(s"Starting offset commit for table '$trackingName' for '$infoDate'")
+
+      val trackingTable = TrackingTable(
+        Thread.currentThread().getId,
+        tableName,
+        outputTable,
+        trackingName,
+        tableDef.batchIdColumn,
+        offsets.map(_.minimumOffset),
+        offsets.map(_.maximumOffset),
+        infoDate,
+        Instant.now()
+      )
+
+      trackingTables += trackingTable
+    }
+
+    df
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/MetaTable.scala
@@ -146,7 +146,7 @@ object MetaTable {
       case Failure(ex) => throw new IllegalArgumentException(s"Unable to read data format from config for the metastore table: $name", ex)
     }
 
-    val batchIdColumn = if (format.isInstanceOf[DataFormat.Raw]) {
+    val batchIdColumn = if (format.isRaw) {
       ConfigUtils.getOptionString(conf, BATCH_ID_COLUMN_KEY).getOrElse(RAW_OFFSET_FIELD_KEY)
     } else {
       ConfigUtils.getOptionString(conf, BATCH_ID_COLUMN_KEY).getOrElse(defaultBatchIdColumn)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/ReaderMode.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/ReaderMode.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.model
+
+trait ReaderMode
+
+object ReaderMode {
+  case object Batch extends ReaderMode
+
+  case object IncrementalValidation extends ReaderMode
+
+  case object IncrementalRun extends ReaderMode
+
+  case object IncrementalPostProcessing extends ReaderMode
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
@@ -26,6 +26,7 @@ case class TrackingTable(
                           outputTable: String,
                           trackingName: String,
                           batchIdColumn: String,
+                          currentMinOffset: Option[OffsetValue],
                           currentMaxOffset: Option[OffsetValue],
                           infoDate: LocalDate,
                           createdAt: Instant

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
@@ -18,13 +18,15 @@ package za.co.absa.pramen.core.metastore.model
 
 import za.co.absa.pramen.api.offset.OffsetValue
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 case class TrackingTable(
+                          threadId: Long,
                           inputTable: String,
                           outputTable: String,
                           trackingName: String,
                           batchIdColumn: String,
                           currentMaxOffset: Option[OffsetValue],
-                          infoDate: LocalDate
+                          infoDate: LocalDate,
+                          createdAt: Instant
                         )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.model
+
+import org.apache.spark.sql.DataFrame
+import za.co.absa.pramen.core.bookkeeper.model.DataOffsetRequest
+
+case class TrackingTable(
+                          inputTable: String,
+                          outputTable: String,
+                          commitRequest: DataOffsetRequest,
+                          data: DataFrame
+                        )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/TrackingTable.scala
@@ -16,12 +16,15 @@
 
 package za.co.absa.pramen.core.metastore.model
 
-import org.apache.spark.sql.DataFrame
-import za.co.absa.pramen.core.bookkeeper.model.DataOffsetRequest
+import za.co.absa.pramen.api.offset.OffsetValue
+
+import java.time.LocalDate
 
 case class TrackingTable(
                           inputTable: String,
                           outputTable: String,
-                          commitRequest: DataOffsetRequest,
-                          data: DataFrame
+                          trackingName: String,
+                          batchIdColumn: String,
+                          currentMaxOffset: Option[OffsetValue],
+                          infoDate: LocalDate
                         )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.metastore.MetaTableStats
 import za.co.absa.pramen.core.metastore.model.HiveConfig
-import za.co.absa.pramen.core.metastore.peristence.TransientTableManager.{RAW_OFFSET_FIELD_KEY, RAW_PATH_FIELD_KEY}
 import za.co.absa.pramen.core.utils.hive.QueryExecutor
 import za.co.absa.pramen.core.utils.{FsUtils, SparkUtils}
 
@@ -35,6 +34,7 @@ class MetastorePersistenceRaw(path: String,
                               saveModeOpt: Option[SaveMode])
                              (implicit spark: SparkSession) extends MetastorePersistence {
 
+  import MetastorePersistenceRaw._
   import spark.implicits._
 
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -179,4 +179,9 @@ class MetastorePersistenceRaw(path: String,
     val emptyRDD = spark.sparkContext.emptyRDD[Row]
     spark.createDataFrame(emptyRDD, schema)
   }
+}
+
+object MetastorePersistenceRaw {
+  val RAW_PATH_FIELD_KEY = "path"
+  val RAW_OFFSET_FIELD_KEY = "file_name"
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientTableManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientTableManager.scala
@@ -32,9 +32,6 @@ import scala.util.Random
 object TransientTableManager {
   private val log = LoggerFactory.getLogger(this.getClass)
 
-  val RAW_PATH_FIELD_KEY = "path"
-  val RAW_OFFSET_FIELD_KEY = "file_name"
-
   private val rawDataframes = new mutable.HashMap[MetastorePartition, DataFrame]()
   private val cachedDataframes = new mutable.HashMap[MetastorePartition, DataFrame]()
   private val persistedLocations = new mutable.HashMap[MetastorePartition, String]()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/notify/pipeline/PipelineNotificationBuilderHtml.scala
@@ -610,9 +610,10 @@ class PipelineNotificationBuilderHtml(implicit conf: Config) extends PipelineNot
 
     task.runStatus match {
       case s: Succeeded        =>
-        s.recordCount match {
-          case Some(recordCount) => renderDifferenceSize(recordCount, s.recordCountOld)
-          case None => ""
+        (s.recordCount, s.recordsAppended) match {
+          case (Some(sizeTotal), Some(sizeAppended)) => renderDifferenceSize(sizeTotal, Some(sizeTotal - sizeAppended))
+          case (Some(sizeTotal), None) => renderDifferenceSize(sizeTotal, s.recordCountOld)
+          case _ => ""
         }
       case d: InsufficientData => renderDifferenceSize(d.actual, d.recordCountOld)
       case _                   => ""

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
@@ -24,7 +24,7 @@ import za.co.absa.pramen.api.jobdef.SourceTable
 import za.co.absa.pramen.api.offset.DataOffset.UncommittedOffset
 import za.co.absa.pramen.api.offset.{OffsetInfo, OffsetType}
 import za.co.absa.pramen.api.status.{DependencyWarning, TaskRunReason}
-import za.co.absa.pramen.api.{DataFormat, Reason, Source}
+import za.co.absa.pramen.api.{Reason, Source}
 import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest}
 import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, OffsetManager, OffsetManagerUtils}
 import za.co.absa.pramen.core.metastore.Metastore
@@ -143,7 +143,7 @@ class IncrementalIngestionJob(operationDef: OperationDef,
       val saveMode = if (isRerun) SaveMode.Overwrite else SaveMode.Append
       val statsToReturn = metastore.saveTable(outputTable.name, infoDate, dfToSave, inputRecordCount, saveModeOverride = Some(saveMode))
 
-      val updatedDf = if (outputTable.format.isInstanceOf[DataFormat.Raw])
+      val updatedDf = if (outputTable.format.isRaw)
         df
       else
         metastore.getBatch(outputTable.name, infoDate, None)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
@@ -28,7 +28,7 @@ import za.co.absa.pramen.api.{DataFormat, Reason, Source}
 import za.co.absa.pramen.core.bookkeeper.model.{DataOffsetAggregated, DataOffsetRequest}
 import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, OffsetManager, OffsetManagerUtils}
 import za.co.absa.pramen.core.metastore.Metastore
-import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
 import za.co.absa.pramen.core.runner.splitter.{ScheduleStrategy, ScheduleStrategyIncremental}
 import za.co.absa.pramen.core.utils.SparkUtils._
 
@@ -169,7 +169,7 @@ class IncrementalIngestionJob(operationDef: OperationDef,
       source.postProcess(
         sourceTable.query,
         outputTable.name,
-        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = true, commitChanges = false, isPostProcessing = true),
+        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, ReaderMode.IncrementalPostProcessing),
         infoDate,
         operationDef.extraOptions
       )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
@@ -178,7 +178,7 @@ class IncrementalIngestionJob(operationDef: OperationDef,
       source.postProcess(
         sourceTable.query,
         outputTable.name,
-        metastore.getMetastoreReader(Seq(outputTable.name), infoDate, runReason, isIncremental = true),
+        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = true, incrementalDryRun = false, isPostProcessing = true),
         infoDate,
         operationDef.extraOptions
       )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -25,7 +25,7 @@ import za.co.absa.pramen.api.{Query, Reason, Source, SourceResult}
 import za.co.absa.pramen.core.app.config.GeneralConfig.TEMPORARY_DIRECTORY_KEY
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.metastore.Metastore
-import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
 import za.co.absa.pramen.core.metastore.peristence.TransientTableManager
 import za.co.absa.pramen.core.runner.splitter.{ScheduleStrategy, ScheduleStrategySourcing}
 import za.co.absa.pramen.core.utils.ConfigUtils
@@ -173,7 +173,7 @@ class IngestionJob(operationDef: OperationDef,
       source.postProcess(
         sourceTable.query,
         outputTable.name,
-        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = false, commitChanges = false, isPostProcessing = true),
+        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, ReaderMode.Batch),
         infoDate,
         operationDef.extraOptions
       )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -173,7 +173,7 @@ class IngestionJob(operationDef: OperationDef,
       source.postProcess(
         sourceTable.query,
         outputTable.name,
-        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = false, incrementalDryRun = false, isPostProcessing = true),
+        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = false, commitChanges = false, isPostProcessing = true),
         infoDate,
         operationDef.extraOptions
       )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -173,7 +173,7 @@ class IngestionJob(operationDef: OperationDef,
       source.postProcess(
         sourceTable.query,
         outputTable.name,
-        metastore.getMetastoreReader(Seq(outputTable.name), infoDate, runReason, isIncremental = false),
+        metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, isIncremental = false, incrementalDryRun = false, isPostProcessing = true),
         infoDate,
         operationDef.extraOptions
       )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/Job.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/Job.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructType
 import za.co.absa.pramen.api.Reason
 import za.co.absa.pramen.api.status.{TaskDef, TaskRunReason}
+import za.co.absa.pramen.core.metastore.Metastore
 import za.co.absa.pramen.core.metastore.model.MetaTable
 import za.co.absa.pramen.core.runner.splitter.ScheduleStrategy
 
@@ -30,6 +31,8 @@ trait Job {
   val name: String
 
   val outputTable: MetaTable
+
+  val metastore: Metastore
 
   val operation: OperationDef
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/JobBase.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 import org.apache.spark.sql.types.StructType
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.pramen.api.jobdef.Schedule
-import za.co.absa.pramen.api.status.{DependencyFailure, DependencyWarning, JobType, MetastoreDependency, TaskDef, TaskRunReason}
+import za.co.absa.pramen.api.status._
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.expr.DateExprEvaluator
 import za.co.absa.pramen.core.metastore.Metastore
@@ -32,7 +32,7 @@ import java.time.{Instant, LocalDate}
 import scala.util.{Failure, Success, Try}
 
 abstract class JobBase(operationDef: OperationDef,
-                       metastore: Metastore,
+                       val metastore: Metastore,
                        bookkeeper: Bookkeeper,
                        jobNotificationTargets: Seq[JobNotificationTarget],
                        outputTableDef: MetaTable

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationSplitter.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationSplitter.scala
@@ -119,7 +119,7 @@ class OperationSplitter(conf: Config,
     val notificationTargets = operationDef.notificationTargets
       .map(targetName => getNotificationTarget(conf, targetName, operationDef.operationConf))
 
-    Seq(new TransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, clazz, transformer))
+    Seq(new TransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, clazz, transformer, batchId))
   }
 
   def createPythonTransformation(operationDef: OperationDef,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationSplitter.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/OperationSplitter.scala
@@ -119,7 +119,11 @@ class OperationSplitter(conf: Config,
     val notificationTargets = operationDef.notificationTargets
       .map(targetName => getNotificationTarget(conf, targetName, operationDef.operationConf))
 
-    Seq(new TransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, clazz, transformer, batchId))
+    val latestInfoDateOpt = if (operationDef.schedule == Schedule.Incremental) {
+      bookkeeper.getOffsetManager.getMaxInfoDateAndOffset(outputTable, None).map(_.maximumInfoDate)
+    } else None
+
+    Seq(new TransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, clazz, transformer, latestInfoDateOpt))
   }
 
   def createPythonTransformation(operationDef: OperationDef,
@@ -139,7 +143,11 @@ class OperationSplitter(conf: Config,
     val notificationTargets = operationDef.notificationTargets
       .map(targetName => getNotificationTarget(conf, targetName, operationDef.operationConf))
 
-    Seq(new PythonTransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, pythonClass, pramenPyConfig, processRunner, databricksClientOpt))
+    val latestInfoDateOpt = if (operationDef.schedule == Schedule.Incremental) {
+      bookkeeper.getOffsetManager.getMaxInfoDateAndOffset(outputTable, None).map(_.maximumInfoDate)
+    } else None
+
+    Seq(new PythonTransformationJob(operationDef, metastore, bookkeeper, notificationTargets, outputMetaTable, pythonClass, pramenPyConfig, processRunner, databricksClientOpt, latestInfoDateOpt))
   }
 
   def createSink(operationDef: OperationDef,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -101,6 +101,11 @@ class SinkJob(operationDef: OperationDef,
 
     val result = RunResult(getDataDf(infoDate, metastoreReader))
 
+    if (isIncremental) {
+      // This ensures offsets are tracked for the input table used as sink's source.
+      metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalStage()
+    }
+
     result
   }
 
@@ -167,6 +172,7 @@ class SinkJob(operationDef: OperationDef,
       )
 
       if (isIncremental) {
+        // This ensures offsets are tracked for all incremental tables used by 'sink.send()'.
         metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalOutputTable(sinkTable.metaTableName, s"${sinkTable.metaTableName}->$sinkName")
         metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalStage()
       }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -122,7 +122,7 @@ class SinkJob(operationDef: OperationDef,
       case NonFatal(ex) => throw new IllegalStateException("Unable to connect to the sink.", ex)
     }
 
-    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = false)
+    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, isIncremental, commitChanges = true, isPostProcessing = false)
 
     try {
       val sinkResult = sink.send(df,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -122,7 +122,7 @@ class SinkJob(operationDef: OperationDef,
       case NonFatal(ex) => throw new IllegalStateException("Unable to connect to the sink.", ex)
     }
 
-    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = true, isPostProcessing = false)
+    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = false)
 
     try {
       val sinkResult = sink.send(df,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -155,7 +155,7 @@ class SinkJob(operationDef: OperationDef,
     } finally {
       Try {
         sink.close()
-        metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncremental()
+        metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncremental(false)
       }
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -148,6 +148,8 @@ class SinkJob(operationDef: OperationDef,
         isTransient
       )
 
+      metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncrementalStage()
+
       val stats = MetaTableStats(Option(sinkResult.recordsSent), None, None)
       SaveResult(stats, sinkResult.filesSent, sinkResult.hiveTables, sinkResult.warnings ++ tooLongWarnings)
     } catch {
@@ -155,7 +157,6 @@ class SinkJob(operationDef: OperationDef,
     } finally {
       Try {
         sink.close()
-        metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncremental(false)
       }
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -22,7 +22,7 @@ import za.co.absa.pramen.api.jobdef.SinkTable
 import za.co.absa.pramen.api.status.{DependencyWarning, JobType, TaskRunReason}
 import za.co.absa.pramen.api.{Reason, Sink}
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
-import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
 import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderCore}
 import za.co.absa.pramen.core.pipeline.JobPreRunStatus.Ready
 import za.co.absa.pramen.core.runner.splitter.{ScheduleStrategy, ScheduleStrategySourcing}
@@ -122,7 +122,9 @@ class SinkJob(operationDef: OperationDef,
       case NonFatal(ex) => throw new IllegalStateException("Unable to connect to the sink.", ex)
     }
 
-    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, isIncremental, commitChanges = true, isPostProcessing = false)
+    val readerMode = if (isIncremental) ReaderMode.IncrementalPostProcessing else ReaderMode.Batch
+
+    val metastoreReader = metastore.getMetastoreReader(List(sinkTable.metaTableName) ++ inputTables, outputTable.name, infoDate, runReason, readerMode)
 
     try {
       val sinkResult = sink.send(df,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -102,7 +102,7 @@ class TransformationJob(operationDef: OperationDef,
       val readerMode = if (isIncremental) ReaderMode.IncrementalRun else ReaderMode.Batch
       val metastoreReaderRun = metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, readerMode)
 
-      metastoreReaderRun.asInstanceOf[MetastoreReaderCore].commitTable(outputTable.name, outputTable.name)
+      metastoreReaderRun.asInstanceOf[MetastoreReaderCore].commitOutputTable(outputTable.name, outputTable.name)
       metastoreReaderRun.asInstanceOf[MetastoreReaderCore].commitIncrementalStage()
     }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -58,8 +58,7 @@ class TransformationJob(operationDef: OperationDef,
   }
 
   override def run(infoDate: LocalDate, runReason: TaskRunReason, conf: Config): RunResult = {
-    val isTransitive = outputTable.format.isTransient
-    val metastoreReader = metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = !isTransitive)
+    val metastoreReader = metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = false)
     val runResult = try {
       RunResult(transformer.run(metastoreReader, infoDate, operationDef.extraOptions))
     } finally {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -58,11 +58,15 @@ class TransformationJob(operationDef: OperationDef,
   }
 
   override def run(infoDate: LocalDate, runReason: TaskRunReason, conf: Config): RunResult = {
+    val isTransient = outputTable.format.isTransient
     val metastoreReader = metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = false)
     val runResult = try {
       RunResult(transformer.run(metastoreReader, infoDate, operationDef.extraOptions))
     } finally {
-      metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncremental()
+      // (!) ToDo Commit only on success, and commit only on save.
+      // Rollback everything on failure
+      // Use ThreadId for parallrl jobs
+      metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncremental(isTransient)
     }
 
     runResult

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -54,11 +54,11 @@ class TransformationJob(operationDef: OperationDef,
   }
 
   override def validate(infoDate: LocalDate, runReason: TaskRunReason, jobConfig: Config): Reason = {
-    transformer.validate(metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = true, isPostProcessing = false), infoDate, operationDef.extraOptions)
+    transformer.validate(metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, commitChanges = false, isPostProcessing = false), infoDate, operationDef.extraOptions)
   }
 
   override def run(infoDate: LocalDate, runReason: TaskRunReason, conf: Config): RunResult = {
-    val metastoreReader = metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = false)
+    val metastoreReader = metastore.getMetastoreReader(inputTables, outputTable.name, infoDate, runReason, isIncremental, commitChanges = true, isPostProcessing = false)
     val runResult = RunResult(transformer.run(metastoreReader, infoDate, operationDef.extraOptions))
 
     metastoreReader.asInstanceOf[MetastoreReaderCore].commitIncrementalStage()
@@ -83,7 +83,7 @@ class TransformationJob(operationDef: OperationDef,
     else
       SaveResult(metastore.saveTable(outputTable.name, infoDate, df, None))
 
-    val metastoreReader = metastore.getMetastoreReader(inputTables :+ outputTable.name, outputTable.name, infoDate, runReason, isIncremental, incrementalDryRun = false, isPostProcessing = true)
+    val metastoreReader = metastore.getMetastoreReader(inputTables :+ outputTable.name, outputTable.name, infoDate, runReason, isIncremental, commitChanges = false, isPostProcessing = true)
 
     try {
       transformer.postProcess(

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -64,6 +64,7 @@ class TransformationJob(operationDef: OperationDef,
     val runResult = RunResult(transformer.run(metastoreReader, infoDate, operationDef.extraOptions))
 
     if (isIncremental) {
+      // Output tables for transient transformations should not be tracked since they are calculated on-demand.
       if (!outputTable.format.isTransient)
         metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalOutputTable(outputTable.name, outputTable.name)
       metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalStage()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/TransformationJob.scala
@@ -98,9 +98,8 @@ class TransformationJob(operationDef: OperationDef,
       case _: AbstractMethodError => log.warn(s"Transformers were built using old version of Pramen that does not support post processing. Ignoring...")
     }
 
-    if (!outputTable.format.isTransient) {
-      val readerMode = if (isIncremental) ReaderMode.IncrementalRun else ReaderMode.Batch
-      val metastoreReaderRun = metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, readerMode)
+    if (isIncremental && !outputTable.format.isTransient) {
+      val metastoreReaderRun = metastore.getMetastoreReader(Seq(outputTable.name), outputTable.name, infoDate, runReason, ReaderMode.IncrementalRun)
 
       metastoreReaderRun.asInstanceOf[MetastoreReaderCore].commitOutputTable(outputTable.name, outputTable.name)
       metastoreReaderRun.asInstanceOf[MetastoreReaderCore].commitIncrementalStage()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -23,7 +23,7 @@ import za.co.absa.pramen.api.Query
 import za.co.absa.pramen.api.offset.OffsetValue
 import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
-import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils, JdbcSparkUtils, TimeUtils}
+import za.co.absa.pramen.core.utils._
 
 import java.time.{Instant, LocalDate}
 import scala.annotation.tailrec
@@ -198,6 +198,10 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
       .load()
 
     if (jdbcReaderConfig.correctDecimalsInSchema || jdbcReaderConfig.correctDecimalsFixPrecision) {
+      if (isDataQuery) {
+        df = SparkUtils.sanitizeDfColumns(df, jdbcReaderConfig.specialCharacters)
+      }
+
       JdbcSparkUtils.getCorrectedDecimalsSchema(df, jdbcReaderConfig.correctDecimalsFixPrecision).foreach(schema =>
         df = spark
           .read

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/TableReaderJdbcConfig.scala
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.offset.OffsetInfo
 import za.co.absa.pramen.api.sql.{QuotingPolicy, SqlColumnType}
 import za.co.absa.pramen.core.config.Keys
+import za.co.absa.pramen.core.config.Keys.SPECIAL_CHARACTERS_IN_COLUMN_NAMES
 import za.co.absa.pramen.core.utils.ConfigUtils
 
 import java.time.ZoneId
@@ -38,6 +39,7 @@ case class TableReaderJdbcConfig(
                                   correctDecimalsFixPrecision: Boolean = false,
                                   enableSchemaMetadata: Boolean = false,
                                   useJdbcNative: Boolean = false,
+                                  specialCharacters: String = " ",
                                   serverTimeZone: ZoneId = ZoneId.systemDefault(),
                                   identifierQuotingPolicy: QuotingPolicy = QuotingPolicy.Auto,
                                   sqlGeneratorClass: Option[String] = None
@@ -98,6 +100,8 @@ object TableReaderJdbcConfig {
       .map(s => QuotingPolicy.fromString(s))
       .getOrElse(QuotingPolicy.Auto)
 
+    val specialCharacters = ConfigUtils.getOptionString(workflowConf, SPECIAL_CHARACTERS_IN_COLUMN_NAMES).getOrElse(" ")
+
     TableReaderJdbcConfig(
       jdbcConfig = JdbcConfig.load(conf, parent),
       hasInfoDate = conf.getBoolean(HAS_INFO_DATE),
@@ -111,6 +115,7 @@ object TableReaderJdbcConfig {
       correctDecimalsFixPrecision = ConfigUtils.getOptionBoolean(conf, CORRECT_DECIMALS_FIX_PRECISION).getOrElse(false),
       enableSchemaMetadata = ConfigUtils.getOptionBoolean(conf, ENABLE_SCHEMA_METADATA_KEY).getOrElse(false),
       useJdbcNative = ConfigUtils.getOptionBoolean(conf, USE_JDBC_NATIVE).getOrElse(false),
+      specialCharacters,
       serverTimezone,
       identifierQuotingPolicy = identifierQuotingPolicy,
       sqlGeneratorClass = ConfigUtils.getOptionString(conf, SQL_GENERATOR_CLASS_KEY)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
@@ -23,7 +23,6 @@ import za.co.absa.pramen.api.status.{RunStatus, TaskResult}
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
 import za.co.absa.pramen.core.exceptions.FatalErrorWrapper
-import za.co.absa.pramen.core.metastore.model.MetaTable
 import za.co.absa.pramen.core.metastore.peristence.TransientJobManager
 import za.co.absa.pramen.core.pipeline.Job
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunner.JobRunResults
@@ -91,9 +90,12 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
 
         completedJobsChannel.send((job, Nil, isSucceeded))
       } catch {
-        case ex: FatalErrorWrapper if ex.cause != null => onFatalException(ex.cause, job, isTransient)
-        case NonFatal(ex)                              => onNonFatalException(ex, job, isTransient)
-        case ex: Throwable                             => onFatalException(ex, job, isTransient)
+        case ex: FatalErrorWrapper if ex.cause != null =>
+          onFatalException(ex.cause, job, isTransient)
+        case NonFatal(ex) =>
+          onNonFatalException(ex, job, isTransient)
+        case ex: Throwable =>
+          onFatalException(ex, job, isTransient)
       }
     }
     completedJobsChannel.close()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/jobrunner/ConcurrentJobRunnerImpl.scala
@@ -18,7 +18,6 @@ package za.co.absa.pramen.core.runner.jobrunner
 
 import com.github.yruslan.channel.{Channel, ReadChannel}
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.api.status.{RunStatus, TaskResult}
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
@@ -119,7 +118,7 @@ class ConcurrentJobRunnerImpl(runtimeConfig: RuntimeConfig,
         None,
         applicationId,
         isTransient,
-        job.outputTable.format.isInstanceOf[DataFormat.Raw],
+        job.outputTable.format.isRaw,
         Nil,
         Nil,
         Nil,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -20,11 +20,9 @@ import com.github.yruslan.channel.Channel
 import com.typesafe.config.Config
 import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.api.status.{RunStatus, TaskResult}
 import za.co.absa.pramen.core.app.AppContext
 import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, ValidationException}
-import za.co.absa.pramen.core.metastore.model.MetaTable
 import za.co.absa.pramen.core.pipeline.{Job, JobDependency, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunner
 import za.co.absa.pramen.core.runner.splitter.ScheduleStrategyUtils.evaluateRunDate
@@ -132,7 +130,7 @@ class OrchestratorImpl extends Orchestrator {
         None,
         applicationId,
         isTransient,
-        job.outputTable.format.isInstanceOf[DataFormat.Raw],
+        job.outputTable.format.isRaw,
         Nil,
         Nil,
         Nil,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/LocalCsvSink.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sink/LocalCsvSink.scala
@@ -24,9 +24,8 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.{ExternalChannelFactory, MetastoreReader, Sink, SinkResult}
 import za.co.absa.pramen.core.sink.LocalCsvSink.OUTPUT_PATH_KEY
-import za.co.absa.pramen.core.utils.{FsUtils, LocalFsUtils}
+import za.co.absa.pramen.core.utils.FsUtils
 
-import java.io.{BufferedWriter, FileOutputStream, OutputStreamWriter}
 import java.nio.file.{Files, Paths}
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
@@ -82,7 +81,7 @@ import java.time.{LocalDate, ZonedDateTime}
   *
   *    tables = [
   *      {
-  *        metastore.table = metastore_table
+  *        input.metastore.table = metastore_table
   *        output.path = "/local/csv/path"
   *
   *        # Date range to read the source table for. By default the job information date is used.

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/RawFileSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/RawFileSource.scala
@@ -122,6 +122,10 @@ class RawFileSource(val sourceConfig: Config,
   }
 
   override def getDataIncremental(query: Query, onlyForInfoDate: Option[LocalDate], offsetFromOpt: Option[OffsetValue], offsetToOpt: Option[OffsetValue], columns: Seq[String]): SourceResult = {
+    if (onlyForInfoDate.isEmpty) {
+      throw new IllegalArgumentException("Incremental ingestion of raw files requires an info date to be part of filename pattern.")
+    }
+
     val filePaths = getPaths(query, onlyForInfoDate.get, onlyForInfoDate.get)
     val list = filePaths.map { path =>
       (path.getPath.toString, path.getPath.getName)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/RawFileSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/RawFileSource.scala
@@ -140,7 +140,6 @@ class RawFileSource(val sourceConfig: Config,
     SourceResult(df, list.map(_._2).sorted)
   }
 
-
   @throws[FileNotFoundException]
   private[source] def getPaths(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Seq[FileStatus] = {
     query match {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
@@ -119,7 +119,7 @@ class ConversionTransformer extends Transformer {
 
     val filesDf = metastore.getTable(inputTable, Option(infoDate), Option(infoDate))
 
-    if (!metastore.getTableDef(inputTable).format.isInstanceOf[DataFormat.Raw]) {
+    if (!metastore.getTableDef(inputTable).format.isRaw) {
       throw new IllegalArgumentException(s"Table $inputTable should be in 'raw' format so the for each file the metastore returns a file path.")
     }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/IdentityTransformer.scala
@@ -22,6 +22,40 @@ import za.co.absa.pramen.core.transformers.IdentityTransformer._
 
 import java.time.LocalDate
 
+/**
+  * The transformer does not do any actual transformation and just returns the input DataFrame.
+  *
+  * It can be used to copy data between metastore tables located in different storages.
+  *
+  * The transformer supports incremental processing.
+  *
+  * Example usage:
+  * {{{
+  *   pramen.operations = [
+  *     {
+  *       name = "Copy table"
+  *       type = "transformation"
+  *
+  *       class = "za.co.absa.pramen.core.transformers.IdentityTransformer"
+  *       schedule.type = "daily"
+  *
+  *       dependencies = [
+  *         {
+  *           tables = [ table_from ]
+  *           date.from = "@infoDate"
+  *         }
+  *       ]
+  *
+  *       option {
+  *         input.table = "table_from"
+  *         empty.allowed = true
+  *       }
+  *
+  *       output.table = "table_to"
+  *     }
+  *   ]
+  * }}}
+  */
 class IdentityTransformer extends Transformer {
   override def validate(metastore: MetastoreReader, infoDate: LocalDate, options: Map[String, String]): Reason = {
     if (!options.contains(INPUT_TABLE_KEY) && !options.contains(INPUT_TABLE_LEGACY_KEY)) {

--- a/pramen/core/src/test/resources/test/config/incremental_pipeline.conf
+++ b/pramen/core/src/test/resources/test/config/incremental_pipeline.conf
@@ -84,6 +84,7 @@ pramen.operations = [
   {
     name = "Running a transformer"
     type = "transformation"
+    disabled = ${transformer.disabled}
 
     class = "za.co.absa.pramen.core.transformers.IdentityTransformer"
     schedule.type = ${transformer.schedule}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
@@ -37,6 +37,7 @@ object RuntimeConfigFactory {
                             parallelTasks: Int = 1,
                             stopSparkSession: Boolean = false,
                             allowEmptyPipeline: Boolean = false,
+                            alwaysAddBatchIdColumn: Boolean = false,
                             historicalRunMode: RunMode = RunMode.CheckUpdates,
                             sparkAppDescriptionTemplate: Option[String] = None): RuntimeConfig = {
     RuntimeConfig(isDryRun,
@@ -53,6 +54,7 @@ object RuntimeConfigFactory {
       parallelTasks,
       stopSparkSession,
       allowEmptyPipeline,
+      alwaysAddBatchIdColumn,
       historicalRunMode,
       sparkAppDescriptionTemplate)
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineDeltaLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineDeltaLongSuite.scala
@@ -109,5 +109,9 @@ class IncrementalPipelineDeltaLongSuite extends IncrementalPipelineLongFixture {
     "offsets cross info days" in {
       testOffsetCrossInfoDateEdgeCase(format)
     }
+
+    "transformer picks up doubly ingested offsets" in {
+      testTransformerPicksUpFromDoubleIngestedData(format)
+    }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
@@ -1274,7 +1274,7 @@ class IncrementalPipelineLongFixture extends AnyWordSpec
       val om = new OffsetManagerJdbc(pramenDb.db, 123L)
 
       val offsets = om.getOffsets("table1->table2", infoDate).map(_.asInstanceOf[CommittedOffset])
-      assert(offsets.length == 2)
+      assert(offsets.length == 1)
     }
     succeed
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineParquetLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineParquetLongSuite.scala
@@ -109,5 +109,9 @@ class IncrementalPipelineParquetLongSuite extends IncrementalPipelineLongFixture
     "offsets cross info days" in {
       testOffsetCrossInfoDateEdgeCase(format)
     }
+
+    "transformer picks up doubly ingested offsets" in {
+      testTransformerPicksUpFromDoubleIngestedData(format)
+    }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -390,7 +390,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, incrementalDryRun = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
 
         val df1 = reader.getTable("table1", Some(infoDate), Some(infoDate))
 
@@ -404,7 +404,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table2" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, incrementalDryRun = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table2" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
 
         val ex = intercept[TableNotConfigured] {
           reader.getTable("table1", Some(infoDate), Some(infoDate))
@@ -420,7 +420,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, incrementalDryRun = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
         val runInfo1 = reader.getTableRunInfo("table1", infoDate)
         val runInfo2 = reader.getTableRunInfo("table1", infoDate.plusDays(1))
 
@@ -438,7 +438,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, incrementalDryRun = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
         val metadataManager = reader.metadataManager
 
         metadataManager.setMetadata("table1", infoDate, "key1", "value1")
@@ -456,7 +456,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
           m.saveTable("table1", infoDate, getDf)
           m.saveTable("table1", infoDate.plusDays(1), getDf)
 
-          val reader = m.getMetastoreReader("table1" :: "table2" :: Nil, "output_table", infoDate.plusDays(10), TaskRunReason.New, isIncremental = false, incrementalDryRun = false, isPostProcessing = false)
+          val reader = m.getMetastoreReader("table1" :: "table2" :: Nil, "output_table", infoDate.plusDays(10), TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
 
           val date1 = reader.getLatestAvailableDate("table1")
           val date2 = reader.getLatestAvailableDate("table1", Some(infoDate))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/MetastoreSuite.scala
@@ -28,6 +28,7 @@ import za.co.absa.pramen.core.app.config.InfoDateConfig
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
+import za.co.absa.pramen.core.metastore.model.ReaderMode
 import za.co.absa.pramen.core.metastore.peristence.TransientJobManager
 import za.co.absa.pramen.core.mocks.bookkeeper.SyncBookkeeperMock
 import za.co.absa.pramen.core.mocks.job.JobSpy
@@ -390,7 +391,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, ReaderMode.Batch)
 
         val df1 = reader.getTable("table1", Some(infoDate), Some(infoDate))
 
@@ -404,7 +405,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table2" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table2" :: Nil, "output_table", infoDate, TaskRunReason.New, ReaderMode.Batch)
 
         val ex = intercept[TableNotConfigured] {
           reader.getTable("table1", Some(infoDate), Some(infoDate))
@@ -420,7 +421,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, ReaderMode.Batch)
         val runInfo1 = reader.getTableRunInfo("table1", infoDate)
         val runInfo2 = reader.getTableRunInfo("table1", infoDate.plusDays(1))
 
@@ -438,7 +439,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
 
         m.saveTable("table1", infoDate, getDf)
 
-        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
+        val reader = m.getMetastoreReader("table1" :: Nil, "output_table", infoDate, TaskRunReason.New, ReaderMode.Batch)
         val metadataManager = reader.metadataManager
 
         metadataManager.setMetadata("table1", infoDate, "key1", "value1")
@@ -456,7 +457,7 @@ class MetastoreSuite extends AnyWordSpec with SparkTestBase with TextComparisonF
           m.saveTable("table1", infoDate, getDf)
           m.saveTable("table1", infoDate.plusDays(1), getDf)
 
-          val reader = m.getMetastoreReader("table1" :: "table2" :: Nil, "output_table", infoDate.plusDays(10), TaskRunReason.New, isIncremental = false, commitChanges = false, isPostProcessing = false)
+          val reader = m.getMetastoreReader("table1" :: "table2" :: Nil, "output_table", infoDate.plusDays(10), TaskRunReason.New, ReaderMode.Batch)
 
           val date1 = reader.getLatestAvailableDate("table1")
           val date2 = reader.getLatestAvailableDate("table1", Some(infoDate))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -174,8 +174,31 @@ class MetaTableSuite extends AnyWordSpec {
       assert(metaTable.infoDateColumn == "INFO_DATE")
       assert(metaTable.infoDateFormat == "dd-MM-yyyy")
       assert(metaTable.infoDateStart.toString == "2020-01-31")
+      assert(metaTable.batchIdColumn == "batchid")
       assert(metaTable.sparkConfig("key1") == "value1")
       assert(metaTable.saveModeOpt.contains(SaveMode.Append))
+    }
+
+    "load a metatable definition for raw format" in {
+      val conf = ConfigFactory.parseString(
+        """
+          |name = my_table
+          |format = raw
+          |path = /a/b/c
+          |""".stripMargin)
+
+      val defaultHiveConfig = HiveDefaultConfig.getNullConfig
+
+      val metaTable = MetaTable.fromConfigSingleEntity(conf, conf, "INFO_DATE", "dd-MM-yyyy", defaultPartitionByInfoDate = true, LocalDate.parse("2020-01-31"), 0, defaultHiveConfig, defaultPreferAddPartition = true, "batchid")
+
+      assert(metaTable.name == "my_table")
+      assert(metaTable.format.name == "raw")
+      assert(metaTable.hiveTable.isEmpty)
+      assert(metaTable.hivePath.isEmpty)
+      assert(metaTable.infoDateColumn == "INFO_DATE")
+      assert(metaTable.infoDateFormat == "dd-MM-yyyy")
+      assert(metaTable.infoDateStart.toString == "2020-01-31")
+      assert(metaTable.batchIdColumn == "file_name")
     }
 
     "load a metatable definition with hive table defined" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
@@ -21,12 +21,13 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructType
 import za.co.absa.pramen.api.status.{TaskDef, TaskRunReason}
 import za.co.absa.pramen.api.{DataFormat, Reason}
-import za.co.absa.pramen.core.{OperationDefFactory, TaskDefFactory}
-import za.co.absa.pramen.core.metastore.MetaTableStats
 import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore}
 import za.co.absa.pramen.core.mocks.MetaTableFactory.getDummyMetaTable
+import za.co.absa.pramen.core.mocks.metastore.MetastoreSpy
 import za.co.absa.pramen.core.pipeline._
 import za.co.absa.pramen.core.runner.splitter.{ScheduleStrategy, ScheduleStrategySourcing}
+import za.co.absa.pramen.core.{OperationDefFactory, TaskDefFactory}
 
 import java.time.{Instant, LocalDate}
 
@@ -58,6 +59,8 @@ class JobSpy(jobName: String = "Dummy Job",
   override val name: String = jobName
 
   override val outputTable: MetaTable = getDummyMetaTable(outputTableIn, format = outputTableFormat, hiveTable = hiveTable)
+
+  override val metastore: Metastore = new MetastoreSpy()
 
   override val operation: OperationDef = operationDef
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -105,7 +105,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
     stats
   }
 
-  override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, isIncremental: Boolean, incrementalDryRun: Boolean, isPostProcessing: Boolean): MetastoreReader = {
+  override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, isIncremental: Boolean, commitChanges: Boolean, isPostProcessing: Boolean): MetastoreReader = {
     val metastore = this
 
     new MetastoreReaderCore {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -171,6 +171,8 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
         }
       }
 
+      override def commitTable(tableName: String, trackingName: String): Unit = {}
+
       override def commitIncrementalStage(): Unit = {}
     }
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -171,7 +171,11 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
         }
       }
 
-      override def commitIncremental(isTransient: Boolean): Unit = {}
+      override def commitIncrementalStage(): Unit = {}
     }
   }
+
+  override def commitIncrementalTables(): Unit = {}
+
+  override def rollbackIncrementalTables(): Unit = {}
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -171,7 +171,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
         }
       }
 
-      override def commitTable(tableName: String, trackingName: String): Unit = {}
+      override def commitOutputTable(tableName: String, trackingName: String): Unit = {}
 
       override def commitIncrementalStage(): Unit = {}
     }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -22,7 +22,7 @@ import za.co.absa.pramen.api.offset.DataOffset
 import za.co.absa.pramen.api.status.TaskRunReason
 import za.co.absa.pramen.api.{MetaTableDef, MetaTableRunInfo, MetadataManager, MetastoreReader}
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
-import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
 import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderCore, TableNotConfigured}
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
@@ -105,7 +105,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
     stats
   }
 
-  override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, isIncremental: Boolean, commitChanges: Boolean, isPostProcessing: Boolean): MetastoreReader = {
+  override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, readMode: ReaderMode): MetastoreReader = {
     val metastore = this
 
     new MetastoreReaderCore {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -171,7 +171,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
         }
       }
 
-      override def commitIncremental(): Unit = {}
+      override def commitIncremental(isTransient: Boolean): Unit = {}
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -23,7 +23,7 @@ import za.co.absa.pramen.api.status.TaskRunReason
 import za.co.absa.pramen.api.{MetaTableDef, MetaTableRunInfo, MetadataManager, MetastoreReader}
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
 import za.co.absa.pramen.core.metastore.model.MetaTable
-import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, TableNotConfigured}
+import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderCore, TableNotConfigured}
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
 import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperSql, HiveQueryTemplates}
@@ -105,10 +105,10 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
     stats
   }
 
-  override def getMetastoreReader(tables: Seq[String], infoDate: LocalDate, taskRunReason: TaskRunReason, isIncremental: Boolean): MetastoreReader = {
+  override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, isIncremental: Boolean, incrementalDryRun: Boolean, isPostProcessing: Boolean): MetastoreReader = {
     val metastore = this
 
-    new MetastoreReader {
+    new MetastoreReaderCore {
       override def getTable(tableName: String, infoDateFrom: Option[LocalDate], infoDateTo: Option[LocalDate]): DataFrame = {
         validateTable(tableName)
         val from = infoDateFrom.orElse(Option(infoDate))
@@ -170,6 +170,8 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
           throw new TableNotConfigured(s"Attempt accessing non-dependent table: $tableName")
         }
       }
+
+      override def commitIncremental(): Unit = {}
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -22,8 +22,8 @@ import za.co.absa.pramen.api.offset.DataOffset
 import za.co.absa.pramen.api.status.TaskRunReason
 import za.co.absa.pramen.api.{MetaTableDef, MetaTableRunInfo, MetadataManager, MetastoreReader}
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
-import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode}
-import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderCore, TableNotConfigured}
+import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode, TrackingTable}
+import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderIncremental, TableNotConfigured}
 import za.co.absa.pramen.core.mocks.MetaTableFactory
 import za.co.absa.pramen.core.mocks.utils.hive.QueryExecutorMock
 import za.co.absa.pramen.core.utils.hive.{HiveHelper, HiveHelperSql, HiveQueryTemplates}
@@ -108,7 +108,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
   override def getMetastoreReader(tables: Seq[String], outputTable: String, infoDate: LocalDate, taskRunReason: TaskRunReason, readMode: ReaderMode): MetastoreReader = {
     val metastore = this
 
-    new MetastoreReaderCore {
+    new MetastoreReaderIncremental {
       override def getTable(tableName: String, infoDateFrom: Option[LocalDate], infoDateTo: Option[LocalDate]): DataFrame = {
         validateTable(tableName)
         val from = infoDateFrom.orElse(Option(infoDate))
@@ -171,11 +171,13 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
         }
       }
 
-      override def commitOutputTable(tableName: String, trackingName: String): Unit = {}
+      override def commitIncrementalOutputTable(tableName: String, trackingName: String): Unit = {}
 
       override def commitIncrementalStage(): Unit = {}
     }
   }
+
+  override def addTrackingTables(trackingTables: Seq[TrackingTable]): Unit = {}
 
   override def commitIncrementalTables(): Unit = {}
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
@@ -611,7 +611,8 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
       "python_class",
       pramenPyConfigOpt,
       processRunner,
-      databricksClientOpt
+      databricksClientOpt,
+      None
     )
 
     (job, processRunner, pramenPyConfigOpt, databricksClientOpt)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransformationJobSuite.scala
@@ -137,7 +137,7 @@ class TransformationJobSuite extends AnyWordSpec with SparkTestBase {
 
     val outputTable = MetaTableFactory.getDummyMetaTable(name = "table1")
 
-    (new TransformationJob(operation, metastore, bk, Nil, outputTable, "dummy_class", transformer), metastore)
+    (new TransformationJob(operation, metastore, bk, Nil, outputTable, "dummy_class", transformer, 1), metastore)
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/TransformationJobSuite.scala
@@ -137,7 +137,7 @@ class TransformationJobSuite extends AnyWordSpec with SparkTestBase {
 
     val outputTable = MetaTableFactory.getDummyMetaTable(name = "table1")
 
-    (new TransformationJob(operation, metastore, bk, Nil, outputTable, "dummy_class", transformer, 1), metastore)
+    (new TransformationJob(operation, metastore, bk, Nil, outputTable, "dummy_class", transformer, None), metastore)
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/source/RawFileSourceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/source/RawFileSourceSuite.scala
@@ -339,7 +339,7 @@ class RawFileSourceSuite extends AnyWordSpec with BeforeAndAfterAll with TempDir
     }
 
     "work from and to offset and an empty data frame" in {
-      val fileB = Some(OffsetValue.StringValue("FILE_TEST_2022-02-18_D.dat"))
+      val fileB = Some(OffsetValue.StringValue("NONEXISTENT_FILE.dat"))
       val files = source.getDataIncremental(Query.Path(filesPattern.toString), Some(infoDate), fileB, fileB, Seq.empty)
 
       val fileNames = files.filesRead

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerJdbcSuite.scala
@@ -20,7 +20,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import za.co.absa.pramen.api.offset.DataOffset.{CommittedOffset, UncommittedOffset}
 import za.co.absa.pramen.api.offset.{OffsetType, OffsetValue}
-import za.co.absa.pramen.core.bookkeeper.{OffsetManager, OffsetManagerJdbc}
+import za.co.absa.pramen.core.bookkeeper.{OffsetManager, OffsetManagerCached, OffsetManagerJdbc}
 import za.co.absa.pramen.core.fixtures.RelationalDbFixture
 import za.co.absa.pramen.core.rdb.PramenDb
 import za.co.absa.pramen.core.reader.model.JdbcConfig
@@ -44,7 +44,7 @@ class OffsetManagerJdbcSuite extends AnyWordSpec with RelationalDbFixture with B
   }
 
   def getOffsetManager: OffsetManager = {
-    new OffsetManagerJdbc(pramenDb.slickDb, 123L)
+    new OffsetManagerCached(new OffsetManagerJdbc(pramenDb.slickDb, 123L))
   }
 
   "getOffsets" should {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerUtilsSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.bookkeeper
+
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.TimestampType
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.api.offset.{OffsetType, OffsetValue}
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.bookkeeper.OffsetManagerUtils
+
+import java.time.Instant
+
+class OffsetManagerUtilsSuite extends AnyWordSpec with SparkTestBase {
+
+  import spark.implicits._
+
+  "getMinMaxValueFromData" should {
+    "work for an integral data type" in {
+      val df = List(("A", 1), ("B", 2), ("C", 3)).toDF("a", "offset")
+
+      val (minValue, maxValue) = OffsetManagerUtils.getMinMaxValueFromData(df, "offset", OffsetType.IntegralType).get
+
+      assert(minValue == OffsetValue.IntegralValue(1))
+      assert(maxValue == OffsetValue.IntegralValue(3))
+    }
+
+    "work for an string data type" in {
+      val df = List(("A", 1), ("B", 2), ("C", 3)).toDF("offset", "b")
+
+      val (minValue, maxValue) = OffsetManagerUtils.getMinMaxValueFromData(df, "offset", OffsetType.StringType).get
+
+      assert(minValue == OffsetValue.StringValue("A"))
+      assert(maxValue == OffsetValue.StringValue("C"))
+    }
+
+    "work for an datetime data type" in {
+      val baseTime = 1733989092000L
+      val df = List(("A", baseTime), ("B", baseTime + 1000), ("C", baseTime + 1500)).toDF("a", "offset")
+        .withColumn("offset", (col("offset") / 1000).cast(TimestampType))
+
+      val (minValue, maxValue) = OffsetManagerUtils.getMinMaxValueFromData(df, "offset", OffsetType.DateTimeType).get
+
+      assert(minValue == OffsetValue.DateTimeValue(Instant.ofEpochMilli(baseTime)))
+      assert(maxValue == OffsetValue.DateTimeValue(Instant.ofEpochMilli(baseTime + 1500)))
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/OffsetManagerUtilsSuite.scala
@@ -40,7 +40,7 @@ class OffsetManagerUtilsSuite extends AnyWordSpec with SparkTestBase {
     }
 
     "work for an string data type" in {
-      val df = List(("A", 1), ("B", 2), ("C", 3)).toDF("offset", "b")
+      val df = List(("A", 3), ("B", 1), ("C", 2)).toDF("offset", "b")
 
       val (minValue, maxValue) = OffsetManagerUtils.getMinMaxValueFromData(df, "offset", OffsetType.StringType).get
 

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/notification/EcsPipelineNotificationTarget.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/notification/EcsPipelineNotificationTarget.scala
@@ -57,7 +57,7 @@ class EcsPipelineNotificationTarget(conf: Config) extends PipelineNotificationTa
           case Some(runInfo) if task.runStatus.isInstanceOf[RunStatus.Succeeded] =>
             if (!task.taskDef.outputTable.format.isTransient &&
               !task.taskDef.outputTable.format.isInstanceOf[DataFormat.Null] &&
-              !task.taskDef.outputTable.format.isInstanceOf[DataFormat.Raw]) {
+              !task.taskDef.outputTable.format.isRaw) {
               EcsNotificationTarget.cleanUpS3VersionsForTable(task.taskDef.outputTable, runInfo.infoDate, ecsApiUrl, ecsApiKey, httpClient)
             } else {
               log.info(s"The task outputting to '${task.taskDef.outputTable.name}' for '${runInfo.infoDate}' outputs to ${task.taskDef.outputTable.format.name} format - skipping ECS cleanup...")

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/KafkaAvroSink.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/KafkaAvroSink.scala
@@ -83,7 +83,7 @@ import java.time.LocalDate
   *
   *    tables = [
   *      {
-  *        metastore.table = metastore_table
+  *        input.metastore.table = metastore_table
   *        output.topic.name = "my.topic"
   *
   *        # All following settings are OPTIONAL


### PR DESCRIPTION
Closes #520

This PR adds the ability to specify `increnental` as the schedule type which would enable incremental transformers and sinks.

In order for a transformer or a sink to use a table from metastore in incremental way, the code should invoke `metastore.getCurrentBatch()` method instead of `metastore.getTable()`. `metastore.getCurrentBatch()` also works for normal batch pipelines. 

- When `getCurrentBatch()` is used with daily, weekly or monthly schedule, it returns data for the information date corresponding to the running job, same as invoking `metastore.getTable("my_table", Some(infoDate), Some(infoDate))`.
- When `getCurrentBatch()` is used with incremental schedule, it returns only latests non-processed data. The offset management is used to keep tracked of processed data. 
- The column `pramen_batchid` is added automatically to output tables of ingested and transformed data in order to track offsets. The exception is metastore `raw` format, which keeps original files as they are, and so we can't add the `pramen_batchid` column to such tables.
- The offsets manager updates the offsets only after output of transformers or sinks have succeeded. It does the update in transactional manner. But if update failed in the middle, duplicates are possible on next runs, so we can say that Pramen provides 'AT LEAST ONCE' semantics for incremental transformation pipelines.
- Reruns are possible for full days to remove duplicates. But for incremental sinks, such ask Kafka sink duplicates still might happen.

Example offsets with one ingestion of raw files, one transient transformer, one normal transformer, and a sink:

Notification of the second run for a day:
![Screenshot 2024-12-12 at 14 44 39](https://github.com/user-attachments/assets/8096492a-f8d3-4c6f-846e-a01a239905f8)

The corresponding offsets are:
![Screenshot 2024-12-12 at 14 37 40](https://github.com/user-attachments/assets/1a7c6584-031b-4f48-b003-bc47adf60397)

Offsets committed together are highlighted. They are committed atomically. Ether all or none. Note that transient jobs are committed only if the jobs that is calling it was successfully saved. This is so that no records are lost.

Records are as follows:
- `TEST_POC_raw` minimum and maximum offsets for the raw file ingestion
- `TEST_POC_raw->TEST_POC_parquet` for tracking the input of the conversion _transient_ transformer
- `TEST_POC_parquet->TEST_POC_publish` for tracking the input of the standardization transformer
- `TEST_POC_publish` for tracking the output of the standardization transformer
- `TEST_POC_publish->TEST_POC_publish->kafka_avro` for tracking the input of the sink
- `TEST_POC_publish->kafka_avro` for tracking the output of the sink.