### PR TITLE
#726 Track critical lazy job failures to enable early failure detection in orchestrator

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientJobManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientJobManager.scala
@@ -41,7 +41,7 @@ object TransientJobManager {
   private var taskRunnerOpt: Option[TaskRunner] = None
   private var criticalLazyJobFailed = false
 
-  def getCriticalLazyJobFailed: Boolean = synchronized {
+  def hasCriticalLazyJobFailed: Boolean = synchronized {
     criticalLazyJobFailed
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientJobManager.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/TransientJobManager.scala
@@ -39,6 +39,15 @@ object TransientJobManager {
   private val lazyJobs = new mutable.HashMap[String, Job]()
   private val runningJobs = new mutable.HashMap[MetastorePartition, Future[DataFrame]]()
   private var taskRunnerOpt: Option[TaskRunner] = None
+  private var criticalLazyJobFailed = false
+
+  def getCriticalLazyJobFailed: Boolean = synchronized {
+    criticalLazyJobFailed
+  }
+
+  private[core] def setCriticalLazyJobFailed(failed: Boolean): Unit = synchronized {
+    criticalLazyJobFailed = failed
+  }
 
   private[core] def setTaskRunner(taskRunner_ : TaskRunner): Unit = synchronized {
     taskRunnerOpt = Option(taskRunner_)
@@ -215,6 +224,7 @@ object TransientJobManager {
     lazyJobs.clear()
     runningJobs.clear()
     taskRunnerOpt = None
+    setCriticalLazyJobFailed(false)
   }
 
   private[core] def runJob(job: Job,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -87,7 +87,7 @@ class OrchestratorImpl extends Orchestrator {
         runningJobs.remove(finishedJob)
 
         hasFatalErrors = hasFatalErrors || taskResults.exists(status => isFatalFailure(status.runStatus))
-        hasCriticalJobFailures = hasCriticalJobFailures || TransientJobManager.getCriticalLazyJobFailed || (!isSucceeded && finishedJob.operation.isCritical)
+        hasCriticalJobFailures = hasCriticalJobFailures || TransientJobManager.hasCriticalLazyJobFailed || (!isSucceeded && finishedJob.operation.isCritical)
 
         val hasAnotherUnfinishedJob = hasAnotherJobWithSameOutputTable(finishedJob.outputTable.name)
         if (hasAnotherUnfinishedJob) {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/orchestrator/OrchestratorImpl.scala
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.status.{RunStatus, TaskResult}
 import za.co.absa.pramen.core.app.AppContext
 import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, ValidationException}
+import za.co.absa.pramen.core.metastore.peristence.TransientJobManager
 import za.co.absa.pramen.core.pipeline.{Job, JobDependency, OperationType}
 import za.co.absa.pramen.core.runner.jobrunner.ConcurrentJobRunner
 import za.co.absa.pramen.core.runner.splitter.ScheduleStrategyUtils.evaluateRunDate
@@ -86,7 +87,7 @@ class OrchestratorImpl extends Orchestrator {
         runningJobs.remove(finishedJob)
 
         hasFatalErrors = hasFatalErrors || taskResults.exists(status => isFatalFailure(status.runStatus))
-        hasCriticalJobFailures = hasCriticalJobFailures || (!isSucceeded && finishedJob.operation.isCritical)
+        hasCriticalJobFailures = hasCriticalJobFailures || TransientJobManager.getCriticalLazyJobFailed || (!isSucceeded && finishedJob.operation.isCritical)
 
         val hasAnotherUnfinishedJob = hasAnotherJobWithSameOutputTable(finishedJob.outputTable.name)
         if (hasAnotherUnfinishedJob) {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -26,12 +26,13 @@ import za.co.absa.pramen.api.lock.TokenLockFactory
 import za.co.absa.pramen.api.status._
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
-import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, ReasonException}
+import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, LazyJobErrorWrapper, ReasonException}
 import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.journal.model.TaskCompleted
 import za.co.absa.pramen.core.lock.TokenLockFactoryAllow
 import za.co.absa.pramen.core.metastore.MetaTableStats
 import za.co.absa.pramen.core.metastore.model.MetaTable
+import za.co.absa.pramen.core.metastore.peristence.TransientJobManager
 import za.co.absa.pramen.core.pipeline.JobPreRunStatus._
 import za.co.absa.pramen.core.pipeline.PipelineDef.{COUNTRY_KEY, ENVIRONMENT_NAME, PIPELINE_NAME_KEY, TENANT_KEY}
 import za.co.absa.pramen.core.pipeline._
@@ -92,14 +93,25 @@ abstract class TaskRunnerBase(conf: Config,
   }
 
   override def runLazyTask(job: Job, infoDate: LocalDate): RunStatus = {
-    val started = Instant.now()
-    val task = Task(job, infoDate, TaskRunReason.OnRequest)
-    val result: TaskResult = validate(task, started) match {
-      case Left(failedResult) => failedResult
-      case Right(validationResult) => run(task, started, validationResult)
-    }
+    if (TransientJobManager.getCriticalLazyJobFailed) {
+      RunStatus.NotRan
+    } else {
+      val started = Instant.now()
+      val task = Task(job, infoDate, TaskRunReason.OnRequest)
+      val result: TaskResult = validate(task, started) match {
+        case Left(failedResult) => failedResult
+        case Right(validationResult) => run(task, started, validationResult)
+      }
 
-    onTaskCompletion(task, result, isLazy = true)
+      val runStatus = onTaskCompletion(task, result, isLazy = true)
+
+      if (job.operation.isCritical && result.runStatus.isFailure) {
+        // Set the flag that a critical job has failed to fail early
+        TransientJobManager.setCriticalLazyJobFailed(true)
+      }
+
+      runStatus
+    }
   }
 
   /** Runs multiple tasks in the single thread in the order of info dates. If one task fails, the rest will be skipped. */
@@ -486,8 +498,11 @@ abstract class TaskRunnerBase(conf: Config,
 
     logTaskResult(updatedResult, isLazy)
     val wasInterrupted = isTaskInterrupted(task, taskResult)
+    val isFaliedBecauseOfALazyJob = isFailureOfLazyJob(updatedResult.runStatus)
     if (wasInterrupted) {
       log.warn("Skipping the interrupted exception of the killed task.")
+    } else if (isFaliedBecauseOfALazyJob) {
+      log.warn("Skipping the caller of the lazy task.")
     } else {
       pipelineState.addTaskCompletion(Seq(updatedResult))
       if (taskResult.runStatus != RunStatus.NotRan)
@@ -495,6 +510,17 @@ abstract class TaskRunnerBase(conf: Config,
     }
 
     updatedResult.runStatus
+  }
+
+  private def isFailureOfLazyJob(runStatus: RunStatus): Boolean = {
+    runStatus match {
+      case RunStatus.ValidationFailed(ex) if ex.isInstanceOf[LazyJobErrorWrapper] =>
+        true
+      case RunStatus.Failed(ex) if ex.isInstanceOf[LazyJobErrorWrapper] =>
+        true
+      case _ =>
+        false
+    }
   }
 
   private def isTaskInterrupted(task: Task, taskResult: TaskResult): Boolean = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -93,7 +93,7 @@ abstract class TaskRunnerBase(conf: Config,
   }
 
   override def runLazyTask(job: Job, infoDate: LocalDate): RunStatus = {
-    if (TransientJobManager.getCriticalLazyJobFailed) {
+    if (TransientJobManager.hasCriticalLazyJobFailed) {
       RunStatus.NotRan
     } else {
       val started = Instant.now()
@@ -498,10 +498,10 @@ abstract class TaskRunnerBase(conf: Config,
 
     logTaskResult(updatedResult, isLazy)
     val wasInterrupted = isTaskInterrupted(task, taskResult)
-    val isFaliedBecauseOfALazyJob = isFailureOfLazyJob(updatedResult.runStatus)
+    val isFailedBecauseOfALazyJob = isFailureOfLazyJob(updatedResult.runStatus)
     if (wasInterrupted) {
       log.warn("Skipping the interrupted exception of the killed task.")
-    } else if (isFaliedBecauseOfALazyJob) {
+    } else if (isFailedBecauseOfALazyJob) {
       log.warn("Skipping the caller of the lazy task.")
     } else {
       pipelineState.addTaskCompletion(Seq(updatedResult))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/state/PipelineStateImpl.scala
@@ -355,7 +355,7 @@ object PipelineStateImpl {
   def pipelineStatus(appException: Option[Throwable], taskResults: Seq[TaskResult], pipelineNotificationFailures: Seq[PipelineNotificationFailure], warningFlag: Boolean, strictFailures: Boolean): PipelineStatus = {
     val isCertainFailure = appException.nonEmpty
     val (someTasksSucceeded, someTasksFailed) = getSuccessFlags(appException, taskResults)
-    val someCriticalTasksFailed = taskResults.exists(t => t.taskDef.isCritical && t.runStatus.isFailure)
+    val someCriticalTasksFailed = taskResults.exists(t => t.taskDef.isCritical && t.runStatus.isFailure) || TransientJobManager.hasCriticalLazyJobFailed
 
     val warningState = warningFlag || hasWarnings(taskResults, pipelineNotificationFailures)
 


### PR DESCRIPTION
Closes #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global critical lazy-job failure state is now cleared on manager reset and halts further lazy task starts once triggered.
  * Pipeline status calculation now considers global lazy-job failures to avoid misreporting success.

* **Improvements**
  * Lazy tasks short-circuit when a critical lazy failure exists; related completion/journal updates are skipped.
  * Logging for lazy-job failures improved for clearer traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->