### PR TITLE
#616: Classify column name prefix as table prefix if it is the same across all columns. Do not remove column prefix if it is not table prefix in sanitizeDfColumns

### DIFF
--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
@@ -163,6 +163,19 @@ class SparkUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture
       assert(stripLineEndings(actual) == stripLineEndings(expected))
     }
 
+    "do not remove table from column name if there is no uniform table name" in {
+      val expected =
+        """[ {  "tbl_a.a_a" : "A",  "tbl_b.b" : 1,  "c" : 4}, {  "tbl_a.a_a" : "B",  "tbl_b.b" : 2,  "c" : 5}, {  "tbl_a.a_a" : "C",  "tbl_b.b" : 3,  "c" : 6} ]"""
+
+      val df = List(("A", 1, 4), ("B", 2, 5), ("C", 3, 6)).toDF("tbl_a.a a", "tbl b.b", "c")
+
+      val actualDf = sanitizeDfColumns(df, " ")
+
+      val actual = convertDataFrameToPrettyJSON(actualDf).stripMargin.linesIterator.mkString("").trim
+
+      assert(stripLineEndings(actual) == stripLineEndings(expected))
+    }
+
     "convert schema from Spark to Json and back should produce the same schema" in {
       val testCaseSchema = StructType(
         Array(


### PR DESCRIPTION
Closes #616  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved column name sanitization to automatically remove a uniform table prefix from all columns when present.

* **Tests**
  * Added a test to ensure that non-uniform table prefixes are preserved during column name sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->