### PR TITLE
#746 Remove CHAR(n) support from data types supported when creting Hive tables.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -31,7 +31,6 @@ object JdbcSparkUtils {
   private val log = LoggerFactory.getLogger(this.getClass)
 
   val MAXIMUM_VARCHAR_LENGTH = 8192
-  val MAXIMUM_CHAR_LENGTH = 255
   val MAXIMUM_UUID_LENGTH = 50
 
   /**

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
@@ -418,16 +418,16 @@ object SparkUtils {
   }
 
   /**
-    * Extracts a string-based data type (CharType, VarcharType, or StringType) from field metadata.
+    * Extracts a string-based data type (VarcharType or StringType) from field metadata.
     *
-    * First checks for the presence of character/varchar type metadata key. If found, parses the metadata
-    * value using a pattern to determine if it represents a CHAR or VARCHAR type with a specific length.
+    * First checks for the presence of char/varchar type metadata key. If found, parses the metadata
+    * value using a pattern to extract the length. Both CHAR and VARCHAR metadata are mapped to VarcharType.
     * If the metadata key is not present, attempts to extract a length value from metadata and creates
     * a VarcharType if successful. Falls back to StringType if no specific type information is found
     * or if the metadata cannot be parsed.
     *
     * @param metadata the metadata object containing type information for a field
-    * @return the resolved string-based DataType, which can be CharType, VarcharType, or StringType
+    * @return the resolved string-based DataType, which can be VarcharType or StringType
     */
   def getStringTypeFromMetadata(metadata: Metadata): DataType = {
     def getLength(lenStr: String): Option[Int] = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/SparkUtils.scala
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.jobdef.TransformExpression
 import za.co.absa.pramen.api.{CatalogTable, FieldChange}
 import za.co.absa.pramen.core.expr.DateExprEvaluator
-import za.co.absa.pramen.core.utils.JdbcSparkUtils.{MAXIMUM_CHAR_LENGTH, MAXIMUM_VARCHAR_LENGTH}
+import za.co.absa.pramen.core.utils.JdbcSparkUtils.MAXIMUM_VARCHAR_LENGTH
 import za.co.absa.pramen.core.utils.SparkMaster.Databricks
 
 import java.io.ByteArrayOutputStream
@@ -439,13 +439,6 @@ object SparkUtils {
 
     if (metadata.contains(CHAR_VARCHAR_METADATA_KEY)) {
       metadata.getString(CHAR_VARCHAR_METADATA_KEY) match {
-        case charVarcharTypePattern(kind, len) if kind.equalsIgnoreCase("char") =>
-          val lenOpt = getLength(len)
-          lenOpt match {
-            case Some(l) if l > 0 && l <= MAXIMUM_CHAR_LENGTH  => CharType(l)
-            case Some(l) => VarcharType(l)
-            case None => StringType
-          }
         case charVarcharTypePattern(_, len) =>
           val lenOpt = getLength(len)
           lenOpt match {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/SparkUtilsSuite.scala
@@ -709,7 +709,7 @@ class SparkUtilsSuite extends AnyWordSpec with SparkTestBase with TempDirFixture
 
       val stringType = SparkUtils.getStringTypeFromMetadata(metadata.build())
 
-      assert(stringType == CharType(12))
+      assert(stringType == VarcharType(12))
     }
 
     "return varchar type and ignore case in CHAR_VARCHAR_METADATA_KEY" in {


### PR DESCRIPTION
Closes #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CHAR data type handling when importing database schemas from JDBC connections—CHAR fields are now properly mapped as VARCHAR types to ensure consistent behavior throughout the system
  * Enhanced string field length metadata detection and application with improved validation thresholds to more accurately capture database schema constraints
  * Added dedicated support for UUID field types with proper length validation handling and metadata extraction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbsaOSS/pramen/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->