### PR TITLE
#552 Fix Hive DDL for tables with long descriptions with '\n' characters.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
@@ -114,7 +114,7 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
     queryExecutor.execute(sqlHiveRepair)
   }
 
-  private def getTableDDL(schema: StructType, partitionBy: Seq[String]): String = {
+  private[core] def getTableDDL(schema: StructType, partitionBy: Seq[String]): String = {
     val partitionColsLower = partitionBy.map(_.toLowerCase())
 
     val nonPartitionFields = SparkUtils.transformSchemaForCatalog(schema)
@@ -128,7 +128,7 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
     }
   }
 
-  private def getPartitionDDL(schema: StructType, partitionBy: Seq[String]): String = {
+  private[core] def getPartitionDDL(schema: StructType, partitionBy: Seq[String]): String = {
     if (partitionBy.isEmpty) {
       ""
     } else {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
@@ -442,6 +442,25 @@ class SparkUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture
     }
   }
 
+  "sanitizeCommentForHiveDDL" should {
+    "replace line ending characters" in {
+      val comment = "line1\nline2\\nline3"
+
+      val actual = sanitizeCommentForHiveDDL(comment)
+
+      assert(actual == "line1 line2 line3")
+    }
+
+    "truncate long comments" in {
+      val comment = "a" * 500
+
+      val actual = sanitizeCommentForHiveDDL(comment)
+
+      assert(actual.length == 255)
+      assert(actual.endsWith("a..."))
+    }
+  }
+
   "getLengthFromMetadata" should {
     "return length for long type" in {
       val metadata = new MetadataBuilder


### PR DESCRIPTION
Closes #552