### PR TITLE
#623 Add support for metstore tables that always overwritten, `parquet` and `raw` formats

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistence.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistence.scala
@@ -49,7 +49,7 @@ object MetastorePersistence {
     metaTable.format match {
       case DataFormat.Parquet(path, partitionInfo) =>
         new MetastorePersistenceParquet(
-          path, metaTable.infoDateColumn, metaTable.infoDateFormat, metaTable.batchIdColumn, batchId, partitionInfo, saveModeOpt, metaTable.readOptions, metaTable.writeOptions
+          path, metaTable.infoDateColumn, metaTable.infoDateFormat, metaTable.batchIdColumn, batchId, partitionInfo, metaTable.partitionScheme, saveModeOpt, metaTable.readOptions, metaTable.writeOptions
         )
       case DataFormat.Delta(query, partitionInfo) =>
         new MetastorePersistenceDelta(
@@ -60,7 +60,7 @@ object MetastorePersistence {
           table, location, metaTable.description, metaTable.infoDateColumn, metaTable.batchIdColumn, batchId, metaTable.partitionScheme, saveModeOpt, metaTable.writeOptions, metaTable.tableProperties
         )
       case DataFormat.Raw(path)                          =>
-        new MetastorePersistenceRaw(path, metaTable.infoDateColumn, metaTable.infoDateFormat, saveModeOpt)
+        new MetastorePersistenceRaw(path, metaTable.infoDateColumn, metaTable.infoDateFormat, metaTable.partitionScheme, saveModeOpt)
       case DataFormat.TransientEager(cachePolicy)             =>
         new MetastorePersistenceTransientEager(TransientTableManager.getTempDirectory(cachePolicy, conf), metaTable.name, cachePolicy)
       case DataFormat.Transient(cachePolicy) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/transformers/ConversionTransformer.scala
@@ -18,7 +18,7 @@ package za.co.absa.pramen.core.transformers
 
 import org.apache.spark.sql.DataFrame
 import org.slf4j.LoggerFactory
-import za.co.absa.pramen.api.{DataFormat, MetastoreReader, Reason, Transformer}
+import za.co.absa.pramen.api.{DataFormat, MetastoreReader, PartitionScheme, Reason, Transformer}
 import za.co.absa.pramen.core.utils.SparkUtils.getPartitionPath
 
 import java.time.LocalDate
@@ -156,7 +156,11 @@ class ConversionTransformer extends Transformer {
 
       val metaTable = metastore.getTableDef(inputTable)
       val path = metaTable.format.asInstanceOf[DataFormat.Raw].path
-      val partitionPath = getPartitionPath(infoDate, metaTable.infoDateColumn, metaTable.infoDateFormat, path).toString
+      val partitionPath = if (metaTable.partitionScheme == PartitionScheme.Overwrite) {
+        path
+      } else {
+        getPartitionPath(infoDate, metaTable.infoDateColumn, metaTable.infoDateFormat, path).toString
+      }
 
       spark.read
         .format(inputFormat)

--- a/pramen/core/src/test/resources/test/config/integration_file_based_overwriting_source.conf
+++ b/pramen/core/src/test/resources/test/config/integration_file_based_overwriting_source.conf
@@ -1,0 +1,91 @@
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variable is expected to be set up by the test suite
+#base.path = "/tmp"
+
+pramen {
+  pipeline.name = "Integration test with a file-based source"
+
+  bookkeeping.enabled = false
+  stop.spark.session = false
+}
+
+pramen.metastore {
+  tables = [
+    {
+      name = "table1"
+      format = "raw"
+      information.date.partition.by = overwrite
+      path = ${base.path}/table1
+    },
+    {
+
+      name = "table2"
+      information.date.partition.by = overwrite
+      format = "parquet"
+      path = ${base.path}/table2
+    }
+  ]
+}
+
+pramen.sources.1 = [
+  {
+    name = "file_source"
+    factory.class = "za.co.absa.pramen.core.source.RawFileSource"
+  }
+]
+
+pramen.operations = [
+  {
+    name = "Sourcing from a folder"
+    type = "ingestion"
+    schedule.type = "daily"
+
+    source = "file_source"
+
+    info.date.expr = "@runDate"
+
+    tables = [
+      {
+        input.path = ${base.path}
+        output.metastore.table = table1
+      }
+    ]
+  },
+  {
+    name = "Converting to parquet"
+    type = "transformation"
+
+    class = "za.co.absa.pramen.core.transformers.ConversionTransformer"
+    schedule.type = "daily"
+
+    output.table = "table2"
+
+    dependencies = [
+      {
+        tables = [ table1 ]
+        date.from = "@infoDate"
+        optional = true # Since no bookkeeping available the table will be seen as empty for the dependency manager
+      }
+    ]
+
+    option {
+      input.table = "table1"
+      input.format = "csv"
+      use.dataframe = ${use.dataframe}
+
+      header = true
+    }
+  }
+]

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/FileSourcingWithOverwriteLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/FileSourcingWithOverwriteLongSuite.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.integration
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.runner.AppRunner
+import za.co.absa.pramen.core.utils.{FsUtils, ResourceUtils}
+
+import java.time.LocalDate
+
+class FileSourcingWithOverwriteLongSuite extends AnyWordSpec with SparkTestBase with TempDirFixture with TextComparisonFixture {
+  private val infoDate = LocalDate.of(2021, 2, 18)
+
+  "File-based sourcing" should {
+    val expected =
+      """{"id":"1","name":"John","pramen_info_date":"2021-02-18"}
+        |{"id":"2","name":"Jack","pramen_info_date":"2021-02-18"}
+        |{"id":"3","name":"Jill","pramen_info_date":"2021-02-18"}
+        |{"id":"4","name":"Mary","pramen_info_date":"2021-02-18"}
+        |{"id":"5","name":"Jane","pramen_info_date":"2021-02-18"}
+        |{"id":"6","name":"Kate","pramen_info_date":"2021-02-18"}
+        |""".stripMargin
+
+    "work end to end with path-based transformer" in {
+      withTempDirectory("integration_file_based") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        fsUtils.writeFile(new Path(tempDir, "landing_file1.csv"), "id,name\n1,John\n2,Jack\n3,Jill\n")
+        fsUtils.writeFile(new Path(tempDir, "landing_file2.csv"), "id,name\n4,Mary\n5,Jane\n6,Kate\n")
+
+        val conf = getConfig(tempDir)
+
+        val exitCode = AppRunner.runPipeline(conf)
+
+        assert(exitCode == 0)
+
+        val table2Path = new Path(tempDir, "table2")
+        val table2Partition = new Path(table2Path, s"pramen_info_date=$infoDate")
+
+        assert(!fsUtils.exists(table2Partition))
+
+        val df = spark.read.parquet(table2Path.toString)
+
+        val actual = df.orderBy("id").toJSON.collect().mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+
+    "work end to end with dataframe-based transformer" in {
+      withTempDirectory("integration_file_based") { tempDir =>
+        val fsUtils = new FsUtils(spark.sparkContext.hadoopConfiguration, tempDir)
+
+        fsUtils.writeFile(new Path(tempDir, "landing_file1.csv"), "id,name\n1,John\n2,Jack\n3,Jill\n")
+        fsUtils.writeFile(new Path(tempDir, "landing_file2.csv"), "id,name\n4,Mary\n5,Jane\n6,Kate\n")
+
+        val conf = getConfig(tempDir, useDataFrame = true)
+
+        val exitCode = AppRunner.runPipeline(conf)
+
+        assert(exitCode == 0)
+
+        val table2Path = new Path(tempDir, "table2")
+        val table2Partition = new Path(table2Path, s"pramen_info_date=$infoDate")
+
+        assert(!fsUtils.exists(table2Partition))
+        val df = spark.read.parquet(table2Path.toString)
+
+        val actual = df.orderBy("id").toJSON.collect().mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+  }
+
+  def getConfig(basePath: String, useDataFrame: Boolean = false): Config = {
+    val configContents = ResourceUtils.getResourceString("/test/config/integration_file_based_overwriting_source.conf")
+    val basePathEscaped = basePath.replace("\\", "\\\\")
+
+    val conf = ConfigFactory.parseString(
+      s"""base.path = "$basePathEscaped"
+         |use.dataframe = $useDataFrame
+         |pramen.runtime.is.rerun = true
+         |pramen.current.date = "$infoDate"
+         |$configContents
+         |""".stripMargin
+    ).withFallback(ConfigFactory.load())
+      .resolve()
+
+    conf
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceParquetSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceParquetSuite.scala
@@ -20,7 +20,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.api.PartitionInfo
+import za.co.absa.pramen.api.{PartitionInfo, PartitionScheme}
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.metastore.peristence.MetastorePersistenceParquet
@@ -40,7 +40,7 @@ class MetastorePersistenceParquetSuite extends AnyWordSpec with SparkTestBase wi
       withTempDirectory("metastore_parquet") { tempDir =>
         val outputPath = new Path(tempDir, "partition=10")
 
-        val persistence = new MetastorePersistenceParquet(tempDir, "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, None, Map.empty, Map.empty)
+        val persistence = new MetastorePersistenceParquet(tempDir, "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, PartitionScheme.PartitionByDay, None, Map.empty, Map.empty)
 
         persistence.writeAndCleanOnFailure(exampleDf, outputPath.toString, fsUtils, SaveMode.Overwrite)
 
@@ -53,7 +53,7 @@ class MetastorePersistenceParquetSuite extends AnyWordSpec with SparkTestBase wi
       withTempDirectory("metastore_parquet") { tempDir =>
         val outputPath = new Path(tempDir, "partition=10")
 
-        val persistence = new MetastorePersistenceParquet(tempDir, "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, Some(SaveMode.Append), Map.empty, Map.empty)
+        val persistence = new MetastorePersistenceParquet(tempDir, "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, PartitionScheme.PartitionByDay, Some(SaveMode.Append), Map.empty, Map.empty)
 
         persistence.writeAndCleanOnFailure(exampleDf, outputPath.toString, fsUtils, SaveMode.Append)
         persistence.writeAndCleanOnFailure(exampleDf, outputPath.toString, fsUtils, SaveMode.Append)
@@ -72,7 +72,7 @@ class MetastorePersistenceParquetSuite extends AnyWordSpec with SparkTestBase wi
 
       when(df.write).thenThrow(new RuntimeException("test exception"))
 
-      val persistence = new MetastorePersistenceParquet("dummy", "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, None, Map.empty, Map.empty)
+      val persistence = new MetastorePersistenceParquet("dummy", "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, PartitionScheme.PartitionByDay, None, Map.empty, Map.empty)
 
       assertThrows[RuntimeException] {
         persistence.writeAndCleanOnFailure(df, "dummy", fsUtils, SaveMode.Overwrite)
@@ -89,7 +89,7 @@ class MetastorePersistenceParquetSuite extends AnyWordSpec with SparkTestBase wi
 
         fsUtils.createDirectoryRecursive(outputPath)
 
-        val persistence = new MetastorePersistenceParquet("dummy", "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, None, Map.empty, Map.empty)
+        val persistence = new MetastorePersistenceParquet("dummy", "ignore", "yyyy-MM-dd", "batchid", 0, PartitionInfo.Default, PartitionScheme.PartitionByDay, None, Map.empty, Map.empty)
 
         val ex = intercept[RuntimeException] {
           persistence.writeAndCleanOnFailure(df, outputPath.toString, fsUtils, SaveMode.Overwrite)


### PR DESCRIPTION
Closes #623 