### PR TITLE
#724 Switch the behavior of Hive repair table on reruns. Do it only if explicitly asked.

### DIFF
--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -112,6 +112,9 @@ pramen {
   # Maximum number of attempts allowed for the pipeline run
   runtime.max.attempts = 1
 
+  # Force re-create Hive tables
+  runtime.hive.force.recreate = false
+
   # Send an email even if there are no changes and no late or not ready data
   email.if.no.changes = true
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/app/config/RuntimeConfig.scala
@@ -47,7 +47,8 @@ case class RuntimeConfig(
                           historicalRunMode: RunMode,
                           sparkAppDescriptionTemplate: Option[String],
                           attempt: Int, // Current attempt number for the pipeline run (for auto-retry automation)
-                          maxAttempts: Int // Maximum number of attempts allowed for the pipeline run
+                          maxAttempts: Int, // Maximum number of attempts allowed for the pipeline run
+                          forceReCreateHiveTables: Boolean
                         )
 
 object RuntimeConfig {
@@ -76,6 +77,7 @@ object RuntimeConfig {
   val SPARK_APP_DESCRIPTION_TEMPLATE = "pramen.job.description.template"
   val ATTEMPT = "pramen.runtime.attempt"
   val MAX_ATTEMPTS = "pramen.runtime.max.attempts"
+  val FORCE_RECREATE_HIVE_TABLES = "pramen.runtime.hive.force.recreate"
 
   def fromConfig(conf: Config): RuntimeConfig = {
     val infoDateFormat = conf.getString(INFORMATION_DATE_FORMAT_APP)
@@ -163,7 +165,8 @@ object RuntimeConfig {
       runMode,
       sparkAppDescriptionTemplate,
       attempt,
-      maxAttempts
+      maxAttempts,
+      forceReCreateHiveTables =  ConfigUtils.getOptionBoolean(conf, FORCE_RECREATE_HIVE_TABLES).getOrElse(false)
     )
   }
 
@@ -188,7 +191,8 @@ object RuntimeConfig {
       historicalRunMode = RunMode.CheckUpdates,
       sparkAppDescriptionTemplate = None,
       attempt = 1,
-      maxAttempts = 1
+      maxAttempts = 1,
+      forceReCreateHiveTables = false
     )
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/cmd/CmdLineConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/cmd/CmdLineConfig.scala
@@ -48,7 +48,8 @@ case class CmdLineConfig(
                           overrideLogLevel: Option[String] = None,
                           logEffectiveConfig: Option[Boolean] = None,
                           attempt: Option[Int] = None,
-                          maxAttempts: Option[Int] = None
+                          maxAttempts: Option[Int] = None,
+                          forceReCreateHiveTables: Option[Boolean] = None
                         )
 
 object CmdLineConfig {
@@ -136,6 +137,9 @@ object CmdLineConfig {
 
     for (maxAttempts <- cmd.maxAttempts)
       accumulatedConfig = accumulatedConfig.withValue(MAX_ATTEMPTS, ConfigValueFactory.fromAnyRef(maxAttempts))
+
+    for (forcereCreateHiveTables <- cmd.forceReCreateHiveTables)
+      accumulatedConfig = accumulatedConfig.withValue(FORCE_RECREATE_HIVE_TABLES, ConfigValueFactory.fromAnyRef(forcereCreateHiveTables))
 
     accumulatedConfig
   }
@@ -253,6 +257,10 @@ object CmdLineConfig {
     opt[Boolean]("log-config").optional().action((value, config) =>
         config.copy(logEffectiveConfig = Option(value)))
       .text("When true (default), Pramen logs the effective configuration.")
+
+    opt[Unit]("force-recreate-hive-tables").optional().action((_, config) =>
+        config.copy(forceReCreateHiveTables = Some(true)))
+      .text("When specified, Hive tables configured for metastore tables will be re-created, and partitions repaired.")
 
     help("help").text("prints this usage text")
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/cmd/CmdLineConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/cmd/CmdLineConfig.scala
@@ -138,8 +138,8 @@ object CmdLineConfig {
     for (maxAttempts <- cmd.maxAttempts)
       accumulatedConfig = accumulatedConfig.withValue(MAX_ATTEMPTS, ConfigValueFactory.fromAnyRef(maxAttempts))
 
-    for (forcereCreateHiveTables <- cmd.forceReCreateHiveTables)
-      accumulatedConfig = accumulatedConfig.withValue(FORCE_RECREATE_HIVE_TABLES, ConfigValueFactory.fromAnyRef(forcereCreateHiveTables))
+    for (forceReCreateHiveTables <- cmd.forceReCreateHiveTables)
+      accumulatedConfig = accumulatedConfig.withValue(FORCE_RECREATE_HIVE_TABLES, ConfigValueFactory.fromAnyRef(forceReCreateHiveTables))
 
     accumulatedConfig
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -411,7 +411,7 @@ abstract class TaskRunnerBase(conf: Config,
         }
 
         val hiveWarnings = if (task.job.outputTable.hiveTable.nonEmpty) {
-          val recreate = schemaChangesBeforeTransform.nonEmpty || schemaChangesAfterTransform.nonEmpty || task.reason == TaskRunReason.Rerun
+          val recreate = schemaChangesBeforeTransform.nonEmpty || schemaChangesAfterTransform.nonEmpty || runtimeConfig.forceReCreateHiveTables
           task.job.createOrRefreshHiveTable(dfTransformed.schema, task.infoDate, recreate)
         } else {
           Seq.empty

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/RuntimeConfigFactory.scala
@@ -42,7 +42,8 @@ object RuntimeConfigFactory {
                             historicalRunMode: RunMode = RunMode.CheckUpdates,
                             sparkAppDescriptionTemplate: Option[String] = None,
                             attempt: Int = 1,
-                            maxAttempts: Int = 1): RuntimeConfig = {
+                            maxAttempts: Int = 1,
+                            forceReCreateHiveTables: Boolean = false): RuntimeConfig = {
     RuntimeConfig(isDryRun,
       isRerun,
       runTables,
@@ -62,7 +63,8 @@ object RuntimeConfigFactory {
       historicalRunMode,
       sparkAppDescriptionTemplate,
       attempt,
-      maxAttempts)
+      maxAttempts,
+      forceReCreateHiveTables)
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/cmd/CmdLineConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/cmd/CmdLineConfigSuite.scala
@@ -366,6 +366,14 @@ class CmdLineConfigSuite extends AnyWordSpec {
 
       assert(cmd.isEmpty)
     }
+
+    "return the modified config if force-recreate-hive-tables = true" in {
+      val cmd = CmdLineConfig.parseCmdLine(Array("--workflow", "dummy.config", "--force-recreate-hive-tables"))
+      val config = CmdLineConfig.applyCmdLineToConfig(populatedConfig, cmd.get)
+
+      assert(config.hasPath(FORCE_RECREATE_HIVE_TABLES))
+      assert(config.getBoolean(FORCE_RECREATE_HIVE_TABLES))
+    }
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/job/JobSpy.scala
@@ -55,6 +55,7 @@ class JobSpy(jobName: String = "Dummy Job",
   var saveCount = 0
   var saveDf: DataFrame = _
   var createHiveTableCount = 0
+  var recreateHiveTable = false
 
   override def taskDef: TaskDef = TaskDefFactory.getDummyTaskNotification(outputTable = MetaTable.getMetaTableDef(outputTable))
 
@@ -109,6 +110,7 @@ class JobSpy(jobName: String = "Dummy Job",
 
   override def createOrRefreshHiveTable(schema: StructType, infoDate: LocalDate, recreate: Boolean): Seq[String] = {
     createHiveTableCount += 1
+    recreateHiveTable = recreate
     Nil
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/TaskRunnerBaseSuite.scala
@@ -550,7 +550,7 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
       assert(bk.asInstanceOf[SyncBookkeeperMock].getDataChunks("table_out", infoDate, None).isEmpty)
     }
 
-    "expose Hive table" in {
+    "expose a new Hive table" in {
       val (runner, bk, _, state, _, tasks) = getUseCase(runFunction = () => RunResult(exampleDf), hiveTable = Some("table_hive"))
 
       val task = tasks.head
@@ -565,6 +565,27 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
       val success = result.runStatus.asInstanceOf[Succeeded]
 
       assert(job.createHiveTableCount == 1)
+      assert(!job.recreateHiveTable)
+      assert(success.hiveTablesUpdated.length == 1)
+      assert(success.hiveTablesUpdated.head == "table_hive")
+    }
+
+    "force re-create existing Hive table" in {
+      val (runner, bk, _, state, _, tasks) = getUseCase(runFunction = () => RunResult(exampleDf), hiveTable = Some("table_hive"), forceReCreateHiveTable = true)
+
+      val task = tasks.head
+      val job = task.job.asInstanceOf[JobSpy]
+
+      val started = Instant.now()
+
+      val result = runner.run(task, started, JobPreRunResult(JobPreRunStatus.Ready, Some(150), Nil, Nil))
+
+      assert(result.runStatus.isInstanceOf[Succeeded])
+
+      val success = result.runStatus.asInstanceOf[Succeeded]
+
+      assert(job.createHiveTableCount == 1)
+      assert(job.recreateHiveTable)
       assert(success.hiveTablesUpdated.length == 1)
       assert(success.hiveTablesUpdated.head == "table_hive")
     }
@@ -679,6 +700,7 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
                  runFunction: () => RunResult = () => null,
                  isDryRun: Boolean = false,
                  isRerun: Boolean = false,
+                 forceReCreateHiveTable: Boolean = false,
                  bookkeeperIn: Bookkeeper = null,
                  allowParallel: Boolean = true,
                  hasSelfDependencies: Boolean = false,
@@ -688,7 +710,7 @@ class TaskRunnerBaseSuite extends AnyWordSpec with SparkTestBase with TextCompar
                 ): (TaskRunnerBase, Bookkeeper, Journal, PipelineStateSpy, OperationDef, Seq[Task]) = {
     val conf = ConfigFactory.empty()
 
-    val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(isRerun = isRerun, isDryRun = isDryRun)
+    val runtimeConfig = RuntimeConfigFactory.getDummyRuntimeConfig(isRerun = isRerun, isDryRun = isDryRun, forceReCreateHiveTables = forceReCreateHiveTable)
 
     val bookkeeper = if (bookkeeperIn == null) new SyncBookkeeperMock else bookkeeperIn
     val journal = new JournalMock


### PR DESCRIPTION
Closes #724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to force Hive table recreation: --force-recreate-hive-tables
  * New runtime configuration key pramen.runtime.hive.force.recreate (defaults to false)

* **Tests**
  * Added/updated tests to cover the new CLI option and runtime flag behavior, including cases for initial table creation and forced re-creation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->