### PR TITLE
Fix JDBC custom schema escaping for decimal columns

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -274,21 +274,23 @@ object JdbcSparkUtils {
     val newSchema = new ListBuffer[String]
 
     df.schema.fields.foreach(field => {
+      val fieldName = escapeColumnNameForSparkDDL(field.name)
+
       field.dataType match {
         case t: DecimalType if t.scale == 0 && t.precision <= 9 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to int")
-          newSchema += s"${field.name} integer"
+          newSchema += s"$fieldName integer"
         case t: DecimalType if t.scale == 0 && t.precision <= 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to long")
-          newSchema += s"${field.name} long"
+          newSchema += s"$fieldName long"
         case t: DecimalType if t.scale > 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal(38, 18)")
-          newSchema += s"${field.name} decimal(38, 18)"
+          newSchema += s"$fieldName decimal(38, 18)"
         case t: DecimalType if fixPrecision && t.scale > 0 =>
           val fixedPrecision = if (t.precision + t.scale > 38) 38 else t.precision + t.scale
           if (fixedPrecision > t.precision) {
             log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal($fixedPrecision, ${t.scale})")
-            newSchema += s"${field.name} decimal($fixedPrecision, ${t.scale})"
+            newSchema += s"$fieldName decimal($fixedPrecision, ${t.scale})"
           }
         case _ =>
           field
@@ -301,6 +303,14 @@ object JdbcSparkUtils {
       Some(customSchema)
     } else {
       None
+    }
+  }
+
+  private[core] def escapeColumnNameForSparkDDL(columnName: String): String = {
+    if (columnName.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+      columnName
+    } else {
+      s"`${columnName.replace("`", "``")}`"
     }
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.pramen.core.tests.utils
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.to_timestamp
 import org.apache.spark.sql.types.{DecimalType, MetadataBuilder, StructField, StructType}
 import org.scalatest.BeforeAndAfterAll
@@ -258,6 +258,20 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = true)
 
       assert(customFields.contains("value decimal(38, 16)"))
+    }
+
+    "escape special column names in custom schema" in {
+      val schema = StructType(Array(
+        StructField("PaidAmount(Incl VAT)", DecimalType(20, 2)),
+        StructField("VATAmount", DecimalType(20, 2)),
+        StructField("PaidAmount`Escaped", DecimalType(20, 2))
+      ))
+
+      val df = spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
+
+      val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = true)
+
+      assert(customFields.contains("`PaidAmount(Incl VAT)` decimal(22, 2), VATAmount decimal(22, 2), `PaidAmount``Escaped` decimal(22, 2)"))
     }
 
     "do nothing if the field is okay" in {


### PR DESCRIPTION
## Summary
- Escape JDBC column names when building decimal correction `customSchema` entries for Spark.
- Preserve the existing unescaped output for simple identifiers.
- Add a regression test for SQL Server-style decimal column names containing parentheses/spaces and embedded backticks.

Fixes #761.

## Testing
- `git diff --check`
- Not run: Scala/Spark test suite locally because this environment does not have `java`, `mvn`, or `sbt` available on `PATH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of column names with special characters when generating schemas, preventing invalid SQL/DDL output.
  * Decimal schema correction now preserves and escapes column identifiers more reliably.

* **Tests**
  * Added coverage for schemas containing names with parentheses and backticks to verify the corrected escaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->