### PR TITLE
#757 Add support for dynamically loaded JDBC drivers and ensure connections are reused in JDBC Native

### DIFF
--- a/pramen/api/pom.xml
+++ b/pramen/api/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>za.co.absa.pramen</groupId>
         <artifactId>pramen</artifactId>
-        <version>1.13.19-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pramen/api/src/main/scala/za/co/absa/pramen/api/TableReader.scala
+++ b/pramen/api/src/main/scala/za/co/absa/pramen/api/TableReader.scala
@@ -21,7 +21,7 @@ import za.co.absa.pramen.api.offset.OffsetValue
 
 import java.time.LocalDate
 
-trait TableReader {
+trait TableReader extends AutoCloseable {
   def getRecordCount(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Long
 
   def getData(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String]): DataFrame

--- a/pramen/core/pom.xml
+++ b/pramen/core/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>za.co.absa.pramen</groupId>
         <artifactId>pramen</artifactId>
-        <version>1.13.19-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaPath.scala
@@ -60,7 +60,7 @@ class BookkeeperDeltaPath(bookkeepingPath: String, batchId: Long)(implicit spark
     try {
       load()
     } catch {
-      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") =>
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") || ex.getMessage().contains("does not exist") =>
         // Spark 2 and 3
         migrateModel(recordsPath)
         load()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/rdb/PramenDb.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/rdb/PramenDb.scala
@@ -250,7 +250,7 @@ object PramenDb {
   def getConnection(jdbcConfig: JdbcConfig): (String, Connection) = {
     val numberOfAttempts = jdbcConfig.retries.getOrElse(DEFAULT_RETRIES)
     val selector = JdbcUrlSelector(jdbcConfig)
-    val (conn, url) = selector.getWorkingConnection(numberOfAttempts)
+    val (conn, url) = selector.getNewConnection(numberOfAttempts)
 
     (url, conn)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/rdb/RdbJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/rdb/RdbJdbc.scala
@@ -89,7 +89,7 @@ object RdbJdbc {
   def apply(jdbcConfig: JdbcConfig): RdbJdbc = {
     val numberOfAttempts = jdbcConfig.retries.getOrElse(DEFAULT_RETRIES)
     val selector = JdbcUrlSelector(jdbcConfig)
-    val (conn, _) = selector.getWorkingConnection(numberOfAttempts)
+    val (conn, _) = selector.getNewConnection(numberOfAttempts)
 
     new RdbJdbc(conn)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/DynamicDriver.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/DynamicDriver.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package za.co.absa.pramen.core.reader
+
+import java.net.URLClassLoader
+import java.sql.Driver
+
+case class DynamicDriver(driver: Driver, classLoader: URLClassLoader)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/DynamicDriver.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/DynamicDriver.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package za.co.absa.pramen.core.reader
 
 import java.net.URLClassLoader

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
@@ -23,7 +23,7 @@ import java.net.URLClassLoader
 import java.sql.{Connection, Driver, SQLException}
 import java.util.Properties
 
-trait JdbcUrlSelector {
+trait JdbcUrlSelector extends AutoCloseable {
   /** The JDBC configuration used for the selector. */
   def jdbcConfig: JdbcConfig
 
@@ -44,7 +44,7 @@ trait JdbcUrlSelector {
 
   /** Returns an url only if it can be successfully connected to. */
   @throws[SQLException]
-  def getWorkingUrl(retriesLeft: Int): String
+  def getWorkingUrl: String
 
   /** Returns properties for the JDBC connection. */
   def getProperties: Properties
@@ -55,12 +55,12 @@ trait JdbcUrlSelector {
   /** Returns a dynamically pre-loaded driver if available. */
   def getLoadedDriver: Option[Driver]
 
-  /** Returns an JDBC connection with the URL that has successfully connected. */
+  /** Returns an JDBC connection with the URL that has successfully connected. Can reuse existing connection */
   @throws[SQLException]
-  def getWorkingConnection(): (Connection, String)
+  def getConnection: (Connection, String)
 
-  /** Returns an JDBC connection with the URL that has successfully connected. */
-  def getWorkingConnection(retriesLeft: Int): (Connection, String)
+  /** Returns an new JDBC connection with the URL that has successfully connected. */
+  def getNewConnection(retriesLeft: Int): (Connection, String)
 }
 
 object JdbcUrlSelector {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
@@ -18,7 +18,9 @@ package za.co.absa.pramen.core.reader
 
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 
-import java.sql.{Connection, SQLException}
+import java.io.File
+import java.net.URLClassLoader
+import java.sql.{Connection, Driver, SQLException}
 import java.util.Properties
 
 trait JdbcUrlSelector {
@@ -47,10 +49,17 @@ trait JdbcUrlSelector {
   /** Returns properties for the JDBC connection. */
   def getProperties: Properties
 
+  /** Returns the path to the Driver JAR if available. */
   def jdbcDriverJarPath: Option[String]
+
+  /** Returns a dynamically pre-loaded driver if available. */
+  def getLoadedDriver: Option[Driver]
 
   /** Returns an JDBC connection with the URL that has successfully connected. */
   @throws[SQLException]
+  def getWorkingConnection(): (Connection, String)
+
+  /** Returns an JDBC connection with the URL that has successfully connected. */
   def getWorkingConnection(retriesLeft: Int): (Connection, String)
 }
 
@@ -58,4 +67,19 @@ object JdbcUrlSelector {
   def apply(jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(None, jdbcConfig)
 
   def apply(jdbcDriverJarPath: Option[String], jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(jdbcDriverJarPath, jdbcConfig)
+
+  def loadDriver(driverJarPath: String, driverClassName: String): Driver = {
+    val jarFile = new File(driverJarPath)
+    val jarURL = jarFile.toURI.toURL
+
+    val loader = new URLClassLoader(
+      Array(jarURL),
+      this.getClass.getClassLoader
+    )
+
+    // Load driver class
+    val driverClass = loader.loadClass(driverClassName)
+    val driver = driverClass.getDeclaredConstructor().newInstance().asInstanceOf[Driver]
+    driver
+  }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
@@ -53,7 +53,7 @@ trait JdbcUrlSelector extends AutoCloseable {
   def jdbcDriverJarPath: Option[String]
 
   /** Returns a dynamically pre-loaded driver if available. */
-  def getLoadedDriver: Option[Driver]
+  val loadedDriver: Option[DynamicDriver]
 
   /** Returns an JDBC connection with the URL that has successfully connected. Can reuse existing connection */
   @throws[SQLException]
@@ -68,7 +68,7 @@ object JdbcUrlSelector {
 
   def apply(jdbcDriverJarPath: Option[String], jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(jdbcDriverJarPath, jdbcConfig)
 
-  def loadDriver(driverJarPath: String, driverClassName: String): Driver = {
+  def loadDriver(driverJarPath: String, driverClassName: String): DynamicDriver = {
     val jarFile = new File(driverJarPath)
     val jarURL = jarFile.toURI.toURL
 
@@ -80,6 +80,6 @@ object JdbcUrlSelector {
     // Load driver class
     val driverClass = loader.loadClass(driverClassName)
     val driver = driverClass.getDeclaredConstructor().newInstance().asInstanceOf[Driver]
-    driver
+    DynamicDriver(driver, loader)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
@@ -47,11 +47,15 @@ trait JdbcUrlSelector {
   /** Returns properties for the JDBC connection. */
   def getProperties: Properties
 
+  def jdbcDriverJarPath: Option[String]
+
   /** Returns an JDBC connection with the URL that has successfully connected. */
   @throws[SQLException]
   def getWorkingConnection(retriesLeft: Int): (Connection, String)
 }
 
 object JdbcUrlSelector {
-  def apply(jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(jdbcConfig)
+  def apply(jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(None, jdbcConfig)
+
+  def apply(jdbcDriverJarPath: Option[String], jdbcConfig: JdbcConfig): JdbcUrlSelector = new JdbcUrlSelectorImpl(jdbcDriverJarPath, jdbcConfig)
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -18,11 +18,13 @@ package za.co.absa.pramen.core.reader
 
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.reader.model.JdbcConfig
-import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
+import za.co.absa.pramen.core.runner.task.ThreadClosableRegistry
+import za.co.absa.pramen.core.utils.JdbcNativeUtils.{DEFAULT_CONNECTION_TIMEOUT_SECONDS, JDBC_WORDS_TO_REDACT}
 import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils}
 
 import java.sql.{Connection, Driver, SQLException}
 import java.util.Properties
+import scala.util.control.NonFatal
 import scala.util.{Failure, Random, Success, Try}
 
 class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig: JdbcConfig) extends JdbcUrlSelector{
@@ -33,6 +35,10 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   private val allUrls = (jdbcConfig.primaryUrl ++ jdbcConfig.fallbackUrls).toSeq
   private val numberOfUrls = allUrls.size
   private var urlPool = allUrls
+  private var isClosed = false
+
+  @transient
+  private var connection: Connection = _
 
   @transient
   override val getLoadedDriver: Option[Driver] = {
@@ -90,10 +96,8 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   }
 
   @throws[SQLException]
-  def getWorkingUrl(retriesLeft: Int): String = {
-    val (connection, url) = getWorkingConnection(retriesLeft)
-    connection.close()
-    url
+  def getWorkingUrl: String = {
+    getConnection._2
   }
 
   override def getProperties: Properties = {
@@ -109,12 +113,25 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   }
 
   @throws[SQLException]
-  override def getWorkingConnection(): (Connection, String) = {
-    getWorkingConnection(jdbcConfig.retries.getOrElse(getNumberOfUrls))
+  override def getConnection: (Connection, String) = {
+    if (isClosed)
+      throw new IllegalStateException("Cannot get a connection from a closed JdbcUrlSelector")
+
+    if (connection == null || connection.isClosed || !connection.isValid(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))) {
+      val retries = jdbcConfig.retries.getOrElse(getNumberOfUrls)
+      val (newConnection, url) = getNewConnection(retries)
+      connection = newConnection
+      ThreadClosableRegistry.registerCloseable(connection)
+      (connection, url)
+    } else {
+      (connection, currentUrl)
+    }
   }
 
   @throws[SQLException]
-  override def getWorkingConnection(retriesLeft: Int): (Connection, String) = {
+  override def getNewConnection(retriesLeft: Int): (Connection, String) = {
+    if (isClosed)
+      throw new IllegalStateException("Cannot get a connection from a closed JdbcUrlSelector")
     val currentUrl = getUrl
     Try {
       JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl, getLoadedDriver)
@@ -127,11 +144,26 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
           log.error(s"JDBC connection error for $currentUrl. Retries left: ${retriesLeft - 1}. Retrying... in $backoffS seconds", ex)
           Thread.sleep(backoffS * 1000)
           log.info(s"Trying URL: $newUrl")
-          getWorkingConnection(retriesLeft - 1)
+          getNewConnection(retriesLeft - 1)
         } else {
           throw ex
         }
     }
+  }
+
+  override def close(): Unit = {
+    if (!isClosed) {
+      isClosed = true
+      if (connection != null && !connection.isClosed) {
+        try {
+          connection.close()
+        } catch {
+          case NonFatal(ex) => log.warn(s"Error while closing JDBC connection $currentUrl", ex)
+        }
+        connection = null
+      }
+    }
+
   }
 
   private def getFirstUrl: String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -22,7 +22,7 @@ import za.co.absa.pramen.core.runner.task.ThreadClosableRegistry
 import za.co.absa.pramen.core.utils.JdbcNativeUtils.{DEFAULT_CONNECTION_TIMEOUT_SECONDS, JDBC_WORDS_TO_REDACT}
 import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils}
 
-import java.sql.{Connection, Driver, SQLException}
+import java.sql.{Connection, SQLException}
 import java.util.Properties
 import scala.util.control.NonFatal
 import scala.util.{Failure, Random, Success, Try}
@@ -41,7 +41,7 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   private var connection: Connection = _
 
   @transient
-  override val getLoadedDriver: Option[Driver] = {
+  override val loadedDriver: Option[DynamicDriver] = {
     jdbcDriverJarPath.map { driverPath =>
       JdbcUrlSelector.loadDriver(driverPath, jdbcConfig.driver)
     }
@@ -117,7 +117,20 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
     if (isClosed)
       throw new IllegalStateException("Cannot get a connection from a closed JdbcUrlSelector")
 
-    if (connection == null || connection.isClosed || !connection.isValid(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))) {
+    val isConnectionClosed = connection != null && connection.isClosed
+
+    if (connection == null || isConnectionClosed || !connection.isValid(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))) {
+      if (connection != null) {
+        ThreadClosableRegistry.unregisterCloseable(connection)
+        if (!isConnectionClosed) {
+          log.warn("Existing connection is not valid. Closing it and creating a new one.")
+          Try(connection.close()).failed.foreach { ex =>
+            log.warn("Failed to close the existing connection", ex)
+          }
+        }
+        connection = null
+      }
+
       val retries = jdbcConfig.retries.getOrElse(getNumberOfUrls)
       val (newConnection, url) = getNewConnection(retries)
       connection = newConnection
@@ -134,7 +147,7 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
       throw new IllegalStateException("Cannot get a connection from a closed JdbcUrlSelector")
     val currentUrl = getUrl
     Try {
-      JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl, getLoadedDriver)
+      JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl, loadedDriver.map(_.driver))
     } match {
       case Success(connection) => (connection, currentUrl)
       case Failure(ex)         =>
@@ -157,6 +170,9 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
       if (connection != null && !connection.isClosed) {
         try {
           connection.close()
+          loadedDriver.foreach { d =>
+            d.classLoader.close()
+          }
         } catch {
           case NonFatal(ex) => log.warn(s"Error while closing JDBC connection $currentUrl", ex)
         }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -25,7 +25,7 @@ import java.sql.{Connection, SQLException}
 import java.util.Properties
 import scala.util.{Failure, Random, Success, Try}
 
-class JdbcUrlSelectorImpl(val jdbcConfig: JdbcConfig) extends JdbcUrlSelector{
+class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig: JdbcConfig) extends JdbcUrlSelector{
   private val log = LoggerFactory.getLogger(this.getClass)
 
   private val BACKOFF_MIN_S = 1

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -21,7 +21,7 @@ import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
 import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils}
 
-import java.sql.{Connection, SQLException}
+import java.sql.{Connection, Driver, SQLException}
 import java.util.Properties
 import scala.util.{Failure, Random, Success, Try}
 
@@ -33,6 +33,13 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   private val allUrls = (jdbcConfig.primaryUrl ++ jdbcConfig.fallbackUrls).toSeq
   private val numberOfUrls = allUrls.size
   private var urlPool = allUrls
+
+  @transient
+  override val getLoadedDriver: Option[Driver] = {
+    jdbcDriverJarPath.map { driverPath =>
+      JdbcUrlSelector.loadDriver(driverPath, jdbcConfig.driver)
+    }
+  }
 
   validate()
 
@@ -102,10 +109,15 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
   }
 
   @throws[SQLException]
-  def getWorkingConnection(retriesLeft: Int): (Connection, String) = {
+  override def getWorkingConnection(): (Connection, String) = {
+    getWorkingConnection(jdbcConfig.retries.getOrElse(getNumberOfUrls))
+  }
+
+  @throws[SQLException]
+  override def getWorkingConnection(retriesLeft: Int): (Connection, String) = {
     val currentUrl = getUrl
     Try {
-      JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl)
+      JdbcNativeUtils.getJdbcConnection(jdbcConfig, currentUrl, getLoadedDriver)
     } match {
       case Success(connection) => (connection, currentUrl)
       case Failure(ex)         =>
@@ -168,5 +180,4 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
       throw new IllegalArgumentException(s"Empty string is not a valid JDBC URL.")
     }
   }
-
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -185,7 +185,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
         case Some(table) => sqlGen.getSchemaQuery(table, Seq.empty)
         case _ => JdbcSparkUtils.getSchemaQuery(sql)
       }
-      JdbcSparkUtils.withJdbcMetadata(jdbcReaderConfig.jdbcConfig, schemaQuery) { (connection, jdbcMetadata) =>
+      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, jdbcMetadata) =>
         val schemaWithMetadata = JdbcSparkUtils.addMetadataFromJdbc(df.schema, jdbcMetadata)
         val schemaWithColumnDescriptions = tableOpt match {
           case Some(table) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
@@ -97,7 +97,7 @@ abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
     var count = 0L
     log.info(s"Executing: $countSql")
 
-    JdbcNativeUtils.withResultSet(jdbcUrlSelector, countSql, jdbcRetries) { rs =>
+    JdbcNativeUtils.withResultSet(jdbcUrlSelector, countSql) { rs =>
       if (!rs.next())
         throw new IllegalStateException(s"No rows returned by the count query: $countSql")
       else {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
@@ -35,11 +35,15 @@ abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
   protected val jdbcRetries: Int = jdbcReaderConfig.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
   protected val extraOptions: Map[String, String] = ConfigUtils.getExtraOptions(conf, "option")
 
+  override def close(): Unit = {
+    jdbcUrlSelector.close()
+  }
+
   private[core] lazy val sqlGen = {
     val gen = SqlGeneratorLoader.getSqlGenerator(jdbcReaderConfig.jdbcConfig.driver, getSqlConfig)
 
     if (gen.requiresConnection) {
-      val (connection, _) = jdbcUrlSelector.getWorkingConnection(jdbcRetries)
+      val (connection, _) = jdbcUrlSelector.getNewConnection(jdbcRetries)
       gen.setConnection(connection)
     }
     gen

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -23,7 +23,7 @@ import za.co.absa.pramen.api.Query
 import za.co.absa.pramen.api.offset.OffsetValue
 import za.co.absa.pramen.core.expr.DateExprEvaluator
 import za.co.absa.pramen.core.reader.model.{JdbcConfig, TableReaderJdbcConfig}
-import za.co.absa.pramen.core.utils.{JdbcNativeUtils, JdbcSparkUtils, StringUtils, TimeUtils}
+import za.co.absa.pramen.core.utils._
 
 import java.time.{Instant, LocalDate}
 
@@ -31,7 +31,6 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
                             jdbcUrlSelector: JdbcUrlSelector,
                             conf: Config)
                            (implicit spark: SparkSession) extends TableReaderJdbcBase(jdbcReaderConfig, jdbcUrlSelector, conf) {
-  import TableReaderJdbcNative._
 
   private val log = LoggerFactory.getLogger(this.getClass)
 
@@ -40,6 +39,10 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
   private val url = jdbcUrlSelector.getWorkingUrl(jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls))
 
   logConfiguration()
+
+  private[core] def getJdbcSelector: JdbcUrlSelector = {
+    jdbcUrlSelector
+  }
 
   private[core] def getJdbcReaderConfig: TableReaderJdbcConfig = {
     jdbcReaderConfig.copy(jdbcConfig = jdbcConfig)
@@ -154,6 +157,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
 
 object TableReaderJdbcNative {
   val FETCH_SIZE_KEY = "option.fetchsize"
+  val DRIVER_JAR_PATH = "driver.jar.path"
 
   def apply(conf: Config,
             workflowConf: Config,
@@ -162,7 +166,8 @@ object TableReaderJdbcNative {
     val tableReaderJdbcOrig = TableReaderJdbcConfig.load(conf, workflowConf, parent)
     val jdbcConfig = getJdbcConfig(tableReaderJdbcOrig, conf)
     val tableReaderJdbc = tableReaderJdbcOrig.copy(jdbcConfig = jdbcConfig)
-    val urlSelector = JdbcUrlSelector(tableReaderJdbc.jdbcConfig)
+    val jdbcDriverJarPath = ConfigUtils.getOptionString(conf, DRIVER_JAR_PATH)
+    val urlSelector = JdbcUrlSelector(jdbcDriverJarPath, tableReaderJdbc.jdbcConfig)
 
     new TableReaderJdbcNative(tableReaderJdbc, urlSelector, conf)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -59,7 +59,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
         getCountForSql(sql)
       case Query.Sql(sql) =>
         log.info(s"JDBC Native count of a non-SELECT SQL statement: $sql")
-        JdbcNativeUtils.getJdbcNativeRecordCount(jdbcConfig, url, sql)
+        JdbcNativeUtils.getJdbcNativeRecordCount(jdbcUrlSelector, sql)
       case other =>
         throw new IllegalArgumentException(s"'${other.name}' is not supported by the JDBC reader. Use 'table' or 'sql' instead.")
     }
@@ -101,7 +101,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
   private[core] def getDataFrame(sql: String, tableOpt: Option[String]): DataFrame = {
     log.info(s"JDBC Query: $sql")
 
-    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcConfig, url, sql)
+    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcUrlSelector, sql)
 
     if (log.isDebugEnabled) {
       log.debug(df.schema.treeString)
@@ -112,7 +112,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
         case Some(table) => sqlGen.getSchemaQuery(table, Seq.empty)
         case _ => JdbcSparkUtils.getSchemaQuery(sql)
       }
-      JdbcSparkUtils.withJdbcMetadata(jdbcConfig, schemaQuery) { (connection, _) =>
+      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, _) =>
         val schemaWithColumnDescriptions = tableOpt match {
           case Some(table) =>
             log.info(s"Reading JDBC metadata descriptions the table: $table")
@@ -135,7 +135,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
     val sql = sqlGen.getDataQueryIncremental(tableName, onlyForInfoDate, offsetFrom, offsetTo, columns)
     log.info(s"JDBC Query: $sql")
 
-    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcConfig, url, sql)
+    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcUrlSelector, sql)
 
     if (log.isDebugEnabled) {
       log.debug(df.schema.treeString)
@@ -144,7 +144,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
     if (jdbcReaderConfig.enableSchemaMetadata) {
       val schemaQuery = sqlGen.getSchemaQuery(tableName, columns)
 
-      JdbcSparkUtils.withJdbcMetadata(jdbcReaderConfig.jdbcConfig, schemaQuery) { (connection, _) =>
+      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, _) =>
         log.info(s"Reading JDBC metadata descriptions the table: $tableName")
         df = spark.createDataFrame(df.rdd,
           JdbcSparkUtils.addColumnDescriptionsFromJdbc(df.schema, sqlGen.unquote(tableName), connection))

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -36,8 +36,6 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
 
   private val jdbcConfig = jdbcReaderConfig.jdbcConfig
 
-  private val url = jdbcUrlSelector.getWorkingUrl(jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls))
-
   logConfiguration()
 
   private[core] def getJdbcSelector: JdbcUrlSelector = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderSpark.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderSpark.scala
@@ -114,6 +114,8 @@ class TableReaderSpark(formatOpt: Option[String],
     }
   }
 
+  override def close(): Unit = {}
+
   private[core] def getDailyDataFrame(query: Query, infoDate: LocalDate): DataFrame = {
     val dateStr = dateFormatter.format(infoDate)
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
@@ -21,8 +21,10 @@ import org.apache.spark.sql.SparkSession
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api._
 import za.co.absa.pramen.api.offset.{OffsetInfo, OffsetValue}
+import za.co.absa.pramen.core.reader.TableReaderJdbcNative.DRIVER_JAR_PATH
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
 import za.co.absa.pramen.core.reader.{JdbcUrlSelector, TableReaderJdbc, TableReaderJdbcNative}
+import za.co.absa.pramen.core.utils.ConfigUtils
 
 import java.time.LocalDate
 
@@ -64,7 +66,8 @@ class JdbcSource(sourceConfig: Config,
   private[core] def getReader(query: Query, isCountQuery: Boolean): TableReader = {
     val jdbcConfig = TableReaderJdbcNative.getJdbcConfig(jdbcReaderConfig, sourceConfig)
     val jdbcReaderConfigNative = jdbcReaderConfig.copy(jdbcConfig = jdbcConfig)
-    val urlSelector = JdbcUrlSelector(jdbcConfig)
+    val jdbcDriverJarPath = ConfigUtils.getOptionString(sourceConfig, DRIVER_JAR_PATH)
+    val urlSelector = JdbcUrlSelector(jdbcDriverJarPath, jdbcConfig)
 
     query match {
       case Query.Table(dbTable) if jdbcReaderConfig.useJdbcNative && !isCountQuery =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/source/JdbcSource.scala
@@ -44,13 +44,22 @@ class JdbcSource(sourceConfig: Config,
   override def getRecordCount(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Long = {
     val reader = getReader(query, isCountQuery = true)
 
-    reader.getRecordCount(query, infoDateBegin, infoDateEnd)
+    val count = try {
+      reader.getRecordCount(query, infoDateBegin, infoDateEnd)
+    } finally {
+      reader.close()
+    }
+    count
   }
 
   override def getData(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String]): SourceResult = {
     val reader = getReader(query, isCountQuery = false)
 
-    val df = reader.getData(query, infoDateBegin, infoDateEnd, columns)
+    val df = try {
+      reader.getData(query, infoDateBegin, infoDateEnd, columns)
+    } finally {
+      reader.close()
+    }
 
     SourceResult(df)
   }
@@ -58,7 +67,11 @@ class JdbcSource(sourceConfig: Config,
   override def getDataIncremental(query: Query, onlyForInfoDate: Option[LocalDate], offsetFrom: Option[OffsetValue], offsetTo: Option[OffsetValue], columns: Seq[String]): SourceResult = {
     val reader = getReader(query, isCountQuery = false)
 
-    val df = reader.getIncrementalData(query, onlyForInfoDate, offsetFrom, offsetTo, columns)
+    val df =  try {
+      reader.getIncrementalData(query, onlyForInfoDate, offsetFrom, offsetTo, columns)
+    } finally {
+      reader.close()
+    }
 
     SourceResult(df)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -49,13 +49,13 @@ object JdbcNativeUtils {
   final val DRIVERS_SUPPORT_ARRAYS = Set("org.postgresql.Driver", "org.hsqldb.jdbc.JDBCDriver")
 
   /** Returns a JDBC URL and connection by a config. */
-  def getConnection(jdbcConfig: JdbcConfig): (String, Connection) = {
+  def getConnection(jdbcConfig: JdbcConfig, driverOpt: Option[Driver]): (String, Connection) = {
     val urlSelector = JdbcUrlSelector(jdbcConfig)
 
     def getConnectionWithRetries(jdbcConfig: JdbcConfig, retriesLeft: Int): (String, Connection) = {
       val currentUrl = urlSelector.getUrl
       try {
-        val connection = getJdbcConnection(jdbcConfig, currentUrl)
+        val connection = getJdbcConnection(jdbcConfig, currentUrl, driverOpt)
 
         (currentUrl, connection)
       } catch {
@@ -74,70 +74,67 @@ object JdbcNativeUtils {
   }
 
   /** Gets the number of records returned by a given query. */
-  def getJdbcNativeRecordCount(jdbcConfig: JdbcConfig,
-                               url: String,
+  def getJdbcNativeRecordCount(urlSelector: JdbcUrlSelector,
                                query: String): Long = {
-    val resultSet = getResultSet(jdbcConfig, url, query)
+    val resultSet = getResultSet(urlSelector, query)
     getResultSetCount(resultSet)
   }
 
   /** Gets a dataframe given a JDBC query */
-  def getJdbcNativeDataFrame(jdbcConfig: JdbcConfig,
-                             url: String,
+  def getJdbcNativeDataFrame(urlSelector: JdbcUrlSelector,
                              query: String)
                             (implicit spark: SparkSession): DataFrame = {
-
     // Executing the query
+    val jdbcConfig = urlSelector.jdbcConfig
     val arraysSupported = DRIVERS_SUPPORT_ARRAYS.contains(jdbcConfig.driver)
-    val rs = getResultSet(jdbcConfig, url, query)
-    val driverIterator = new ResultSetToRowIterator(rs, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
-    val schema = JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
+    val rs = getResultSet(urlSelector, query)
 
-    driverIterator.close()
+    val schema = UsingUtils.using(new ResultSetToRowIterator(rs, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)) { driverIterator =>
+      JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
+    }
+
+    val url = urlSelector.getUrl
 
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {
-      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q), jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
+      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q, urlSelector.jdbcDriverJarPath), jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
     })
 
     spark.createDataFrame(rdd, schema)
   }
 
   def withResultSet(jdbcUrlSelector: JdbcUrlSelector,
-                    query: String,
-                    retries: Int)
+                    query: String)
                    (action: ResultSet => Unit): Unit = {
-    val (connection, _) = jdbcUrlSelector.getWorkingConnection(retries)
+    import UsingUtils.Implicits._
 
-    try {
-      val statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+    val retries = jdbcUrlSelector.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
 
-      try {
-        val resultSet = executeQuery(statement, query, retries)
-        try {
-          action(resultSet)
-        } finally {
-          resultSet.close()
-        }
-      } finally {
-        statement.close()
-      }
-    } finally {
-      connection.close()
+    val (conn, _) = jdbcUrlSelector.getWorkingConnection()
+
+    for {
+      connection <- conn
+      statement <- connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+      resultSet <- executeQuery(statement, query, retries)
+    } {
+      action(resultSet)
     }
   }
 
   private[core] def executeQuery(statement: Statement, query: String, retriesLeft: Int): ResultSet = {
-    try {
-      statement.executeQuery(query)
-    } catch {
-      // This is a workaround for an intermittent issue with the Hive JDBC driver that occasionally throws an index-related exception.
-      // Retrying the query has proven to resolve the issue.
-      case ex: SQLException if retriesLeft > 0 && ex.getMessage.contains("Index: 1, Size: 1") =>
-        log.error(s"Error executing query. Retries left = $retriesLeft. Retrying...", ex)
-        executeQuery(statement, query, retriesLeft - 1)
-      case ex: Throwable =>
-        throw ex
+    var remainingRetries = retriesLeft
+
+    while (true) {
+      try {
+        return statement.executeQuery(query)
+      } catch {
+        case ex: SQLException if remainingRetries > 0 && ex.getMessage.contains("Index: 1, Size: 1") =>
+          log.error(s"Error executing query. Retries left = $remainingRetries. Retrying...", ex)
+          remainingRetries -= 1
+        case ex: Throwable  =>
+          throw ex
+      }
     }
+    throw new IllegalStateException("Unreachable")
   }
 
   private[core] def getResultSetCount(resultSet: ResultSet): Long = {
@@ -159,11 +156,26 @@ object JdbcNativeUtils {
     count
   }
 
-  private def getResultSet(jdbcConfig: JdbcConfig,
-                           url: String,
+  private[core] def getResultSet(urlSelector: JdbcUrlSelector,
                            query: String): ResultSet = {
-    val connection = getJdbcConnection(jdbcConfig, url)
+    val (connection, _) = urlSelector.getWorkingConnection()
 
+    getResultSet(connection, urlSelector.jdbcConfig, query)
+  }
+
+  private[core] def getResultSet(jdbcConfig: JdbcConfig,
+                           url: String,
+                           query: String,
+                           jdbcDriverJarPath: Option[String]): ResultSet = {
+    val driverOpt = jdbcDriverJarPath.map(path => JdbcUrlSelector.loadDriver(path, jdbcConfig.driver))
+    val connection = getJdbcConnection(jdbcConfig, url, driverOpt)
+
+    getResultSet(connection, jdbcConfig, query)
+  }
+
+  private[core] def getResultSet(connection: Connection,
+                           jdbcConfig: JdbcConfig,
+                           query: String): ResultSet = {
     val statement = try {
       if (jdbcConfig.driver == "org.postgresql.Driver")
         // Special handling of PostgreSQL driver that loads.
@@ -189,7 +201,7 @@ object JdbcNativeUtils {
     statement.executeQuery(query)
   }
 
-  private[core] def getJdbcConnection(jdbcConfig: JdbcConfig, url: String): Connection = {
+  private[core] def getJdbcConnection(jdbcConfig: JdbcConfig, url: String, driverOpt: Option[Driver]): Connection = {
     val properties = new Properties()
     jdbcConfig.user.foreach(db => properties.put("user", db))
     jdbcConfig.password.foreach(db => properties.put("password", db))
@@ -199,25 +211,22 @@ object JdbcNativeUtils {
         properties.put(k, v)
     }
 
+    def getConnectionFromDriver(driver: Driver): Connection = {
+      val conn = driver.connect(url, properties)
+      if (conn == null) {
+        throw new SQLException(s"Driver ${jdbcConfig.driver} returned null connection for URL: $url")
+      }
+      conn
+    }
+
     DriverManager.setLoginTimeout(jdbcConfig.connectionTimeoutSeconds.getOrElse(DEFAULT_CONNECTION_TIMEOUT_SECONDS))
 
-    val connection = try {
-      // Trying using default class loader
-      Class.forName(jdbcConfig.driver)
-      DriverManager.getConnection(url, properties)
-    } catch {
-      case ex: ClassNotFoundException =>
-        // Trying using the class loader set by the thread context in case the driver is dynamically loaded
-        log.info(s"Unable to initialize the driver ${jdbcConfig.driver} using the default class loader. Trying to use the local thread class loader instead", ex)
-        val loader = Thread.currentThread().getContextClassLoader
-        val driverClass = Class.forName(jdbcConfig.driver, true, loader)
-        val driver = driverClass.getDeclaredConstructor().newInstance().asInstanceOf[Driver]
-        DriverManager.registerDriver(driver)
-        val conn = driver.connect(url, properties)
-        if (conn == null) {
-          throw new SQLException(s"Driver ${jdbcConfig.driver} returned null connection for URL: $url")
-        }
-        conn
+    val connection = driverOpt match {
+      case Some(driver) =>
+        getConnectionFromDriver(driver)
+      case None =>
+        Class.forName(jdbcConfig.driver)
+        DriverManager.getConnection(url, properties)
     }
 
     jdbcConfig.autoCommit.foreach { autoCommit =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -78,8 +78,17 @@ object JdbcNativeUtils {
   /** Gets the number of records returned by a given query. */
   def getJdbcNativeRecordCount(urlSelector: JdbcUrlSelector,
                                query: String): Long = {
-    val resultSet = getResultSet(urlSelector, query)
-    getResultSetCount(resultSet)
+    val (resultSet, statement) = getResultSet(urlSelector, query)
+    try {
+      val count = getResultSetCount(resultSet)
+      count
+    } finally {
+      try {
+        statement.close()
+      } catch {
+        case NonFatal(ex) => log.warn("Failed to close the statement", ex)
+      }
+    }
   }
 
   /** Gets a dataframe given a JDBC query */
@@ -88,9 +97,9 @@ object JdbcNativeUtils {
                             (implicit spark: SparkSession): DataFrame = {
     val jdbcConfig = urlSelector.jdbcConfig
     val arraysSupported = DRIVERS_SUPPORT_ARRAYS.contains(jdbcConfig.driver)
-    val rs = getResultSet(urlSelector, query)
+    val (rs, statement) = getResultSet(urlSelector, query)
 
-    val schema = UsingUtils.using(new ResultSetToRowIterator(rs, None, None, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)) { driverIterator =>
+    val schema = UsingUtils.using(new ResultSetToRowIterator(rs, Option(statement), None, None, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)) { driverIterator =>
       JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
     }
 
@@ -108,8 +117,8 @@ object JdbcNativeUtils {
                                          arraysSupported: Boolean)
                             (implicit spark: SparkSession): DataFrame = {
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {
-      val (rs, connection, classLoaderOpt) = getResultSetForRDD(jdbcConfig, url, q, jdbcDriverJarPath)
-      new ResultSetToRowIterator(rs, Option(connection), classLoaderOpt, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
+      val (rs, statement, connection, classLoaderOpt) = getResultSetForRDD(jdbcConfig, url, q, jdbcDriverJarPath)
+      new ResultSetToRowIterator(rs, Option(statement), Option(connection), classLoaderOpt, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
     })
 
     spark.createDataFrame(rdd, schema)
@@ -169,7 +178,7 @@ object JdbcNativeUtils {
   }
 
   private[core] def getResultSet(urlSelector: JdbcUrlSelector,
-                           query: String): ResultSet = {
+                           query: String): (ResultSet, Statement) = {
     val (connection, _) = urlSelector.getConnection
 
     getResultSet(connection, urlSelector.jdbcConfig, query)
@@ -178,16 +187,16 @@ object JdbcNativeUtils {
   private[core] def getResultSetForRDD(jdbcConfig: JdbcConfig,
                                        url: String,
                                        query: String,
-                                       jdbcDriverJarPath: Option[String]): (ResultSet, Connection, Option[URLClassLoader]) = {
+                                       jdbcDriverJarPath: Option[String]): (ResultSet, Statement, Connection, Option[URLClassLoader]) = {
     val dynamicDriverOpt = jdbcDriverJarPath.map(path => JdbcUrlSelector.loadDriver(path, jdbcConfig.driver))
     val connection = getJdbcConnection(jdbcConfig, url, dynamicDriverOpt.map(_.driver))
-    val rs = getResultSet(connection, jdbcConfig, query)
-    (rs, connection, dynamicDriverOpt.map(_.classLoader))
+    val (rs, statement) = getResultSet(connection, jdbcConfig, query)
+    (rs, statement, connection, dynamicDriverOpt.map(_.classLoader))
   }
 
   private[core] def getResultSet(connection: Connection,
                            jdbcConfig: JdbcConfig,
-                           query: String): ResultSet = {
+                           query: String): (ResultSet, Statement) = {
     val statement = try {
       if (jdbcConfig.driver == "org.postgresql.Driver")
         // Special handling of PostgreSQL driver that loads.
@@ -210,7 +219,7 @@ object JdbcNativeUtils {
       statement.setFetchSize(n)
     )
 
-    statement.executeQuery(query)
+    (statement.executeQuery(query), statement)
   }
 
   private[core] def getJdbcConnection(jdbcConfig: JdbcConfig, url: String, driverOpt: Option[Driver]): Connection = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -23,6 +23,7 @@ import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.impl.ResultSetToRowIterator
 
+import java.net.URLClassLoader
 import java.sql._
 import java.util.Properties
 import scala.util.Try
@@ -89,7 +90,7 @@ object JdbcNativeUtils {
     val arraysSupported = DRIVERS_SUPPORT_ARRAYS.contains(jdbcConfig.driver)
     val rs = getResultSet(urlSelector, query)
 
-    val schema = UsingUtils.using(new ResultSetToRowIterator(rs, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)) { driverIterator =>
+    val schema = UsingUtils.using(new ResultSetToRowIterator(rs, None, None, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)) { driverIterator =>
       JdbcSparkUtils.addMetadataFromJdbc(driverIterator.getSchema, rs.getMetaData)
     }
 
@@ -107,7 +108,8 @@ object JdbcNativeUtils {
                                          arraysSupported: Boolean)
                             (implicit spark: SparkSession): DataFrame = {
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {
-      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q, jdbcDriverJarPath), jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
+      val (rs, connection, classLoaderOpt) = getResultSetForRDD(jdbcConfig, url, q, jdbcDriverJarPath)
+      new ResultSetToRowIterator(rs, Option(connection), classLoaderOpt, jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
     })
 
     spark.createDataFrame(rdd, schema)
@@ -123,8 +125,7 @@ object JdbcNativeUtils {
     val (conn, _) = jdbcUrlSelector.getConnection
 
     for {
-      connection <- conn
-      statement <- connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
+      statement <- conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
       resultSet <- executeQuery(statement, query, retries)
     } {
       action(resultSet)
@@ -174,14 +175,14 @@ object JdbcNativeUtils {
     getResultSet(connection, urlSelector.jdbcConfig, query)
   }
 
-  private[core] def getResultSet(jdbcConfig: JdbcConfig,
-                           url: String,
-                           query: String,
-                           jdbcDriverJarPath: Option[String]): ResultSet = {
-    val driverOpt = jdbcDriverJarPath.map(path => JdbcUrlSelector.loadDriver(path, jdbcConfig.driver))
-    val connection = getJdbcConnection(jdbcConfig, url, driverOpt)
-
-    getResultSet(connection, jdbcConfig, query)
+  private[core] def getResultSetForRDD(jdbcConfig: JdbcConfig,
+                                       url: String,
+                                       query: String,
+                                       jdbcDriverJarPath: Option[String]): (ResultSet, Connection, Option[URLClassLoader]) = {
+    val dynamicDriverOpt = jdbcDriverJarPath.map(path => JdbcUrlSelector.loadDriver(path, jdbcConfig.driver))
+    val connection = getJdbcConnection(jdbcConfig, url, dynamicDriverOpt.map(_.driver))
+    val rs = getResultSet(connection, jdbcConfig, query)
+    (rs, connection, dynamicDriverOpt.map(_.classLoader))
   }
 
   private[core] def getResultSet(connection: Connection,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcNativeUtils.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.pramen.core.utils
 
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.reader.JdbcUrlSelector
@@ -84,7 +85,6 @@ object JdbcNativeUtils {
   def getJdbcNativeDataFrame(urlSelector: JdbcUrlSelector,
                              query: String)
                             (implicit spark: SparkSession): DataFrame = {
-    // Executing the query
     val jdbcConfig = urlSelector.jdbcConfig
     val arraysSupported = DRIVERS_SUPPORT_ARRAYS.contains(jdbcConfig.driver)
     val rs = getResultSet(urlSelector, query)
@@ -95,8 +95,19 @@ object JdbcNativeUtils {
 
     val url = urlSelector.getUrl
 
+    getJdbcNativeDataFrameSerializable(schema, url, query, urlSelector.jdbcConfig, urlSelector.jdbcDriverJarPath, arraysSupported)
+  }
+
+  /** This method uses only serializable parameters because they are going to be passed to the RDD */
+  private def getJdbcNativeDataFrameSerializable(schema: StructType,
+                                         url: String,
+                                         query: String,
+                                         jdbcConfig: JdbcConfig,
+                                         jdbcDriverJarPath: Option[String],
+                                         arraysSupported: Boolean)
+                            (implicit spark: SparkSession): DataFrame = {
     val rdd = spark.sparkContext.parallelize(Seq(query)).flatMap(q => {
-      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q, urlSelector.jdbcDriverJarPath), jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
+      new ResultSetToRowIterator(getResultSet(jdbcConfig, url, q, jdbcDriverJarPath), jdbcConfig.sanitizeDateTime, jdbcConfig.incorrectDecimalsAsString, arraysSupported)
     })
 
     spark.createDataFrame(rdd, schema)
@@ -109,7 +120,7 @@ object JdbcNativeUtils {
 
     val retries = jdbcUrlSelector.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
 
-    val (conn, _) = jdbcUrlSelector.getWorkingConnection()
+    val (conn, _) = jdbcUrlSelector.getConnection
 
     for {
       connection <- conn
@@ -158,7 +169,7 @@ object JdbcNativeUtils {
 
   private[core] def getResultSet(urlSelector: JdbcUrlSelector,
                            query: String): ResultSet = {
-    val (connection, _) = urlSelector.getWorkingConnection()
+    val (connection, _) = urlSelector.getConnection
 
     getResultSet(connection, urlSelector.jdbcConfig, query)
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
+import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.SparkUtils.{COMMENT_METADATA_KEY, MAX_LENGTH_METADATA_KEY}
 import za.co.absa.pramen.core.utils.impl.JdbcFieldMetadata
@@ -178,14 +179,14 @@ object JdbcSparkUtils {
     * Connects to a database and executes a raw SQL query using Java JDBC, and allows running a custom action on the
     * metadata of the query.
     *
-    * @param jdbcConfig  a JDBC configuration.
-    * @param schemaQuery a SQL query in the dialect native to the database which does not return records.
-    * @param action      the action to execute on a connection + resultset metadata.
+    * @param jdbcUrlSelector a JDBC URL slector.
+    * @param schemaQuery     a SQL query in the dialect native to the database which does not return records.
+    * @param action          the action to execute on a connection + resultset metadata.
     */
-  def withJdbcMetadata(jdbcConfig: JdbcConfig,
+  def withJdbcMetadata(jdbcUrlSelector: JdbcUrlSelector,
                        schemaQuery: String)
                       (action: (Connection, ResultSetMetaData) => Unit): Unit = {
-    val (_, connection) = JdbcNativeUtils.getConnection(jdbcConfig)
+    val (connection, _) = jdbcUrlSelector.getWorkingConnection()
 
     log.info(s"Getting metadata for: $schemaQuery")
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -186,16 +186,12 @@ object JdbcSparkUtils {
   def withJdbcMetadata(jdbcUrlSelector: JdbcUrlSelector,
                        schemaQuery: String)
                       (action: (Connection, ResultSetMetaData) => Unit): Unit = {
-    val (connection, _) = jdbcUrlSelector.getWorkingConnection()
+    val (connection, _) = jdbcUrlSelector.getConnection
 
     log.info(s"Getting metadata for: $schemaQuery")
 
-    try {
-      withMetadataResultSet(connection, schemaQuery) { rs =>
-        action(connection, rs.getMetaData)
-      }
-    } finally {
-      connection.close()
+    withMetadataResultSet(connection, schemaQuery) { rs =>
+      action(connection, rs.getMetaData)
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -120,7 +120,7 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
     }
 
     if (connection == null || forceReconnect) {
-      val (newConnection, url) = jdbcUrlSelector.getWorkingConnection(retries)
+      val (newConnection, url) = jdbcUrlSelector.getNewConnection(retries)
       log.info(s"Selected query executor connection: $url")
       close()
       connection = newConnection

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
@@ -25,7 +25,7 @@ import java.sql.{Date, ResultSet, Timestamp}
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.collection.mutable
 
-class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrectDecimalsAsString: Boolean, arraysSupported: Boolean) extends Iterator[Row] {
+class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrectDecimalsAsString: Boolean, arraysSupported: Boolean) extends Iterator[Row] with AutoCloseable {
   import ResultSetToRowIterator._
 
   private var didHasNext = false
@@ -63,7 +63,7 @@ class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrect
     StructType(columns)
   }
 
-  def close(): Unit = {
+  override def close(): Unit = {
     rs.close()
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
@@ -20,12 +20,43 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 
+import java.net.URLClassLoader
 import java.sql.Types._
-import java.sql.{Date, ResultSet, Timestamp}
+import java.sql.{Connection, Date, ResultSet, Timestamp}
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.collection.mutable
 
-class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrectDecimalsAsString: Boolean, arraysSupported: Boolean) extends Iterator[Row] with AutoCloseable {
+/**
+  * An iterator that wraps a JDBC ResultSet and converts each row into a Spark Row.
+  *
+  * This class provides a bridge between JDBC result sets and Spark's Row abstraction,
+  * enabling lazy iteration over database query results. It implements both
+  * `scala.collection.Iterator` for traversal and `java.lang.AutoCloseable` for
+  * proper resource management of the underlying JDBC connection and result set.
+  *
+  * The iterator supports a wide range of JDBC data types including primitive types,
+  * binary data, decimals, dates, timestamps, and arrays of various element types.
+  * Date and timestamp values are sanitized to ensure they fall within safe boundaries
+  * compatible with Spark's internal representation.
+  *
+  * The schema of the underlying result set can be retrieved as a Spark StructType
+  * via the `getSchema` method, which maps JDBC column types to their corresponding
+  * Spark SQL data types.
+  *
+  * Closing the iterator will release the underlying ResultSet, the optional JDBC
+  * connection, and the optional driver class loader. The iterator automatically
+  * closes these resources when all rows have been consumed.
+  *
+  * Note. Pass a connection and the class loader only if you want the iterator to own them as
+  * resources and close them automatically when the iterator is closed or the end of data is
+  * reached.
+  */
+final class ResultSetToRowIterator(rs: ResultSet,
+                                   connectionOpt: Option[Connection],
+                                   driverClassLoader: Option[URLClassLoader],
+                                   sanitizeDateTime: Boolean,
+                                   incorrectDecimalsAsString: Boolean,
+                                   arraysSupported: Boolean) extends Iterator[Row] with AutoCloseable {
   import ResultSetToRowIterator._
 
   private var didHasNext = false
@@ -65,6 +96,8 @@ class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrect
 
   override def close(): Unit = {
     rs.close()
+    connectionOpt.foreach(_.close())
+    driverClassLoader.foreach(_.close())
   }
 
   private[core] def fetchNext(): Unit = {
@@ -78,7 +111,7 @@ class ResultSetToRowIterator(rs: ResultSet, sanitizeDateTime: Boolean, incorrect
       }
       item = Some(new GenericRow(data))
     } else {
-      rs.close()
+      close()
       item = None
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ResultSetToRowIterator.scala
@@ -19,12 +19,14 @@ package za.co.absa.pramen.core.utils.impl
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
+import org.slf4j.LoggerFactory
 
 import java.net.URLClassLoader
 import java.sql.Types._
-import java.sql.{Connection, Date, ResultSet, Timestamp}
+import java.sql.{Connection, Date, ResultSet, Statement, Timestamp}
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /**
   * An iterator that wraps a JDBC ResultSet and converts each row into a Spark Row.
@@ -47,16 +49,19 @@ import scala.collection.mutable
   * connection, and the optional driver class loader. The iterator automatically
   * closes these resources when all rows have been consumed.
   *
-  * Note. Pass a connection and the class loader only if you want the iterator to own them as
-  * resources and close them automatically when the iterator is closed or the end of data is
-  * reached.
+  * Note. Pass a statement, a connection and the class loader only if you want the
+  * iterator to own them as resources and close them automatically when the iterator
+  * is closed or the end of data is reached.
   */
 final class ResultSetToRowIterator(rs: ResultSet,
+                                   statementOpt: Option[Statement],
                                    connectionOpt: Option[Connection],
                                    driverClassLoader: Option[URLClassLoader],
                                    sanitizeDateTime: Boolean,
                                    incorrectDecimalsAsString: Boolean,
                                    arraysSupported: Boolean) extends Iterator[Row] with AutoCloseable {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
   import ResultSetToRowIterator._
 
   private var didHasNext = false
@@ -95,9 +100,18 @@ final class ResultSetToRowIterator(rs: ResultSet,
   }
 
   override def close(): Unit = {
-    rs.close()
-    connectionOpt.foreach(_.close())
-    driverClassLoader.foreach(_.close())
+    safeClose("result set")(rs.close())
+    statementOpt.foreach(s => safeClose("statement")(s.close()))
+    connectionOpt.foreach(c => safeClose("connection")(c.close()))
+    driverClassLoader.foreach(cl => safeClose("driver class loader")(cl.close()))
+  }
+
+  private def safeClose(name: String)(action: => Unit): Unit = {
+    try {
+      action
+    } catch {
+      case NonFatal(ex) => log.info(s"Error while closing $name: ${ex.getMessage}")
+    }
   }
 
   private[core] def fetchNext(): Unit = {

--- a/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.12/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -54,7 +54,7 @@ class BookkeeperDeltaTable(database: Option[String],
     val df = try {
       spark.table(recordsFullTableName).as[DataChunk]
     } catch {
-      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") =>
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") || ex.getMessage().contains("does not exist") =>
         // Spark 2 and 3
         migrateModel()
         spark.table(recordsFullTableName).as[DataChunk]

--- a/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
+++ b/pramen/core/src/main/scala_2.13/za/co/absa/pramen/core/bookkeeper/BookkeeperDeltaTable.scala
@@ -54,6 +54,11 @@ class BookkeeperDeltaTable(database: Option[String],
     val df = try {
       spark.table(recordsFullTableName).as[DataChunk]
     } catch {
+      case ex: AnalysisException if ex.getMessage().contains("cannot resolve") || ex.getMessage().contains("does not exist") =>
+        // Spark 2 and 3
+        migrateModel()
+        spark.table(recordsFullTableName).as[DataChunk]
+
       case ex: Throwable if ex.getMessage.contains("UNRESOLVED_COLUMN") =>
         // Spark 3 and 4
         migrateModel()

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineJdbcLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineJdbcLongSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.rdb.{PramenDb, RdbJdbc}
-import za.co.absa.pramen.core.reader.JdbcUrlSelectorImpl
+import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.runner.AppRunner
 import za.co.absa.pramen.core.samples.RdbExampleTable
@@ -152,7 +152,7 @@ class IncrementalPipelineJdbcLongSuite extends AnyWordSpec
   }
 
   private def debugSql(sql: String): Unit = {
-    JdbcNativeUtils.withResultSet(new JdbcUrlSelectorImpl(jdbcConfig), sql, 1) { rs =>
+    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), sql, 1) { rs =>
       val mt = rs.getMetaData
 
       for (i <- 1 to mt.getColumnCount) {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineJdbcLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineJdbcLongSuite.scala
@@ -152,7 +152,7 @@ class IncrementalPipelineJdbcLongSuite extends AnyWordSpec
   }
 
   private def debugSql(sql: String): Unit = {
-    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), sql, 1) { rs =>
+    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), sql) { rs =>
       val mt = rs.getMetaData
 
       for (i <- 1 to mt.getColumnCount) {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
@@ -1451,7 +1451,7 @@ class IncrementalPipelineLongFixture extends AnyWordSpec
 
   /* This method is used to inspect offsets after operations */
   private def debugOffsets(): Unit = {
-    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), "SELECT * FROM \"offsets\"", 1) { rs =>
+    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), "SELECT * FROM \"offsets\"") { rs =>
       val mt = rs.getMetaData
 
       for (i <- 1 to mt.getColumnCount) {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/integration/IncrementalPipelineLongFixture.scala
@@ -29,7 +29,7 @@ import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.bookkeeper.OffsetManagerJdbc
 import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TempDirFixture, TextComparisonFixture}
 import za.co.absa.pramen.core.rdb.{PramenDb, RdbJdbc}
-import za.co.absa.pramen.core.reader.JdbcUrlSelectorImpl
+import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.runner.AppRunner
 import za.co.absa.pramen.core.utils.{FsUtils, JdbcNativeUtils, ResourceUtils, UsingUtils}
@@ -1451,7 +1451,7 @@ class IncrementalPipelineLongFixture extends AnyWordSpec
 
   /* This method is used to inspect offsets after operations */
   private def debugOffsets(): Unit = {
-    JdbcNativeUtils.withResultSet(new JdbcUrlSelectorImpl(jdbcConfig), "SELECT * FROM \"offsets\"", 1) { rs =>
+    JdbcNativeUtils.withResultSet(JdbcUrlSelector(jdbcConfig), "SELECT * FROM \"offsets\"", 1) { rs =>
       val mt = rs.getMetaData
 
       for (i <- 1 to mt.getColumnCount) {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/reader/ReaderSpy.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/reader/ReaderSpy.scala
@@ -53,4 +53,6 @@ class ReaderSpy(numRecords: Long,
   }
 
   override def getIncrementalData(query: Query, onlyForInfoDate: Option[LocalDate], offsetFromOpt: Option[OffsetValue], offsetToOpt: Option[OffsetValue], columns: Seq[String]): DataFrame = ???
+
+  override def close(): Unit = {}
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/reader/ReaderStub.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/mocks/reader/ReaderStub.scala
@@ -28,4 +28,6 @@ class ReaderStub extends TableReader {
   override def getData(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate, columns: Seq[String]): DataFrame = null
 
   override def getIncrementalData(query: Query, onlyForInfoDate: Option[LocalDate], offsetFromOpt: Option[OffsetValue], offsetToOpt: Option[OffsetValue], columns: Seq[String]): DataFrame = ???
+
+  override def close(): Unit = {}
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/JournalHadoopDeltaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/journal/JournalHadoopDeltaTableSuite.scala
@@ -59,7 +59,6 @@ class JournalHadoopDeltaTableSuite extends AnyWordSpec with BeforeAndAfterAll wi
           journal.addEntry(task2)
           journal.addEntry(task3)
 
-
           val entries = journal.getEntries(instant2, instant3).sortBy(_.informationDate.toString)
 
           assert(entries.nonEmpty)
@@ -76,13 +75,17 @@ class JournalHadoopDeltaTableSuite extends AnyWordSpec with BeforeAndAfterAll wi
   private def cleanUpWarehouse(): Unit = {
     val warehouseDir = new File("spark-warehouse")
     if (warehouseDir.exists()) {
-      warehouseDir.listFiles().foreach(f => {
-        if (f.isDirectory) {
-          f.listFiles().foreach(ff => ff.delete())
-        }
-        f.delete()
-      })
-      warehouseDir.delete()
+      deleteRecursively(warehouseDir)
     }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory) {
+      val children = file.listFiles()
+      if (children != null) {
+        children.foreach(deleteRecursively)
+      }
+    }
+    file.delete()
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/JdbcUrlSelectorImplSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/JdbcUrlSelectorImplSuite.scala
@@ -17,8 +17,8 @@
 package za.co.absa.pramen.core.tests.reader
 
 import org.scalatest.wordspec.AnyWordSpec
-import za.co.absa.pramen.core.reader.JdbcUrlSelectorImpl
 import za.co.absa.pramen.core.reader.model.JdbcConfig
+import za.co.absa.pramen.core.reader.{JdbcUrlSelector, JdbcUrlSelectorImpl}
 
 class JdbcUrlSelectorImplSuite extends AnyWordSpec {
   "constructor" should {
@@ -144,6 +144,6 @@ class JdbcUrlSelectorImplSuite extends AnyWordSpec {
 
   private def getJdbcUrlSelector(primaryUrl: Option[String], fallbackUrls: Seq[String]): JdbcUrlSelectorImpl = {
     val conf = JdbcConfig("testDriver", primaryUrl, fallbackUrls, None, Some("testUser"), Some("testPassword"))
-    new JdbcUrlSelectorImpl(conf)
+    JdbcUrlSelector(conf).asInstanceOf[JdbcUrlSelectorImpl]
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcNativeSuite.scala
@@ -85,6 +85,19 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
        |
        |  has.information.date.column = false
        |  limit.records = 100
+       |}
+       |reader_jar {
+       |  driver.jar.path = "test.jar"
+       |  jdbc {
+       |    driver = "$driver"
+       |    connection.string = "$url"
+       |    user = "$user"
+       |    password = "$password"
+       |    autocommit = false
+       |  }
+       |
+       |  has.information.date.column = false
+       |  limit.records = 100
        |}""".stripMargin)
 
   override protected def beforeAll(): Unit = {
@@ -126,6 +139,17 @@ class TableReaderJdbcNativeSuite extends AnyWordSpec with RelationalDbFixture wi
 
     "work with config with limits" in {
       val reader = TableReaderJdbcNative(conf.getConfig("reader_limit"), conf.getConfig("reader_limit"), "reader_limit")
+      assert(reader.getJdbcReaderConfig.infoDateFormat == "yyyy-MM-dd")
+      assert(reader.getJdbcReaderConfig.jdbcConfig.sanitizeDateTime)
+      assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit.contains(false))
+      assert(reader.getJdbcReaderConfig.jdbcConfig.fetchSize.isEmpty)
+      assert(reader.getJdbcReaderConfig.limitRecords.contains(100))
+    }
+
+    "work with driver JAR path" in {
+      val reader = TableReaderJdbcNative(conf.getConfig("reader_jar"), conf.getConfig("reader_jar"), "reader_jar")
+      val jdbcSelector = reader.getJdbcSelector
+      assert(jdbcSelector.jdbcDriverJarPath.contains("test.jar"))
       assert(reader.getJdbcReaderConfig.infoDateFormat == "yyyy-MM-dd")
       assert(reader.getJdbcReaderConfig.jdbcConfig.sanitizeDateTime)
       assert(reader.getJdbcReaderConfig.jdbcConfig.autoCommit.contains(false))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
@@ -223,7 +223,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     when(resultSet.getMetaData).thenReturn(resultSetMetaData)
 
     "return normal decimal for correct precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(10, 0) == DecimalType(10, 0))
       assert(iterator.getDecimalSparkSchema(10, 2) == DecimalType(10, 2))
@@ -232,7 +232,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return fixed decimal for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(1, -1) == DecimalType(38, 18))
       assert(iterator.getDecimalSparkSchema(0, 0) == DecimalType(38, 18))
@@ -244,7 +244,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return string type for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = true, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(1, -1) == StringType)
       assert(iterator.getDecimalSparkSchema(0, 0) == StringType)
@@ -264,7 +264,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     when(resultSet.getMetaData).thenReturn(resultSetMetaData)
 
     "return normal decimal for correct precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(10)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -272,7 +272,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return fixed decimal for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(0)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -280,7 +280,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return string type for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = true, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(0)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -307,7 +307,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       val maxTimestamp = 253402300799999L
 
       "ignore null values" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
         val fixedTs = iterator.sanitizeTimestamp(null)
 
@@ -315,7 +315,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql positive infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(POSTGRESQL_DATE_POSITIVE_INFINITY))
 
         val fixedTs = iterator.sanitizeTimestamp(timestamp)
@@ -324,7 +324,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql negative infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(POSTGRESQL_DATE_NEGATIVE_INFINITY))
 
         val fixedTs = iterator.sanitizeTimestamp(timestamp)
@@ -333,7 +333,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert overflowed value to the maximum value supported" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(1000000000000000L))
 
         val actual = iterator.sanitizeTimestamp(timestamp)
@@ -347,7 +347,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "do nothing if the feature is turned off" in {
-        val iterator = new ResultSetToRowIterator(resultSet, false, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(1000000000000000L))
 
         val actual = iterator.sanitizeTimestamp(timestamp)
@@ -367,7 +367,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       val maxDate = 253402214400000L
 
       "ignore null values" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
         val fixedDate = iterator.sanitizeDate(null)
 
@@ -375,7 +375,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql positive infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(POSTGRESQL_DATE_POSITIVE_INFINITY)
 
         val fixedDate = iterator.sanitizeDate(date)
@@ -384,7 +384,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql negative infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(POSTGRESQL_DATE_NEGATIVE_INFINITY)
 
         val fixedDate = iterator.sanitizeDate(date)
@@ -393,7 +393,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert overflowed value to the maximum value supported" in {
-        val iterator = new ResultSetToRowIterator(resultSet, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(1000000000000000L)
 
         val actual = iterator.sanitizeDate(date)
@@ -407,7 +407,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "do nothing if the feature is turned off" in {
-        val iterator = new ResultSetToRowIterator(resultSet, false, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(1000000000000000L)
 
         val actual = iterator.sanitizeDate(date)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito.{mock, when}
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.utils.impl.ResultSetToRowIterator
@@ -68,7 +69,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     "select working connection when provided a connection pool" in {
       val jdbcConfig = JdbcConfig(driver, Some("bogus_url"), "bogus_url2" :: url :: Nil, None, Option(user), Option(password))
 
-      val (actualUrl, conn) = JdbcNativeUtils.getConnection(jdbcConfig)
+      val (actualUrl, conn) = JdbcNativeUtils.getConnection(jdbcConfig, None)
       conn.close()
 
       assert(actualUrl == url)
@@ -80,7 +81,8 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     val conf = JdbcConfig(driver, Some(url), Nil, None, Option(user), Option(password))
 
     "return record count when data is available" in {
-      val count = JdbcNativeUtils.getJdbcNativeRecordCount(conf, conf.primaryUrl.get, s"SELECT id FROM $tableName WHERE id = 1")
+      val selector = JdbcUrlSelector(conf)
+      val count = JdbcNativeUtils.getJdbcNativeRecordCount(selector, s"SELECT id FROM $tableName WHERE id = 1")
 
       assert(count == 1)
     }
@@ -97,14 +99,16 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
 
     "throw an exception on error" in {
       intercept[SQLSyntaxErrorException] {
-        JdbcNativeUtils.getJdbcNativeRecordCount(conf, conf.primaryUrl.get, s"SELECT id FROM no_such_table")
+        val selector = JdbcUrlSelector(conf)
+        JdbcNativeUtils.getJdbcNativeRecordCount(selector, s"SELECT id FROM no_such_table")
       }
     }
   }
 
   "getJdbcNativeDataFrame()" should {
     "return proper schema from a JDBC query" in {
-      val df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcConfig, jdbcConfig.primaryUrl.get, s"SELECT * FROM $tableName WHERE id = 1")
+      val selector = JdbcUrlSelector(jdbcConfig)
+      val df = JdbcNativeUtils.getJdbcNativeDataFrame(selector, s"SELECT * FROM $tableName WHERE id = 1")
       val expected =
         """{
           |  "type" : "struct",
@@ -168,6 +172,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return proper data from a JDBC query" in {
+      val selector = JdbcUrlSelector(jdbcConfig)
       val expected =
         """[ {
           |  "ID" : 1,
@@ -196,15 +201,16 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
           |  "FOUNDED" : "2016-12-31"
           |} ]""".stripMargin
 
-      val df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcConfig, jdbcConfig.primaryUrl.get, s"SELECT id, name, email, founded, is_tax_free, tax_id FROM $tableName")
+      val df = JdbcNativeUtils.getJdbcNativeDataFrame(selector, s"SELECT id, name, email, founded, is_tax_free, tax_id FROM $tableName")
       val actual = SparkUtils.convertDataFrameToPrettyJSON(df)
 
       compareText(actual, expected)
     }
 
     "throw an exception on error" in {
+      val selector = JdbcUrlSelector(jdbcConfig)
       intercept[SQLSyntaxErrorException] {
-        JdbcNativeUtils.getJdbcNativeDataFrame(jdbcConfig, jdbcConfig.primaryUrl.get, s"SELECT id FROM no_such_table")
+        JdbcNativeUtils.getJdbcNativeDataFrame(selector, s"SELECT id FROM no_such_table")
       }
     }
   }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcNativeUtilsSuite.scala
@@ -223,7 +223,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     when(resultSet.getMetaData).thenReturn(resultSetMetaData)
 
     "return normal decimal for correct precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(10, 0) == DecimalType(10, 0))
       assert(iterator.getDecimalSparkSchema(10, 2) == DecimalType(10, 2))
@@ -232,7 +232,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return fixed decimal for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(1, -1) == DecimalType(38, 18))
       assert(iterator.getDecimalSparkSchema(0, 0) == DecimalType(38, 18))
@@ -244,7 +244,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return string type for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
 
       assert(iterator.getDecimalSparkSchema(1, -1) == StringType)
       assert(iterator.getDecimalSparkSchema(0, 0) == StringType)
@@ -264,7 +264,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     when(resultSet.getMetaData).thenReturn(resultSetMetaData)
 
     "return normal decimal for correct precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(10)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -272,7 +272,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return fixed decimal for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(0)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -280,7 +280,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
     }
 
     "return string type for incorrect precision and scale" in {
-      val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
+      val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = true, arraysSupported = true)
       when(resultSetMetaData.getPrecision(0)).thenReturn(0)
       when(resultSetMetaData.getScale(0)).thenReturn(2)
 
@@ -307,7 +307,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       val maxTimestamp = 253402300799999L
 
       "ignore null values" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
         val fixedTs = iterator.sanitizeTimestamp(null)
 
@@ -315,7 +315,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql positive infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(POSTGRESQL_DATE_POSITIVE_INFINITY))
 
         val fixedTs = iterator.sanitizeTimestamp(timestamp)
@@ -324,7 +324,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql negative infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(POSTGRESQL_DATE_NEGATIVE_INFINITY))
 
         val fixedTs = iterator.sanitizeTimestamp(timestamp)
@@ -333,7 +333,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert overflowed value to the maximum value supported" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(1000000000000000L))
 
         val actual = iterator.sanitizeTimestamp(timestamp)
@@ -347,7 +347,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "do nothing if the feature is turned off" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
         val timestamp = Timestamp.from(Instant.ofEpochMilli(1000000000000000L))
 
         val actual = iterator.sanitizeTimestamp(timestamp)
@@ -367,7 +367,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       val maxDate = 253402214400000L
 
       "ignore null values" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
 
         val fixedDate = iterator.sanitizeDate(null)
 
@@ -375,7 +375,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql positive infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(POSTGRESQL_DATE_POSITIVE_INFINITY)
 
         val fixedDate = iterator.sanitizeDate(date)
@@ -384,7 +384,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert PostgreSql negative infinity value" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(POSTGRESQL_DATE_NEGATIVE_INFINITY)
 
         val fixedDate = iterator.sanitizeDate(date)
@@ -393,7 +393,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "convert overflowed value to the maximum value supported" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, true, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(1000000000000000L)
 
         val actual = iterator.sanitizeDate(date)
@@ -407,7 +407,7 @@ class JdbcNativeUtilsSuite extends AnyWordSpec with RelationalDbFixture with Spa
       }
 
       "do nothing if the feature is turned off" in {
-        val iterator = new ResultSetToRowIterator(resultSet, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
+        val iterator = new ResultSetToRowIterator(resultSet, None, None, None, false, incorrectDecimalsAsString = false, arraysSupported = true)
         val date = new Date(1000000000000000L)
 
         val actual = iterator.sanitizeDate(date)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.{RelationalDbFixture, TextComparisonFixture}
+import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.utils.JdbcSparkUtils
@@ -86,8 +87,9 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
         .load()
 
       var newSchema: StructType = null
+      val selector = JdbcUrlSelector(jdbcConfig)
 
-      JdbcSparkUtils.withJdbcMetadata(jdbcConfig, s"SELECT * FROM ${RdbExampleTable.Company.tableName}") { (connection, metadataRs) =>
+      JdbcSparkUtils.withJdbcMetadata(selector, s"SELECT * FROM ${RdbExampleTable.Company.tableName}") { (connection, metadataRs) =>
         newSchema = JdbcSparkUtils.addColumnDescriptionsFromJdbc(
           JdbcSparkUtils.addMetadataFromJdbc(df.schema, metadataRs),
           RdbExampleTable.Company.tableName,
@@ -136,7 +138,8 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
   "withJdbcMetadata" should {
     "provide the metadata object for the query" in {
-      JdbcSparkUtils.withJdbcMetadata(jdbcConfig, s"SELECT * FROM ${RdbExampleTable.Company.tableName}") { (connection, metadata) =>
+      val selector = JdbcUrlSelector(jdbcConfig)
+      JdbcSparkUtils.withJdbcMetadata(selector, s"SELECT * FROM ${RdbExampleTable.Company.tableName}") { (connection, metadata) =>
         assert(!connection.isClosed)
         assert(metadata.getColumnName(2) == "NAME")
       }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
@@ -139,11 +139,11 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
 
     "handle retries" in {
       val baseSelector = JdbcUrlSelector(jdbcConfig)
-      val (conn, _) = baseSelector.getWorkingConnection(1)
+      val (conn, _) = baseSelector.getNewConnection(1)
       val sel = mock(classOf[JdbcUrlSelector])
 
       whenMock(sel.jdbcConfig).thenReturn(jdbcConfig)
-      whenMock(sel.getWorkingConnection(anyInt())).thenReturn((conn, "dummyurl"))
+      whenMock(sel.getNewConnection(anyInt())).thenReturn((conn, "dummyurl"))
 
       val qe = new QueryExecutorJdbc(sel, true)
       qe.execute("SELECT * FROM company")
@@ -168,11 +168,11 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
 
     "fail if retry fails" in {
       val baseSelector = JdbcUrlSelector(jdbcConfig)
-      val (conn, _) = baseSelector.getWorkingConnection(1)
+      val (conn, _) = baseSelector.getNewConnection(1)
       val sel = mock(classOf[JdbcUrlSelector])
 
       whenMock(sel.jdbcConfig).thenReturn(jdbcConfig)
-      whenMock(sel.getWorkingConnection(anyInt()))
+      whenMock(sel.getNewConnection(anyInt()))
         .thenReturn((conn, "dummyurl"))
         .thenThrow(new RuntimeException("fail the second time"))
 
@@ -202,11 +202,11 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
 
     "fail the first time when a connection selector can't select a connection" in {
       val baseSelector = JdbcUrlSelector(jdbcConfig)
-      val (conn, _) = baseSelector.getWorkingConnection(1)
+      val (conn, _) = baseSelector.getNewConnection(1)
       val sel = mock(classOf[JdbcUrlSelector])
 
       whenMock(sel.jdbcConfig).thenReturn(jdbcConfig)
-      whenMock(sel.getWorkingConnection(anyInt()))
+      whenMock(sel.getNewConnection(anyInt()))
         .thenThrow(new RuntimeException("fail the first time"))
         .thenThrow(new RuntimeException("fail the second time"))
         .thenReturn((conn, "dummyurl"))

--- a/pramen/extras/pom.xml
+++ b/pramen/extras/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>za.co.absa.pramen</groupId>
         <artifactId>pramen</artifactId>
-        <version>1.13.19-SNAPSHOT</version>
+        <version>1.14.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/pramen/extras/src/test/scala/za/co/absa/pramen/extras/mocks/ReaderSpy.scala
+++ b/pramen/extras/src/test/scala/za/co/absa/pramen/extras/mocks/ReaderSpy.scala
@@ -45,4 +45,6 @@ class ReaderSpy(numRecords: Long = 0L)(implicit spark: SparkSession)
   }
 
   override def getIncrementalData(query: Query, onlyForInfoDate: Option[LocalDate], offsetFromOpt: Option[OffsetValue], offsetToOpt: Option[OffsetValue], columns: Seq[String]): DataFrame = ???
+
+  override def close(): Unit = {}
 }

--- a/pramen/pom.xml
+++ b/pramen/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>za.co.absa.pramen</groupId>
     <artifactId>pramen</artifactId>
-    <version>1.13.19-SNAPSHOT</version>
+    <version>1.14.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Pramen</name>


### PR DESCRIPTION
Closes #757 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readers now support closeable lifecycle and loading external JDBC driver JARs (DynamicDriver support).

* **Improvements**
  * Better recovery for missing/invalid Delta schemas.
  * Selector-based JDBC connection handling with safer result-set and executor-side behavior.
  * JDBC readers are ensured closed after operations.

* **Tests**
  * Tests updated to use selector-based APIs and cover driver-jar scenarios.

* **Chores**
  * Project version bumped to 1.14.0-SNAPSHOT.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AbsaOSS/pramen/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->