### PR TITLE
#640 Apply 'autocommit' only when necessary or explicitly set by a user.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -18,10 +18,10 @@ package za.co.absa.pramen.core.reader
 
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.reader.model.JdbcConfig
-import za.co.absa.pramen.core.utils.ConfigUtils
-import za.co.absa.pramen.core.utils.JdbcNativeUtils.{DEFAULT_CONNECTION_TIMEOUT_SECONDS, JDBC_WORDS_TO_REDACT}
+import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
+import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils}
 
-import java.sql.{Connection, DriverManager, SQLException}
+import java.sql.{Connection, SQLException}
 import java.util.Properties
 import scala.util.{Failure, Random, Success, Try}
 
@@ -104,12 +104,7 @@ class JdbcUrlSelectorImpl(val jdbcConfig: JdbcConfig) extends JdbcUrlSelector{
     val currentUrl = getUrl
 
     Try {
-      Class.forName(jdbcConfig.driver)
-
-      val properties = getProperties
-
-      DriverManager.setLoginTimeout(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))
-      DriverManager.getConnection(currentUrl, properties)
+      JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl)
     } match {
       case Success(connection) => (connection, currentUrl)
       case Failure(ex)         =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/JdbcConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/model/JdbcConfig.scala
@@ -89,7 +89,11 @@ object JdbcConfig {
     val autoCommitOpt = explicitAutoCommit.orElse(defaultAutoCommit)
 
     if (explicitAutoCommit.isDefined && defaultAutoCommit.isDefined && explicitAutoCommit.get != defaultAutoCommit.get) {
-      log.warn(s"The JDBC driver is known to work poorly with 'autocommit=${explicitAutoCommit.get}'. The recommended value is '${defaultAutoCommit.get}'.")
+      log.warn(s"[$driver] JDBC driver is known to work poorly with 'autocommit=${explicitAutoCommit.get}'. The recommended value is '${defaultAutoCommit.get}'. Override acknowledged.")
+    }
+
+    if (driver == "com.ibm.db2.jcc.DB2Driver" && explicitAutoCommit.contains(false)) {
+      log.warn(s"[$driver] JDBC driver is known to work poorly with 'autocommit=false'. The recommended value is 'true' or not specified. Override acknowledged.")
     }
 
     JdbcConfig(

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -162,7 +162,6 @@ object JdbcNativeUtils {
   private def getResultSet(jdbcConfig: JdbcConfig,
                            url: String,
                            query: String): ResultSet = {
-    Class.forName(jdbcConfig.driver)
     val connection = getJdbcConnection(jdbcConfig, url)
 
     val statement = try {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -187,13 +187,6 @@ object JdbcSparkUtils {
                       (action: (Connection, ResultSetMetaData) => Unit): Unit = {
     val (_, connection) = JdbcNativeUtils.getConnection(jdbcConfig)
 
-    try {
-      // When autoCommit is true, PostgreSQL retrieves all query results at once, which can cause memory issues for large datasets.
-      connection.setAutoCommit(false)
-    } catch {
-      case _: Throwable => log.info("The JDBC driver does not support 'setAutoCommit(false)'")
-    }
-
     log.info(s"Getting metadata for: $schemaQuery")
 
     try {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
@@ -38,7 +38,6 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |    connection.string = "$url"
        |    user = "$user"
        |    password = "$password"
-       |    autocommit = true
        |  }
        |
        |  has.information.date.column = true
@@ -81,6 +80,7 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |    connection.string = "$url"
        |    user = "$user"
        |    password = "$password"
+       |    autocommit = false
        |  }
        |
        |  has.information.date.column = false
@@ -105,7 +105,7 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
       val reader = getReader
       assert(reader != null)
       assert(reader.getJdbcReaderConfig.infoDateFormat == "YYYY-MM-dd")
-      assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit)
+      assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit.isEmpty)
       assert(reader.getJdbcReaderConfig.jdbcConfig.fetchSize.get == 1000)
     }
 
@@ -119,8 +119,18 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
       val reader = TableReaderJdbcNative(conf.getConfig("reader_minimal"), conf.getConfig("reader_minimal"), "reader_minimal")
       assert(reader.getJdbcReaderConfig.infoDateFormat == "yyyy-MM-dd")
       assert(reader.getJdbcReaderConfig.jdbcConfig.sanitizeDateTime)
-      assert(!reader.getJdbcReaderConfig.jdbcConfig.autoCommit)
+      assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit.isEmpty)
       assert(reader.getJdbcReaderConfig.jdbcConfig.fetchSize.isEmpty)
+      assert(reader.getJdbcReaderConfig.limitRecords.isEmpty)
+    }
+
+    "work with config with limits" in {
+      val reader = TableReaderJdbcNative(conf.getConfig("reader_limit"), conf.getConfig("reader_limit"), "reader_limit")
+      assert(reader.getJdbcReaderConfig.infoDateFormat == "yyyy-MM-dd")
+      assert(reader.getJdbcReaderConfig.jdbcConfig.sanitizeDateTime)
+      assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit.contains(false))
+      assert(reader.getJdbcReaderConfig.jdbcConfig.fetchSize.isEmpty)
+      assert(reader.getJdbcReaderConfig.limitRecords.contains(100))
     }
 
     "throw an exception if config is missing" in {


### PR DESCRIPTION
Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Auto-commit is now optional and configurable with per-driver defaults (e.g., PostgreSQL defaults to disabled); configured auto-commit is applied when connections are created.
  - Warnings emitted when explicit auto-commit differs from driver defaults or for DB2-specific cases.

- Bug Fixes
  - Reduced connection errors by avoiding unsupported per-query auto-commit adjustments.

- Refactor
  - JDBC connection setup and auto-commit handling centralized for consistent behavior without public API changes.

- Tests
  - Tests and configs updated for optional auto-commit, legacy reader behavior, and driver-specific expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->