### PR TITLE
#649 Add ability to select how key is serialized in Kafka Avro source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,9 +945,9 @@ pramen.sources = [
     # [Optional] Set name for the Kafka key column
     #key.column.name = "kafka_key"
     
-    # The Kafka key serializer. Can be "none", "binary", "string", "avro".
-    # When "avro", "key.naming.strategy" should be deined at the "schema.registry" section.
-    # Default is "binary", but if "key.naming.strategy" is defined, "avro" is selected automatically.
+    # The Kafka key serializer when key.naming.strategy is NOT defined. Can be "none", "binary", "string".
+    # When key.naming.strategy IS defined in schema.registry, Avro deserialization is used automatically.
+    # Default is "binary".
     #key.column.serializer = "none"
 
     kafka {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/model/QueryBuilder.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/model/QueryBuilder.scala
@@ -53,9 +53,9 @@ object QueryBuilder {
       case _                           =>
         val parent = if (parentPath.isEmpty) "" else s" at $parentPath"
         if (prefix.isEmpty)
-          throw new IllegalArgumentException(s"No options are specified for the query. Usually, it is one of: '$SQL_KEY', '$PATH_KEY', '$TABLE_KEY', '$DB_TABLE_KEY'$parent.")
+          throw new IllegalArgumentException(s"No options are specified for the query. Usually, it is one of: '$SQL_KEY', '$PATH_KEY', '$TABLE_KEY', '$DB_TABLE_KEY', '$TOPIC_KEY'$parent.")
         else
-          throw new IllegalArgumentException(s"No options are specified for the '$prefix' query. Usually, it is one of: '$p$SQL_KEY', '$p$PATH_KEY', '$p$TABLE_KEY', '$p$DB_TABLE_KEY'$parent.")
+          throw new IllegalArgumentException(s"No options are specified for the '$prefix' query. Usually, it is one of: '$p$SQL_KEY', '$p$PATH_KEY', '$p$TABLE_KEY', '$p$DB_TABLE_KEY', '$p$TOPIC_KEY'$parent.")
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/model/QueryBuilderSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/model/QueryBuilderSuite.scala
@@ -55,7 +55,7 @@ class QueryBuilderSuite extends AnyWordSpec {
         QueryBuilder.fromConfig(conf, "", "")
       }
 
-      assert(exception.getMessage == "No options are specified for the query. Usually, it is one of: 'sql', 'path', 'table', 'db.table'.")
+      assert(exception.getMessage == "No options are specified for the query. Usually, it is one of: 'sql', 'path', 'table', 'db.table', 'topic'.")
     }
 
     "throw an exception when the prefix is empty" in {
@@ -65,7 +65,7 @@ class QueryBuilderSuite extends AnyWordSpec {
         QueryBuilder.fromConfig(conf, "input", "")
       }
 
-      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table'.")
+      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table', 'input.topic'.")
     }
 
     "throw an exception when the prefix is empty and parent is specified" in {
@@ -75,7 +75,7 @@ class QueryBuilderSuite extends AnyWordSpec {
         QueryBuilder.fromConfig(conf, "input", "my.parent")
       }
 
-      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table' at my.parent.")
+      assert(exception.getMessage == "No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table', 'input.topic' at my.parent.")
     }
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableParserSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/SourceTableParserSuite.scala
@@ -119,7 +119,7 @@ class SourceTableParserSuite extends AnyWordSpec {
         SourceTableParser.fromConfig(conf, "source.tables")
       }
 
-      assert(ex.getMessage.contains("No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table' at source.tables[0]."))
+      assert(ex.getMessage.contains("No options are specified for the 'input' query. Usually, it is one of: 'input.sql', 'input.path', 'input.table', 'input.db.table', 'input.topic' at source.tables[0]."))
     }
 
     "throw an exception in case of duplicate entries" in {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "topic" as an input source configuration option (alongside table, db.table, path, and sql)
  * Added `key.column.serializer` configuration option for Kafka key handling (supports binary, string, avro, or none)

* **Documentation**
  * Updated Kafka Avro source configuration examples and documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->