### PR TITLE
#656 Make offset types exhaustive when matching in SQL generators.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDatabricks.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDatabricks.scala
@@ -118,6 +118,8 @@ class SqlGeneratorDatabricks(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in Databricks SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDb2.scala
@@ -104,6 +104,8 @@ class SqlGeneratorDb2(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in DB2 SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorDenodo.scala
@@ -122,6 +122,8 @@ class SqlGeneratorDenodo(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in Denodo SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorGeneric.scala
@@ -104,6 +104,8 @@ class SqlGeneratorGeneric(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConf
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in the generic SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHive.scala
@@ -118,6 +118,8 @@ class SqlGeneratorHive(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig)
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in Hive SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorHsqlDb.scala
@@ -104,6 +104,8 @@ class SqlGeneratorHsqlDb(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in HSQLDB SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMicrosoft.scala
@@ -190,6 +190,8 @@ class SqlGeneratorMicrosoft(sqlConfig: SqlConfig) extends SqlGenerator {
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in MS SQL Server query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMySQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorMySQL.scala
@@ -100,6 +100,8 @@ class SqlGeneratorMySQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in MySQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorOracle.scala
@@ -97,6 +97,8 @@ class SqlGeneratorOracle(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfi
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in Oracle SQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorPostgreSQL.scala
@@ -100,6 +100,8 @@ class SqlGeneratorPostgreSQL(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlC
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in PostgreSQL query generator.")
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/sql/SqlGeneratorSas.scala
@@ -199,6 +199,8 @@ class SqlGeneratorSas(sqlConfig: SqlConfig) extends SqlGeneratorBase(sqlConfig) 
         s"$column $condition $value"
       case OffsetValue.StringValue(value) =>
         s"$column $condition '$value'"
+      case t =>
+        throw new IllegalArgumentException(s"Offset type [${t.dataType.dataTypeString}] is not supported in SAS SQL query generator.")
     }
   }
 }


### PR DESCRIPTION
Closes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for offset operations across all supported database platforms. The system now provides explicit, descriptive error messages when encountering unsupported offset value types, replacing previous behavior that could result in silent failures or unclear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->