### PR TITLE
#718 Add support for "prefer.coalesce" when repartitioning metastore tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,13 @@ pramen.metastore {
       name = "table_name"
       format = "parquet"
       path = "hdfs://cluster/path/to/parquet/folder"
+      # You can specify the target nuber of records per partition
       records.per.partition = 1000000
+      # Or the excplicit partition count
+      #number.of.partitions
+
+      # If true, Pramen will use coalesce() instead of repartition() when `records.per.partition` is specified
+      #prefer.coalesce = true
       
       # (Experimental) Save mode to use when writing to partitions.
       # Supported: overwrite (default), append
@@ -447,6 +453,8 @@ Metastore table options:
 | `table`                                   | Delta Lake table name (if Delta Lake tables are the underlying storage).                                                                                                                                                                                            |
 | `cache.policy`                            | For `transient` format only. Cache policy defines how to store transient tables for the duration of the pipeline. Available options: `cache`, `no_cache`, `persist`.----                                                                                            |
 | `records.per.partition`                   | Number of records per partition (in order to avoid small files problem).                                                                                                                                                                                            |
+| `number.of.partitions`                    | Specify the number of partitions explicitly. Peamen is going to use `df.coalesce(x)` before writing to the metastore table.                                                                                                                                         |
+| `prefer.coalesce`                         | If true, Pramen will use coalesce() instead of repartition() when `records.per.partition` is specified.                                                                                                                                                             |
 | `information.date.column`                 | Name of the column that contains the information date. *                                                                                                                                                                                                            |
 | `information.date.format`                 | Format of the information date used for partitioning (in Java format notation). *                                                                                                                                                                                   |
 | `information.date.start`                  | The earliest date the table contains data for. *                                                                                                                                                                                                                    |

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/PartitionInfo.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/PartitionInfo.scala
@@ -23,6 +23,6 @@ object PartitionInfo {
 
   case class Explicit(numberOfPartitions: Int) extends PartitionInfo
 
-  case class PerRecordCount(recordsPerPartition: Long) extends PartitionInfo
+  case class PerRecordCount(recordsPerPartition: Long, preferCoalesce: Boolean) extends PartitionInfo
 
 }

--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -48,6 +48,10 @@ pramen {
   # Or you can specify the same option in the number of days from the current calendar date.
   #information.date.max.days.behind = 30
 
+  # If true, when repartitioning tables in metastore prefer coalesce() to repartition()
+  # Coalesce is always used when the target number of partitions is 1
+  prefer.coalesce = false
+
   # If non-zero, specifies how many tasks can be ran in parallel
   parallel.tasks = 1
 
@@ -169,6 +173,10 @@ pramen {
 
   # Default number of records per partition for metastore tables
   #default.records.per.partition = 1000000
+
+  # When true, coalesce() is used for repartitioning instead of repartition() by default
+  # Coalesce is always used when the target number of partitions is 1
+  default.prefer.coalesce = false
 
   # Default minimum dates to start initial data sourcing from a table when no bookkeeping information
   # is created for that table

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/DataFormatParser.scala
@@ -17,7 +17,7 @@
 package za.co.absa.pramen.core.metastore.model
 
 import com.typesafe.config.Config
-import za.co.absa.pramen.api.{CachePolicy, CatalogTable, DataFormat, PartitionInfo, Query}
+import za.co.absa.pramen.api._
 import za.co.absa.pramen.core.utils.ConfigUtils
 
 object DataFormatParser {
@@ -33,24 +33,27 @@ object DataFormatParser {
   val TABLE_KEY = "table"
   val NUMBER_OF_PARTITIONS_KEY = "number.of.partitions"
   val RECORDS_PER_PARTITION_KEY = "records.per.partition"
+  val PREFER_COALESCE_KEY = "prefer.coalesce"
   val CACHE_POLICY_KEY = "cache.policy"
   val DEFAULT_FORMAT = "parquet"
 
   val DEFAULT_RECORDS_PER_PARTITION_KEY = "pramen.default.records.per.partition"
+  val DEFAULT_PREFER_COALESCE_KEY = "pramen.default.prefer.coalesce"
 
   def fromConfig(conf: Config, appConfig: Config): DataFormat = {
     val format = ConfigUtils.getOptionString(conf, FORMAT_KEY).getOrElse(DEFAULT_FORMAT)
 
     val defaultRecordsPerPartition = ConfigUtils.getOptionLong(appConfig, DEFAULT_RECORDS_PER_PARTITION_KEY)
+    val defaultPreferCoalesce = ConfigUtils.getOptionBoolean(appConfig, DEFAULT_PREFER_COALESCE_KEY).getOrElse(false)
 
     format match {
       case FORMAT_PARQUET =>
         val path = getPath(conf)
-        val partitionInfo = getPartitionInfo(conf, defaultRecordsPerPartition)
+        val partitionInfo = getPartitionInfo(conf, defaultRecordsPerPartition, defaultPreferCoalesce)
         DataFormat.Parquet(path, partitionInfo)
       case FORMAT_DELTA   =>
         val query = getQuery(conf)
-        val partitionInfo = getPartitionInfo(conf, defaultRecordsPerPartition)
+        val partitionInfo = getPartitionInfo(conf, defaultRecordsPerPartition, defaultPreferCoalesce)
         DataFormat.Delta(query, partitionInfo)
       case FORMAT_ICEBERG =>
         if (!conf.hasPath(TABLE_KEY)) throw new IllegalArgumentException(s"Mandatory option for a metastore table having 'iceberg' format: $TABLE_KEY")
@@ -72,9 +75,10 @@ object DataFormatParser {
     }
   }
 
-  private[core] def getPartitionInfo(conf: Config, defaultRecordsPerPartition: Option[Long]): PartitionInfo = {
+  private[core] def getPartitionInfo(conf: Config, defaultRecordsPerPartition: Option[Long], defaultPreferCoalesce: Boolean): PartitionInfo = {
     val numberOfPartitionsOpt = ConfigUtils.getOptionInt(conf, NUMBER_OF_PARTITIONS_KEY)
     val recordsPerPartitionOpt = ConfigUtils.getOptionLong(conf, RECORDS_PER_PARTITION_KEY)
+    val preferCoalesce = ConfigUtils.getOptionBoolean(conf, PREFER_COALESCE_KEY).getOrElse(defaultPreferCoalesce)
 
     (numberOfPartitionsOpt, recordsPerPartitionOpt) match {
       case (Some(_), Some(_)) =>
@@ -83,10 +87,10 @@ object DataFormatParser {
       case (Some(nop), None) =>
         PartitionInfo.Explicit(nop)
       case (None, Some(rpp)) =>
-        PartitionInfo.PerRecordCount(rpp)
+        PartitionInfo.PerRecordCount(rpp, preferCoalesce)
       case (None, None) =>
         defaultRecordsPerPartition match {
-          case Some(rpp) => PartitionInfo.PerRecordCount(rpp)
+          case Some(rpp) => PartitionInfo.PerRecordCount(rpp, preferCoalesce)
           case None => PartitionInfo.Default
         }
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceParquet.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceParquet.scala
@@ -234,13 +234,16 @@ class MetastorePersistenceParquet(path: String,
 object MetastorePersistenceParquet {
   def applyPartitioning(dfIn: DataFrame, partitionInfo: PartitionInfo, recordCountEstimate: Option[Long]): DataFrame = {
     partitionInfo match {
-      case PartitionInfo.Default => dfIn
-      case PartitionInfo.Explicit(nop) =>
+      case PartitionInfo.Default                             => dfIn
+      case PartitionInfo.Explicit(nop)                       =>
         dfIn.coalesce(nop)
-      case PartitionInfo.PerRecordCount(rpp) =>
+      case PartitionInfo.PerRecordCount(rpp, preferCoalesce) =>
         val recordCount = recordCountEstimate.getOrElse(dfIn.count())
         val numPartitions = Math.max(1, Math.ceil(recordCount.toDouble / rpp)).toInt
-        dfIn.repartition(numPartitions)
+        if (preferCoalesce)
+          dfIn.coalesce(numPartitions)
+        else
+          dfIn.repartition(numPartitions)
     }
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJob.scala
@@ -286,8 +286,9 @@ class PythonTransformationJob(operationDef: OperationDef,
         ""
       case PartitionInfo.Explicit(npp) =>
         s"\n  number_of_partitions: $npp"
-      case PartitionInfo.PerRecordCount(rpp) =>
-        s"\n  records_per_partition: $rpp"
+      case PartitionInfo.PerRecordCount(rpp, preferCoalesce) =>
+        s"""\n  records_per_partition: $rpp
+           |  prefer_coalesce: $preferCoalesce""".stripMargin
     }
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/DataFormatSuite.scala
@@ -41,6 +41,7 @@ class DataFormatSuite extends AnyWordSpec {
         """format = parquet
           |path = /a/b/c
           |records.per.partition = 100
+          |prefer.coalesce = false
           |""".stripMargin)
 
       val format = DataFormatParser.fromConfig(conf, conf)
@@ -49,7 +50,24 @@ class DataFormatSuite extends AnyWordSpec {
       assert(!format.isTransient)
       assert(format.isInstanceOf[Parquet])
       assert(format.asInstanceOf[Parquet].path == "/a/b/c")
-      assert(format.asInstanceOf[Parquet].partitionInfo == PartitionInfo.PerRecordCount(100L))
+      assert(format.asInstanceOf[Parquet].partitionInfo == PartitionInfo.PerRecordCount(100L, preferCoalesce = false))
+    }
+
+    "use 'parquet' when rpp specified explicitly and prefer coalesce" in {
+      val conf = ConfigFactory.parseString(
+        """format = parquet
+          |path = /a/b/c
+          |records.per.partition = 100
+          |prefer.coalesce = true
+          |""".stripMargin)
+
+      val format = DataFormatParser.fromConfig(conf, conf)
+
+      assert(format.name == "parquet")
+      assert(!format.isTransient)
+      assert(format.isInstanceOf[Parquet])
+      assert(format.asInstanceOf[Parquet].path == "/a/b/c")
+      assert(format.asInstanceOf[Parquet].partitionInfo == PartitionInfo.PerRecordCount(100L, preferCoalesce = true))
     }
 
     "use 'parquet' when npp specified explicitly" in {
@@ -82,7 +100,7 @@ class DataFormatSuite extends AnyWordSpec {
       assert(format.isInstanceOf[Delta])
       assert(format.asInstanceOf[Delta].query.isInstanceOf[Query.Path])
       assert(format.asInstanceOf[Delta].query.query == "/a/b/c")
-      assert(format.asInstanceOf[Delta].partitionInfo == PartitionInfo.PerRecordCount(200L))
+      assert(format.asInstanceOf[Delta].partitionInfo == PartitionInfo.PerRecordCount(200L, preferCoalesce = false))
     }
 
     "use 'delta' when npp specified explicitly" in {
@@ -232,7 +250,7 @@ class DataFormatSuite extends AnyWordSpec {
       assert(format.isInstanceOf[Delta])
       assert(format.asInstanceOf[Delta].query.isInstanceOf[Query.Path])
       assert(format.asInstanceOf[Delta].query.query == "/a/b/c")
-      assert(format.asInstanceOf[Delta].partitionInfo == PartitionInfo.PerRecordCount(100))
+      assert(format.asInstanceOf[Delta].partitionInfo == PartitionInfo.PerRecordCount(100, preferCoalesce = false))
     }
 
     "throw an exception on unknown format" in {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -209,6 +209,7 @@ class MetaTableSuite extends AnyWordSpec {
           |name = my_table
           |format = parquet
           |path = /a/b/c
+          |prefer.coalesce = true
           |hive.table = my_hive_table
           |hive.path = /d/e/f
           |information.date.column = INFORMATION_DATE
@@ -250,7 +251,7 @@ class MetaTableSuite extends AnyWordSpec {
       assert(metaTable.hiveConfig.templates.dropTableTemplate == "drop")
       assert(metaTable.hiveConfig.ignoreFailures)
       assert(metaTable.format.name == "parquet")
-      assert(metaTable.format.asInstanceOf[Parquet].partitionInfo == PartitionInfo.PerRecordCount(100))
+      assert(metaTable.format.asInstanceOf[Parquet].partitionInfo == PartitionInfo.PerRecordCount(100, preferCoalesce = true))
       assert(metaTable.hiveTable.contains("my_hive_table"))
       assert(metaTable.hivePath.contains("/d/e/f"))
       assert(!metaTable.hivePreferAddPartition)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode}
 import org.scalatest.Assertion
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.api.{CachePolicy, DataFormat, PartitionInfo, PartitionScheme, Query}
+import za.co.absa.pramen.api._
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.metastore.peristence.{MetastorePersistence, MetastorePersistenceDelta, MetastorePersistenceParquet, MetastorePersistenceTransientEager}
@@ -749,7 +749,7 @@ class MetastorePersistenceSuite extends AnyWordSpec with SparkTestBase with Temp
 
       "support records per partition" in {
         withTempDirectory("mt_persist") { tempDir =>
-          testRecordsPerPartition(s"$tempDir/parquet/info_date=2021-10-12", "*.parquet", getParquetMtPersistence(tempDir, partitionInfo = PartitionInfo.PerRecordCount(2)))
+          testRecordsPerPartition(s"$tempDir/parquet/info_date=2021-10-12", "*.parquet", getParquetMtPersistence(tempDir, partitionInfo = PartitionInfo.PerRecordCount(2, preferCoalesce = false)))
         }
       }
 
@@ -919,7 +919,7 @@ class MetastorePersistenceSuite extends AnyWordSpec with SparkTestBase with Temp
 
       "supports records per partition" in {
         withTempDirectory("mt_persist") { tempDir =>
-          testRecordsPerPartition(s"$tempDir/delta/info_date=2021-10-12", "*.parquet", getDeltaMtPersistence(tempDir, partitionInfo = PartitionInfo.PerRecordCount(2)))
+          testRecordsPerPartition(s"$tempDir/delta/info_date=2021-10-12", "*.parquet", getDeltaMtPersistence(tempDir, partitionInfo = PartitionInfo.PerRecordCount(2, preferCoalesce = false)))
         }
       }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/pipeline/PythonTransformationJobSuite.scala
@@ -411,6 +411,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
           |  format: parquet
           |  path: /tmp/dummy
           |  records_per_partition: 100000
+          |  prefer_coalesce: true
           |  info_date_settings:
           |    column: INFO_DATE
           |    format: yyyy-MM-dd
@@ -422,6 +423,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
           |  format: parquet
           |  path: /tmp/dummy
           |  records_per_partition: 100000
+          |  prefer_coalesce: true
           |  info_date_settings:
           |    column: INFO_DATE
           |    format: yyyy-MM-dd
@@ -430,7 +432,7 @@ class PythonTransformationJobSuite extends AnyWordSpec with BeforeAndAfterAll wi
           |  writer_options: {}
           |""".stripMargin
 
-      val (job, _, _, _) = getUseCase(partitionInfo = PartitionInfo.PerRecordCount(100000L))
+      val (job, _, _, _) = getUseCase(partitionInfo = PartitionInfo.PerRecordCount(100000L, preferCoalesce = true))
 
       val actual = job.getYamlConfig(infoDate)
 


### PR DESCRIPTION
Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `number.of.partitions` metastore table option for specifying partition counts during writes
  * Added `prefer.coalesce` configuration option to control partitioning strategy (coalesce vs. repartition) for records-per-partition settings

* **Documentation**
  * Updated configuration documentation with new metastore table partitioning options and example configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->