### PR TITLE
#754 Add schema migration support for Delta bookkeeper tables via mergeSchema on model mismatch

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
@@ -18,8 +18,8 @@ package za.co.absa.pramen.core.bookkeeper
 
 import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 import za.co.absa.pramen.core.utils.FsUtils
@@ -60,7 +60,7 @@ class BookkeeperDeltaPath(bookkeepingPath: String, batchId: Long)(implicit spark
     try {
       load()
     } catch {
-      case _: AnalysisException =>
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") =>
         // Spark 2 and 3
         migrateModel(recordsPath)
         load()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.bookkeeper
 import io.delta.tables.DeltaTable
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{Column, Dataset, SaveMode, SparkSession}
+import org.apache.spark.sql._
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 import za.co.absa.pramen.core.utils.FsUtils
@@ -48,14 +48,28 @@ class BookkeeperDeltaPath(bookkeepingPath: String, batchId: Long)(implicit spark
   init()
 
   override def getBkDf(filter: Column): Dataset[DataChunk] = {
-    val df = spark
-      .read
-      .format("delta")
-      .load(recordsPath.toUri.toString)
+    def load(): Dataset[DataChunk] = {
+      spark
+        .read
+        .format("delta")
+        .load(recordsPath.toUri.toString)
+        .filter(filter)
+        .orderBy(col("jobFinished"))
+        .as[DataChunk]
+    }
+    try {
+      load()
+    } catch {
+      case _: AnalysisException =>
+        // Spark 2 and 3
+        migrateModel(recordsPath)
+        load()
 
-    df.filter(filter)
-      .orderBy(col("jobFinished"))
-      .as[DataChunk]
+      case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
+        // Spark 3 and 4
+        migrateModel(recordsPath)
+        load()
+    }
   }
 
   override def saveRecordCountDelta(dataChunk: DataChunk): Unit = {
@@ -131,5 +145,19 @@ class BookkeeperDeltaPath(bookkeepingPath: String, batchId: Long)(implicit spark
       fsUtils.createDirectoryRecursive(path)
       writeEmptyDataset[TableSchemaJson](path.toUri.toString)
     }
+  }
+
+  private def migrateModel(path: Path): Unit = {
+    migrateModelViaEmptyDataset[DataChunk](path.toString)
+  }
+
+  private def migrateModelViaEmptyDataset[T <: Product : universe.TypeTag : ClassTag](pathOrTable: String): Unit = {
+    val df = Seq.empty[T].toDS
+
+    df.write
+      .mode(SaveMode.Append)
+      .format("delta")
+      .option("mergeSchema", "true")
+      .save(pathOrTable)
   }
 }

--- a/pramen/core/src/main/scala_2.11/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.11/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -53,7 +53,7 @@ class BookkeeperDeltaTable(database: Option[String],
     val df = try {
       spark.table(recordsFullTableName).as[DataChunk]
     } catch {
-      case _: AnalysisException =>
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") =>
         // Spark 2 and 3
         migrateModel()
         spark.table(recordsFullTableName).as[DataChunk]

--- a/pramen/core/src/main/scala_2.11/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.11/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -17,7 +17,7 @@
 package za.co.absa.pramen.core.bookkeeper
 
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.{Column, Dataset, SaveMode, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Column, Dataset, SaveMode, SparkSession}
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 
@@ -50,7 +50,19 @@ class BookkeeperDeltaTable(database: Option[String],
   init()
 
   override def getBkDf(filter: Column): Dataset[DataChunk] = {
-    val df = spark.table(recordsFullTableName).as[DataChunk]
+    val df = try {
+      spark.table(recordsFullTableName).as[DataChunk]
+    } catch {
+      case _: AnalysisException =>
+        // Spark 2 and 3
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+
+      case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
+        // Spark 3 and 4
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+    }
 
     df.filter(filter)
       .orderBy(col("jobFinished"))
@@ -112,5 +124,19 @@ class BookkeeperDeltaTable(database: Option[String],
     if (!spark.catalog.tableExists(schemasFullTableName)) {
       writeEmptyDataset[TableSchemaJson](schemasFullTableName)
     }
+  }
+
+  private def migrateModel(): Unit = {
+    migrateModelViaEmptyDataset[DataChunk](recordsFullTableName)
+  }
+
+  private def migrateModelViaEmptyDataset[T <: Product : universe.TypeTag : ClassTag](pathOrTable: String): Unit = {
+    val df = Seq.empty[T].toDS
+
+    df.write
+      .format("delta")
+      .mode(SaveMode.Append)
+      .option("mergeSchema", "true")
+      .saveAsTable(pathOrTable)
   }
 }

--- a/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -18,7 +18,7 @@ package za.co.absa.pramen.core.bookkeeper
 
 import io.delta.tables.DeltaTable
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.{Column, Dataset, SaveMode, SparkSession}
+import org.apache.spark.sql._
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 
@@ -51,7 +51,19 @@ class BookkeeperDeltaTable(database: Option[String],
   init()
 
   override def getBkDf(filter: Column): Dataset[DataChunk] = {
-    val df = spark.table(recordsFullTableName).as[DataChunk]
+    val df = try {
+      spark.table(recordsFullTableName).as[DataChunk]
+    } catch {
+      case _: AnalysisException =>
+        // Spark 2 and 3
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+
+      case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
+        // Spark 3 and 4
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+    }
 
     df.filter(filter)
       .orderBy(col("jobFinished"))
@@ -117,5 +129,19 @@ class BookkeeperDeltaTable(database: Option[String],
     if (!spark.catalog.tableExists(schemasFullTableName)) {
       writeEmptyDataset[TableSchemaJson](schemasFullTableName)
     }
+  }
+
+  private def migrateModel(): Unit = {
+    migrateModelViaEmptyDataset[DataChunk](recordsFullTableName)
+  }
+
+  private def migrateModelViaEmptyDataset[T <: Product : universe.TypeTag : ClassTag](pathOrTable: String): Unit = {
+    val df = Seq.empty[T].toDS
+
+    df.write
+      .format("delta")
+      .mode(SaveMode.Append)
+      .option("mergeSchema", "true")
+      .saveAsTable(pathOrTable)
   }
 }

--- a/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -17,8 +17,8 @@
 package za.co.absa.pramen.core.bookkeeper
 
 import io.delta.tables.DeltaTable
-import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql._
+import org.apache.spark.sql.functions.{col, lit}
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 
@@ -54,7 +54,7 @@ class BookkeeperDeltaTable(database: Option[String],
     val df = try {
       spark.table(recordsFullTableName).as[DataChunk]
     } catch {
-      case _: AnalysisException =>
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") =>
         // Spark 2 and 3
         migrateModel()
         spark.table(recordsFullTableName).as[DataChunk]

--- a/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -18,7 +18,7 @@ package za.co.absa.pramen.core.bookkeeper
 
 import io.delta.tables.DeltaTable
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.{Column, Dataset, SaveMode, SparkSession}
+import org.apache.spark.sql.{AnalysisException, Column, Dataset, SaveMode, SparkSession}
 import za.co.absa.pramen.core.bookkeeper.model.TableSchemaJson
 import za.co.absa.pramen.core.model.{DataChunk, TableSchema}
 
@@ -51,7 +51,19 @@ class BookkeeperDeltaTable(database: Option[String],
   init()
 
   override def getBkDf(filter: Column): Dataset[DataChunk] = {
-    val df = spark.table(recordsFullTableName).as[DataChunk]
+    val df = try {
+      spark.table(recordsFullTableName).as[DataChunk]
+    } catch {
+      case _: AnalysisException =>
+        // Spark 2 and 3
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+
+      case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
+        // Spark 3 and 4
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+    }
 
     df.filter(filter)
       .orderBy(col("jobFinished"))
@@ -117,5 +129,19 @@ class BookkeeperDeltaTable(database: Option[String],
     if (!spark.catalog.tableExists(schemasFullTableName)) {
       writeEmptyDataset[TableSchemaJson](schemasFullTableName)
     }
+  }
+
+  private def migrateModel(): Unit = {
+    migrateModelViaEmptyDataset[DataChunk](recordsFullTableName)
+  }
+
+  private def migrateModelViaEmptyDataset[T <: Product : universe.TypeTag : ClassTag](pathOrTable: String): Unit = {
+    val df = Seq.empty[T].toDS
+
+    df.write
+      .format("delta")
+      .mode(SaveMode.Append)
+      .option("mergeSchema", "true")
+      .saveAsTable(pathOrTable)
   }
 }

--- a/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -54,11 +54,6 @@ class BookkeeperDeltaTable(database: Option[String],
     val df = try {
       spark.table(recordsFullTableName).as[DataChunk]
     } catch {
-      case _: AnalysisException =>
-        // Spark 2 and 3
-        migrateModel()
-        spark.table(recordsFullTableName).as[DataChunk]
-
       case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
         // Spark 3 and 4
         migrateModel()

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperDeltaPathLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperDeltaPathLongSuite.scala
@@ -21,7 +21,10 @@ import org.scalatest.BeforeAndAfter
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.bookkeeper.BookkeeperDeltaPath
 import za.co.absa.pramen.core.fixtures.TempDirFixture
+import za.co.absa.pramen.core.model.DataChunk
 import za.co.absa.pramen.core.utils.FsUtils
+
+import java.time.LocalDate
 
 class BookkeeperDeltaPathLongSuite extends BookkeeperCommonSuite with SparkTestBase with BeforeAndAfter with TempDirFixture {
   import za.co.absa.pramen.core.bookkeeper.BookkeeperDeltaPath._
@@ -50,6 +53,25 @@ class BookkeeperDeltaPathLongSuite extends BookkeeperCommonSuite with SparkTestB
         assert(fsUtils.exists(new Path(tmpDir, s"$bookkeepingRootPath/$recordsDirName")))
         assert(fsUtils.exists(new Path(tmpDir, locksDirName)))
       }
+    }
+
+    "test migrations work properly" in {
+      import spark.implicits._
+
+      assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Delta Lake for Spark ${spark.version}")
+
+      val tmpDir2 = createTempDir("bkHadoopDeltaPathSuite_migration")
+      val recordsPath = new Path(tmpDir2, s"$bookkeepingRootPath/$recordsDirName").toString
+
+      Seq.empty[DataChunk].toDS.toDF
+        .drop("batchId", "appendedRecordCount")
+        .write
+        .format("delta")
+        .save(recordsPath)
+
+      val bk = new BookkeeperDeltaPath(tmpDir2, 234L)
+
+      bk.getDataChunks("table1", LocalDate.parse("2018-02-18"), Some(234L))
     }
 
     testBookKeeper(batchId => getBookkeeper(batchId))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperDeltaTableLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/bookkeeper/BookkeeperDeltaTableLongSuite.scala
@@ -19,8 +19,10 @@ package za.co.absa.pramen.core.tests.bookkeeper
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.bookkeeper.BookkeeperDeltaTable
+import za.co.absa.pramen.core.model.DataChunk
 
 import java.io.File
+import java.time.LocalDate
 import scala.util.Random
 
 class BookkeeperDeltaTableLongSuite extends BookkeeperCommonSuite with SparkTestBase with BeforeAndAfter with BeforeAndAfterAll {
@@ -70,6 +72,28 @@ class BookkeeperDeltaTableLongSuite extends BookkeeperCommonSuite with SparkTest
 
       assert(spark.catalog.tableExists(s"${prefix}bookkeeping"))
       assert(spark.catalog.tableExists(s"${prefix}schemas"))
+    }
+
+    "test migrations work properly" in {
+      import spark.implicits._
+
+      assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Delta Lake for Spark ${spark.version}")
+
+      val prefix = getNewTablePrefix
+      val bkTable = s"${prefix}bookkeeping"
+
+      val df = Seq.empty[DataChunk].toDS.toDF
+        .drop("batchId", "appendedRecordCount")
+
+      df.write
+        .format("delta")
+        .saveAsTable(bkTable)
+
+      assert(spark.catalog.tableExists(bkTable))
+
+      val bk = getBookkeeper(prefix, 123L)
+
+      bk.getDataChunks("table1", LocalDate.parse("2018-02-18"), Some(123L))
     }
   }
 


### PR DESCRIPTION
Closes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading Delta tables with schema incompatibilities. The system now automatically detects and recovers from unresolved column errors by performing a schema migration and retrying the read operation.

* **Tests**
  * Added test coverage for schema migration workflows across Delta table operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbsaOSS/pramen/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->