### PR TITLE
#642 Add retries to copying of files when copying files to S3.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetaTableStats.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetaTableStats.scala
@@ -18,6 +18,7 @@ package za.co.absa.pramen.core.metastore
 
 case class MetaTableStats(
                            recordCount: Option[Long],
-                           recordCountAppended: Option[Long],
-                           dataSizeBytes: Option[Long]
+                           recordCountAppended: Option[Long] = None,
+                           dataSizeBytes: Option[Long] = None,
+                           warnings: Seq[String] = Seq.empty
                          )

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/MetastoreImpl.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.metastore
 import com.typesafe.config.Config
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.types.{DateType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api._
@@ -32,7 +32,6 @@ import za.co.absa.pramen.core.bookkeeper.{Bookkeeper, OffsetManagerUtils}
 import za.co.absa.pramen.core.config.Keys
 import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode, TrackingTable}
 import za.co.absa.pramen.core.metastore.peristence.{MetastorePersistence, TransientJobManager}
-import za.co.absa.pramen.core.pipeline.OperationDef
 import za.co.absa.pramen.core.utils.ConfigUtils
 import za.co.absa.pramen.core.utils.hive.{HiveFormat, HiveHelper}
 
@@ -126,7 +125,7 @@ class MetastoreImpl(appConfig: Config,
     val isTransient = mt.format.isTransient
     val start = Instant.now.getEpochSecond
 
-    var stats = MetaTableStats(Some(0), None, None)
+    var stats = MetaTableStats(Some(0))
 
     withSparkConfig(mt.sparkConfig) {
       stats = MetastorePersistence.fromMetaTable(mt, appConfig, batchId, saveModeOverride).saveTable(infoDate, df, inputRecordCount)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
@@ -85,11 +85,11 @@ class MetastorePersistenceIceberg(table: CatalogTable,
       val batchCount = df.filter(col(batchIdColumn) === batchId).count()
       val countAll = df.count()
 
-      MetaTableStats(Option(countAll), Option(batchCount), None)
+      MetaTableStats(Option(countAll), Option(batchCount))
     } else {
       val countAll = df.count()
 
-      MetaTableStats(Option(countAll), None, None)
+      MetaTableStats(Option(countAll))
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceNull.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceNull.scala
@@ -29,11 +29,11 @@ class MetastorePersistenceNull(implicit spark: SparkSession) extends MetastorePe
   }
 
   override def saveTable(infoDate: LocalDate, df: DataFrame, numberOfRecordsEstimate: Option[Long]): MetaTableStats = {
-    MetaTableStats(Some(0), None, None)
+    MetaTableStats(Some(0))
   }
 
   override def getStats(infoDate: LocalDate, onlyForCurrentBatchId: Boolean): MetaTableStats = {
-    MetaTableStats(Some(0), None, None)
+    MetaTableStats(Some(0))
   }
 
   override def createOrUpdateHiveTable(infoDate: LocalDate,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
@@ -96,7 +96,7 @@ class MetastorePersistenceRaw(path: String,
         copiedSize += fsSrc.getContentSummary(srcPath).getLength
         fsUtilsTrg.copyFileWithRetry(srcPath, trgPath) match {
           case None => Seq.empty[String]
-          case Some(ex) => Seq(ex.getMessage)
+          case Some(ex) if ex.getMessage != null => Seq(ex.getMessage)
         }
       }
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IncrementalIngestionJob.scala
@@ -181,8 +181,9 @@ class IncrementalIngestionJob(operationDef: OperationDef,
 
     val jobFinished = Instant.now
     val tooLongWarnings = getTookTooLongWarnings(jobStarted, jobFinished, sourceTable.warnMaxExecutionTimeSeconds)
+    val warnings = stats.warnings ++ tooLongWarnings
 
-    SaveResult(stats, warnings = tooLongWarnings)
+    SaveResult(stats, warnings = warnings)
   }
 
   private[core] def validateReadiness(infoDate: LocalDate, om: OffsetManager, hasInfoDate: Boolean, isRerun: Boolean): Reason = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/IngestionJob.scala
@@ -186,7 +186,8 @@ class IngestionJob(operationDef: OperationDef,
     val jobFinished = Instant.now
     val tooLongWarnings = getTookTooLongWarnings(jobStarted, jobFinished, sourceTable.warnMaxExecutionTimeSeconds)
 
-    SaveResult(stats, warnings = tooLongWarnings)
+    val warnings = stats.warnings ++ tooLongWarnings
+    SaveResult(stats, warnings = warnings)
   }
 
   private def supportsTrackDays(hasInfoDate: Boolean): Boolean = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/SinkJob.scala
@@ -178,7 +178,7 @@ class SinkJob(operationDef: OperationDef,
         metastoreReader.asInstanceOf[MetastoreReaderIncremental].commitIncrementalStage()
       }
 
-      val stats = MetaTableStats(Option(sinkResult.recordsSent), None, None)
+      val stats = MetaTableStats(Option(sinkResult.recordsSent))
       SaveResult(stats, sinkResult.filesSent, sinkResult.hiveTables, sinkResult.warnings ++ tooLongWarnings)
     } catch {
       case NonFatal(ex) => throw new IllegalStateException("Unable to write to the sink.", ex)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/FsUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/FsUtils.scala
@@ -454,7 +454,7 @@ class FsUtils(conf: Configuration, pathBase: String) {
       copyFile(srcFile, dstFile, overwrite)
       None
     } catch {
-      case ex: IOException if ex.getMessage.contains("multipart upload") =>
+      case ex: IOException if Option(ex.getMessage).exists(_.toLowerCase.contains("multipart upload")) =>
         if (numberOfAttempts > 1) {
           log.warn(s"Failed to copy $srcFile to $dstFile due to multipart upload issue. Retrying in $backoffTimeSeconds seconds...", ex)
           Thread.sleep(backoffTimeSeconds * 1000)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
@@ -41,7 +41,7 @@ class JobSpy(jobName: String = "Dummy Job",
              runFunction: () => RunResult = () => null,
              scheduleStrategyIn: ScheduleStrategy = new ScheduleStrategySourcing(true),
              allowParallel: Boolean = true,
-             saveStats: MetaTableStats = MetaTableStats(Some(0), None, None),
+             saveStats: MetaTableStats = MetaTableStats(Some(0)),
              jobNotificationTargets: Seq[JobNotificationTarget] = Seq.empty,
              jobTrackDays: Int = 0
             ) extends Job {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/metastore/MetastoreSpy.scala
@@ -18,9 +18,9 @@ package za.co.absa.pramen.core.mocks.metastore
 
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode}
+import za.co.absa.pramen.api._
 import za.co.absa.pramen.api.offset.DataOffset
 import za.co.absa.pramen.api.status.TaskRunReason
-import za.co.absa.pramen.api._
 import za.co.absa.pramen.core.metadata.MetadataManagerNull
 import za.co.absa.pramen.core.metastore.model.{MetaTable, ReaderMode, TrackingTable}
 import za.co.absa.pramen.core.metastore.{MetaTableStats, Metastore, MetastoreReaderIncremental, TableNotConfigured}
@@ -36,7 +36,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
                    dataFormat: DataFormat = DataFormat.Parquet("/tmp/dummy"),
                    tableDf: DataFrame = null,
                    tableException: Throwable = null,
-                   stats: MetaTableStats = MetaTableStats(Some(0), None, None),
+                   stats: MetaTableStats = MetaTableStats(Some(0)),
                    statsException: Throwable = null,
                    isTableAvailable: Boolean = true,
                    isTableEmpty: Boolean = false,
@@ -80,7 +80,7 @@ class MetastoreSpy(registeredTables: Seq[String] = Seq("table1", "table2"),
 
   override def saveTable(tableName: String, infoDate: LocalDate, df: DataFrame, inputRecordCount: Option[Long], saveModeOverride: Option[SaveMode]): MetaTableStats = {
     saveTableInvocations.append((tableName, infoDate, df))
-    MetaTableStats(Option(df.count()), None, None)
+    MetaTableStats(Option(df.count()))
   }
 
   def getHiveHelper(tableName: String): HiveHelper = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
@@ -38,7 +38,6 @@ import java.nio.file.{Files, Paths}
 import java.time.{Instant, LocalDate}
 
 class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll with SparkTestBase with TempDirFixture with TextComparisonFixture {
-
   import spark.implicits._
 
   private val infoDate = LocalDate.of(2022, 2, 18)
@@ -220,7 +219,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
 
   "save" should {
     "update the bookkeeper" in {
-      val statsIn = MetaTableStats(Some(100), None, None)
+      val statsIn = MetaTableStats(Some(100))
 
       val (job, _, _, _) = getUseCase(stats = statsIn)
 
@@ -244,7 +243,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
     }
 
     "allow no records in the output table" in {
-      val statsIn = MetaTableStats(Some(0), None, None)
+      val statsIn = MetaTableStats(Some(0))
 
       val (job, _, _, _) = getUseCase(stats = statsIn)
 
@@ -256,7 +255,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
     }
 
     "throw an exception if no records in the output table" in {
-      val statsIn = MetaTableStats(Some(0), None, None)
+      val statsIn = MetaTableStats(Some(0))
 
       val (job, _, _, _) = getUseCase(stats = statsIn, extraOptions = Map("minimum.records" -> "1"))
 
@@ -270,7 +269,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
     }
 
     "throw an exception if the number of records is less then expected" in {
-      val statsIn = MetaTableStats(Some(9), None, None)
+      val statsIn = MetaTableStats(Some(9))
 
       val (job, _, _, _) = getUseCase(stats = statsIn, extraOptions = Map("minimum.records" -> "10"))
 


### PR DESCRIPTION
Closes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - File copy now auto-retries on transient errors for improved reliability.
  - Warnings from file-copy failures are collected and surfaced with save results.

- Behavior changes
  - Table statistics payload simplified and now includes a warnings list with sensible defaults.
  - Save results now aggregate warnings from multiple sources for better visibility.

- Bug Fixes
  - Corrected a log message typo (“Nothing to save”).

- Tests
  - Added unit tests covering the retryable file copy behavior and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->