### PR TITLE
#585 Add stack traces to notifications when the code invokes `System.exit()`

### DIFF
--- a/pramen/build.sbt
+++ b/pramen/build.sbt
@@ -272,7 +272,7 @@ lazy val assemblySettingsCommon = Seq(
       }
     case _ => MergeStrategy.deduplicate
   },
-  assembly / assemblyOption:= (assembly / assemblyOption).value.copy(includeScala = false),
+  assembly / assemblyOption ~= { _.withIncludeScala(false) },
   assembly / assemblyJarName := s"${runnerAssemblyName(name.value)}_${scalaBinaryVersion.value}${runnerSparkVersionSuffix(name.value, scalaVersion.value, assemblyFeatures.value.contains("includeDelta"))}-${version.value}.jar",
   assembly / logLevel := Level.Info,
   assembly / test := {}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -31,6 +31,7 @@ import za.co.absa.pramen.core.runner.orchestrator.OrchestratorImpl
 import za.co.absa.pramen.core.runner.task.{TaskRunner, TaskRunnerMultithreaded}
 import za.co.absa.pramen.core.state.{PipelineState, PipelineStateImpl}
 import za.co.absa.pramen.core.utils.Emoji._
+import za.co.absa.pramen.core.utils.impl.SystemExitCatcherSecurityManager
 import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ResourceUtils}
 
 import scala.util.{Failure, Success, Try}
@@ -51,6 +52,10 @@ object AppRunner {
       case Failure(ex)  =>
         log.error(s"An error has occurred before notification configuration is available. No notifications will be sent.", ex)
         return ERROR_CODE_MAJOR_FAILURE
+    }
+
+    Try {
+      System.setSecurityManager(new SystemExitCatcherSecurityManager(state.asInstanceOf[PipelineStateImpl]))
     }
 
     val exitCodeTry = for {
@@ -327,6 +332,10 @@ object AppRunner {
   }
 
   private[core] def resetState(state: PipelineState): Unit = {
+    Try {
+      System.setSecurityManager(null)
+    }
+
     // Neither of these should throw any exceptions.
     // The handling of exceptions is added as a precaution.
     runIgnoringExceptions {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/AppRunner.scala
@@ -29,9 +29,8 @@ import za.co.absa.pramen.core.pipeline.{Job, OperationDef, OperationSplitter, Pi
 import za.co.absa.pramen.core.runner.jobrunner.{ConcurrentJobRunner, ConcurrentJobRunnerImpl}
 import za.co.absa.pramen.core.runner.orchestrator.OrchestratorImpl
 import za.co.absa.pramen.core.runner.task.{TaskRunner, TaskRunnerMultithreaded}
-import za.co.absa.pramen.core.state.{PipelineState, PipelineStateImpl}
+import za.co.absa.pramen.core.state.{PipelineState, PipelineStateImpl, SystemExitCatcherSecurityManager}
 import za.co.absa.pramen.core.utils.Emoji._
-import za.co.absa.pramen.core.utils.impl.SystemExitCatcherSecurityManager
 import za.co.absa.pramen.core.utils.{BuildPropertyUtils, ResourceUtils}
 
 import scala.util.{Failure, Success, Try}
@@ -55,6 +54,8 @@ object AppRunner {
     }
 
     Try {
+      // Setting the security manager that catches all System.exit() calls and records stack traces.
+      // In case this fails, just ignore the feature.
       System.setSecurityManager(new SystemExitCatcherSecurityManager(state.asInstanceOf[PipelineStateImpl]))
     }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
@@ -315,7 +315,7 @@ class PipelineStateImpl(implicit conf: Config, notificationBuilder: Notification
     signalHandlers.append(newHandler)
   }
 
-  private[core] def setFailureException(ex: Throwable): Unit = {
+  private[state] def setFailureException(ex: Throwable): Unit = {
     if (failureException.isEmpty) {
       failureException = Option(ex)
     }
@@ -323,7 +323,7 @@ class PipelineStateImpl(implicit conf: Config, notificationBuilder: Notification
 
   private[state] def getFailureException: Option[Throwable] = failureException
 
-  private[core] def setSignalException(ex: Throwable): Unit = {
+  private[state] def setSignalException(ex: Throwable): Unit = {
     if (signalException.isEmpty) {
       signalException = Option(ex)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
@@ -315,7 +315,7 @@ class PipelineStateImpl(implicit conf: Config, notificationBuilder: Notification
     signalHandlers.append(newHandler)
   }
 
-  private[state] def setFailureException(ex: Throwable): Unit = {
+  private[core] def setFailureException(ex: Throwable): Unit = {
     if (failureException.isEmpty) {
       failureException = Option(ex)
     }
@@ -323,7 +323,7 @@ class PipelineStateImpl(implicit conf: Config, notificationBuilder: Notification
 
   private[state] def getFailureException: Option[Throwable] = failureException
 
-  private[state] def setSignalException(ex: Throwable): Unit = {
+  private[core] def setSignalException(ex: Throwable): Unit = {
     if (signalException.isEmpty) {
       signalException = Option(ex)
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/state/SystemExitCatcherSecurityManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/state/SystemExitCatcherSecurityManager.scala
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package za.co.absa.pramen.core.utils.impl
+package za.co.absa.pramen.core.state
 
 import za.co.absa.pramen.core.exceptions.OsSignalException
-import za.co.absa.pramen.core.state.PipelineStateImpl
 import za.co.absa.pramen.core.utils.JvmUtils
 
 import java.security.Permission

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/StringUtils.scala
@@ -20,7 +20,6 @@ import za.co.absa.pramen.core.exceptions.ThreadStackTrace
 import za.co.absa.pramen.core.expr.DateExprEvaluator
 import za.co.absa.pramen.core.expr.exceptions.SyntaxErrorException
 
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.{Base64, StringTokenizer}
 import scala.compat.Platform.EOL
@@ -192,17 +191,8 @@ object StringUtils {
   }
 
   def renderThreadDumps(threadStackTraces: Seq[ThreadStackTrace]): String = {
-    val threadTitlePadding = "  "
-    val stackTracePadding = "    "
     val base = s"""Stack trace of threads at the moment of the interruption:\n"""
-
-    val details = threadStackTraces.zipWithIndex.map {
-      case (threadStackTrace, index) =>
-        val threadTitle = s"${threadTitlePadding}Thread $index (${threadStackTrace.threadName}): \n"
-        val stackTrace = threadStackTrace.stackTrace
-        val stackTraceStr = s"""${stackTrace.map(s => s"$stackTracePadding$s").mkString("", EOL, EOL)}""".stripMargin
-        threadTitle + stackTraceStr
-    }.mkString("\n")
+    val details = JvmUtils.renderStackTraces(threadStackTraces)
 
     base + details
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
@@ -43,7 +43,7 @@ object ThreadUtils {
 
     val handler = new UncaughtExceptionHandler {
       override def uncaughtException(t: Thread, ex: Throwable): Unit = {
-        thread.asInstanceOf[ThreadWithException].setException(ex)
+        thread.setException(ex)
       }
     }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/SystemExitCatcherSecurityManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/SystemExitCatcherSecurityManager.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.impl
+
+import za.co.absa.pramen.core.exceptions.OsSignalException
+import za.co.absa.pramen.core.state.PipelineStateImpl
+import za.co.absa.pramen.core.utils.JvmUtils
+
+import java.security.Permission
+
+class SystemExitCatcherSecurityManager(stateImpl: PipelineStateImpl) extends SecurityManager {
+  override def checkPermission(perm: Permission): Unit = {}
+
+  override def checkPermission(perm: Permission, context: Object): Unit = {}
+
+  override def checkExit(status: Int): Unit = {
+    val nonDaemonStackTraces = JvmUtils.getStackTraces
+    stateImpl.setSignalException(OsSignalException("System.exit()", nonDaemonStackTraces))
+  }
+}

--- a/pramen/project/plugins.sbt
+++ b/pramen/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.2.1")
 addSbtPlugin("com.github.sbt"    % "sbt-release"   % "1.4.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "3.12.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.7.0")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "2.2.0")
 
 addDependencyTreePlugin
 


### PR DESCRIPTION
Closes #585 

For example, here how [truncated] stack traces look like when I added `System.exit(0)` to the Identity transformer `run()` method:
```
The application was interrupted by a signal: System.exit().

Stack trace of threads at the moment of the interruption:
  Thread 0 (pool-32-thread-4): 
    sun.misc.Unsafe.park(Native Method)
    java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)

      Thread 6 (pool-35-thread-1): 
    java.lang.Thread.dumpThreads(Native Method)
    java.lang.Thread.getAllStackTraces(Thread.java:1615)
    za.co.absa.pramen.core.utils.JvmUtils$.getStackTraces(JvmUtils.scala:51)
    za.co.absa.pramen.core.utils.impl.SystemExitCatcherSecurityManager.checkExit(SystemExitCatcherSecurityManager.scala:31)
    java.lang.Runtime.exit(Runtime.java:101)
>   java.lang.System.exit(System.java:987)
>   za.co.absa.pramen.core.pipeline.transformers.IdentityTransformer.run(TestTransformer.scala:72)
    za.co.absa.pramen.core.pipeline.TransformationJob.run(TransformationJob.scala:64)
    za.co.absa.pramen.core.runner.task.TaskRunnerBase.$anonfun$run$1(TaskRunnerBase.scala:343)
    za.co.absa.pramen.core.runner.task.TaskRunnerBase$$Lambda$2519/1619491041.apply(Unknown Source)
    scala.util.Try$.apply(Try.scala:213)
    za.co.absa.pramen.core.runner.task.TaskRunnerBase.run(TaskRunnerBase.scala:335)
    za.co.absa.pramen.core.runner.task.TaskRunnerBase.doValidateAndRunTask(TaskRunnerBase.scala:163)
    za.co.absa.pramen.core.runner.task.TaskRunnerBase.runTask(TaskRunnerBase.scala:150)
    za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded.$anonfun$runParallel$3(TaskRunnerMultithreaded.scala:94)
    za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded$$Lambda$2496/2076911850.apply(Unknown Source)
    za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded.whenEnoughResourcesAreAvailable(TaskRunnerMultithreaded.scala:67)
    za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded.$anonfun$runParallel$2(TaskRunnerMultithreaded.scala:92)
    za.co.absa.pramen.core.runner.task.TaskRunnerMultithreaded$$Lambda$2495/1688405016.apply(Unknown Source)
    scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
    scala.concurrent.Future$$$Lambda$1621/1843118011.apply(Unknown Source)
    scala.util.Success.$anonfun$map$1(Try.scala:255)
    scala.util.Success.map(Try.scala:213)
    scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
    scala.concurrent.Future$$Lambda$1456/60949700.apply(Unknown Source)
    scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
    scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
    scala.concurrent.impl.Promise$$Lambda$1458/1660775884.apply(Unknown Source)
    scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    java.lang.Thread.run(Thread.java:750)
```