### PR TITLE
#752 Remove 'driver' from JDBC options, and try current thread context class loader for dynamically loaded JDBC drivers.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -91,7 +91,6 @@ class JdbcUrlSelectorImpl(val jdbcConfig: JdbcConfig) extends JdbcUrlSelector{
 
   override def getProperties: Properties = {
     val properties = new Properties()
-    properties.put("driver", jdbcConfig.driver)
     jdbcConfig.user.foreach(db => properties.put("user", db))
     jdbcConfig.password.foreach(db => properties.put("password", db))
     jdbcConfig.database.foreach(db => properties.put("database", db))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -210,11 +210,14 @@ object JdbcNativeUtils {
         // Trying using the class loader set by the thread context in case the driver is dynamically loaded
         log.info(s"Unable to initialize the driver ${jdbcConfig.driver} using the default class loader. Trying to use the local thread class loader instead", ex)
         val loader = Thread.currentThread().getContextClassLoader
-        Class.forName(jdbcConfig.driver, true, loader)
-        val driverClass = loader.loadClass(jdbcConfig.driver)
+        val driverClass = Class.forName(jdbcConfig.driver, true, loader)
         val driver = driverClass.getDeclaredConstructor().newInstance().asInstanceOf[Driver]
         DriverManager.registerDriver(driver)
-        driver.connect(url, properties)
+        val conn = driver.connect(url, properties)
+        if (conn == null) {
+          throw new SQLException(s"Driver ${jdbcConfig.driver} returned null connection for URL: $url")
+        }
+        conn
     }
 
     jdbcConfig.autoCommit.foreach { autoCommit =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -190,10 +190,7 @@ object JdbcNativeUtils {
   }
 
   private[core] def getJdbcConnection(jdbcConfig: JdbcConfig, url: String): Connection = {
-    Class.forName(jdbcConfig.driver)
-
     val properties = new Properties()
-    properties.put("driver", jdbcConfig.driver)
     jdbcConfig.user.foreach(db => properties.put("user", db))
     jdbcConfig.password.foreach(db => properties.put("password", db))
     jdbcConfig.database.foreach(db => properties.put("database", db))
@@ -204,7 +201,21 @@ object JdbcNativeUtils {
 
     DriverManager.setLoginTimeout(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))
 
-    val connection = DriverManager.getConnection(url, properties)
+    val connection = try {
+      // Trying using default class loader
+      Class.forName(jdbcConfig.driver)
+      DriverManager.getConnection(url, properties)
+    } catch {
+      case ex: ClassNotFoundException =>
+        // Trying using the class loader set by the thread context in case the driver is dynamically loaded
+        log.info(s"Unable to initialize the driver ${jdbcConfig.driver} using the default class loader. Trying to use the local thread class loader instead", ex)
+        val loader = Thread.currentThread().getContextClassLoader
+        Class.forName(jdbcConfig.driver, true, loader)
+        val driverClass = loader.loadClass(jdbcConfig.driver)
+        val driver = driverClass.getDeclaredConstructor().newInstance().asInstanceOf[Driver]
+        DriverManager.registerDriver(driver)
+        driver.connect(url, properties)
+    }
 
     jdbcConfig.autoCommit.foreach { autoCommit =>
       try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved JDBC connection initialization with deferred driver loading. The system now loads the database driver at connection time rather than during initialization, with an intelligent fallback mechanism to handle different class loader contexts. This change enhances compatibility and flexibility across various deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbsaOSS/pramen/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->