### PR TITLE
Use source JDBC options for count connections

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbc.scala
@@ -185,7 +185,7 @@ class TableReaderJdbc(jdbcReaderConfig: TableReaderJdbcConfig,
         case Some(table) => sqlGen.getSchemaQuery(table, Seq.empty)
         case _ => JdbcSparkUtils.getSchemaQuery(sql)
       }
-      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, jdbcMetadata) =>
+      JdbcSparkUtils.withJdbcMetadata(nativeJdbcUrlSelector, schemaQuery) { (connection, jdbcMetadata) =>
         val schemaWithMetadata = JdbcSparkUtils.addMetadataFromJdbc(df.schema, jdbcMetadata)
         val schemaWithColumnDescriptions = tableOpt match {
           case Some(table) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcBase.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.TableReader
 import za.co.absa.pramen.api.sql.SqlConfig
-import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
+import za.co.absa.pramen.core.reader.model.{JdbcConfig, TableReaderJdbcConfig}
 import za.co.absa.pramen.core.sql.SqlGeneratorLoader
 import za.co.absa.pramen.core.utils.JdbcNativeUtils.JDBC_WORDS_TO_REDACT
 import za.co.absa.pramen.core.utils.{ConfigUtils, JdbcNativeUtils}
@@ -34,16 +34,27 @@ abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
 
   protected val jdbcRetries: Int = jdbcReaderConfig.jdbcConfig.retries.getOrElse(jdbcUrlSelector.getNumberOfUrls)
   protected val extraOptions: Map[String, String] = ConfigUtils.getExtraOptions(conf, "option")
+  protected val nativeJdbcConfig: JdbcConfig = TableReaderJdbcBase.getNativeJdbcConfig(jdbcReaderConfig, conf)
+  protected val nativeJdbcUrlSelector: JdbcUrlSelector = {
+    if (nativeJdbcConfig == jdbcUrlSelector.jdbcConfig) {
+      jdbcUrlSelector
+    } else {
+      JdbcUrlSelector(jdbcUrlSelector.jdbcDriverJarPath, nativeJdbcConfig)
+    }
+  }
 
   override def close(): Unit = {
     jdbcUrlSelector.close()
+    if (nativeJdbcUrlSelector ne jdbcUrlSelector) {
+      nativeJdbcUrlSelector.close()
+    }
   }
 
   private[core] lazy val sqlGen = {
     val gen = SqlGeneratorLoader.getSqlGenerator(jdbcReaderConfig.jdbcConfig.driver, getSqlConfig)
 
     if (gen.requiresConnection) {
-      val (connection, _) = jdbcUrlSelector.getNewConnection(jdbcRetries)
+      val (connection, _) = nativeJdbcUrlSelector.getNewConnection(jdbcRetries)
       gen.setConnection(connection)
     }
     gen
@@ -101,7 +112,7 @@ abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
     var count = 0L
     log.info(s"Executing: $countSql")
 
-    JdbcNativeUtils.withResultSet(jdbcUrlSelector, countSql) { rs =>
+    JdbcNativeUtils.withResultSet(nativeJdbcUrlSelector, countSql) { rs =>
       if (!rs.next())
         throw new IllegalStateException(s"No rows returned by the count query: $countSql")
       else {
@@ -112,5 +123,26 @@ abstract class TableReaderJdbcBase(jdbcReaderConfig: TableReaderJdbcConfig,
     }
 
     count
+  }
+}
+
+object TableReaderJdbcBase {
+  private val FetchSizeOption = "fetchsize"
+  private val BatchSizeOption = "batchsize"
+
+  private[core] def getNativeJdbcConfig(jdbcReaderConfig: TableReaderJdbcConfig, conf: Config): JdbcConfig = {
+    val extraOptions = ConfigUtils.getExtraOptions(conf, "option")
+    val fetchSize = extraOptions
+      .collectFirst { case (key, value) if key.equalsIgnoreCase(FetchSizeOption) => value.toInt }
+      .orElse(jdbcReaderConfig.jdbcConfig.fetchSize)
+    val connectionOptions = extraOptions.filterNot { case (key, _) =>
+      val normalizedKey = key.toLowerCase
+      normalizedKey == FetchSizeOption || normalizedKey == BatchSizeOption
+    }
+
+    jdbcReaderConfig.jdbcConfig.copy(
+      fetchSize = fetchSize,
+      extraOptions = jdbcReaderConfig.jdbcConfig.extraOptions ++ connectionOptions
+    )
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/TableReaderJdbcNative.scala
@@ -34,16 +34,14 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
 
   private val log = LoggerFactory.getLogger(this.getClass)
 
-  private val jdbcConfig = jdbcReaderConfig.jdbcConfig
-
   logConfiguration()
 
   private[core] def getJdbcSelector: JdbcUrlSelector = {
-    jdbcUrlSelector
+    nativeJdbcUrlSelector
   }
 
   private[core] def getJdbcReaderConfig: TableReaderJdbcConfig = {
-    jdbcReaderConfig.copy(jdbcConfig = jdbcConfig)
+    jdbcReaderConfig.copy(jdbcConfig = nativeJdbcConfig)
   }
 
   override def getRecordCount(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Long = {
@@ -57,7 +55,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
         getCountForSql(sql)
       case Query.Sql(sql) =>
         log.info(s"JDBC Native count of a non-SELECT SQL statement: $sql")
-        JdbcNativeUtils.getJdbcNativeRecordCount(jdbcUrlSelector, sql)
+        JdbcNativeUtils.getJdbcNativeRecordCount(nativeJdbcUrlSelector, sql)
       case other =>
         throw new IllegalArgumentException(s"'${other.name}' is not supported by the JDBC reader. Use 'table' or 'sql' instead.")
     }
@@ -99,7 +97,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
   private[core] def getDataFrame(sql: String, tableOpt: Option[String]): DataFrame = {
     log.info(s"JDBC Query: $sql")
 
-    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcUrlSelector, sql)
+    var df = JdbcNativeUtils.getJdbcNativeDataFrame(nativeJdbcUrlSelector, sql)
 
     if (log.isDebugEnabled) {
       log.debug(df.schema.treeString)
@@ -110,7 +108,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
         case Some(table) => sqlGen.getSchemaQuery(table, Seq.empty)
         case _ => JdbcSparkUtils.getSchemaQuery(sql)
       }
-      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, _) =>
+      JdbcSparkUtils.withJdbcMetadata(nativeJdbcUrlSelector, schemaQuery) { (connection, _) =>
         val schemaWithColumnDescriptions = tableOpt match {
           case Some(table) =>
             log.info(s"Reading JDBC metadata descriptions the table: $table")
@@ -133,7 +131,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
     val sql = sqlGen.getDataQueryIncremental(tableName, onlyForInfoDate, offsetFrom, offsetTo, columns)
     log.info(s"JDBC Query: $sql")
 
-    var df = JdbcNativeUtils.getJdbcNativeDataFrame(jdbcUrlSelector, sql)
+    var df = JdbcNativeUtils.getJdbcNativeDataFrame(nativeJdbcUrlSelector, sql)
 
     if (log.isDebugEnabled) {
       log.debug(df.schema.treeString)
@@ -142,7 +140,7 @@ class TableReaderJdbcNative(jdbcReaderConfig: TableReaderJdbcConfig,
     if (jdbcReaderConfig.enableSchemaMetadata) {
       val schemaQuery = sqlGen.getSchemaQuery(tableName, columns)
 
-      JdbcSparkUtils.withJdbcMetadata(jdbcUrlSelector, schemaQuery) { (connection, _) =>
+      JdbcSparkUtils.withJdbcMetadata(nativeJdbcUrlSelector, schemaQuery) { (connection, _) =>
         log.info(s"Reading JDBC metadata descriptions the table: $tableName")
         df = spark.createDataFrame(df.rdd,
           JdbcSparkUtils.addColumnDescriptionsFromJdbc(df.schema, sqlGen.unquote(tableName), connection))
@@ -171,12 +169,7 @@ object TableReaderJdbcNative {
   }
 
   private[core] def getJdbcConfig(tableReaderJdbcConfig: TableReaderJdbcConfig, conf: Config): JdbcConfig = {
-    val originConfig = tableReaderJdbcConfig.jdbcConfig
-    if (conf.hasPath(FETCH_SIZE_KEY)) {
-      originConfig.copy(fetchSize = Option(conf.getInt(FETCH_SIZE_KEY)))
-    } else {
-      originConfig
-    }
+    TableReaderJdbcBase.getNativeJdbcConfig(tableReaderJdbcConfig, conf)
   }
 
   def applyInfoDateExpressionToQuery(query: Query, infoDateBegin: LocalDate, infoDateEnd: LocalDate): Query = {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/reader/TableReaderJdbcSuite.scala
@@ -26,7 +26,7 @@ import za.co.absa.pramen.core.base.SparkTestBase
 import za.co.absa.pramen.core.fixtures.RelationalDbFixture
 import za.co.absa.pramen.core.mocks.SqlGeneratorDummy
 import za.co.absa.pramen.core.reader.model.TableReaderJdbcConfig
-import za.co.absa.pramen.core.reader.{JdbcUrlSelector, TableReaderJdbc, TableReaderJdbcNative}
+import za.co.absa.pramen.core.reader.{JdbcUrlSelector, TableReaderJdbc, TableReaderJdbcBase, TableReaderJdbcNative}
 import za.co.absa.pramen.core.samples.RdbExampleTable
 import za.co.absa.pramen.core.sql.SqlGeneratorHsqlDb
 import za.co.absa.pramen.core.utils.SparkUtils.{COMMENT_METADATA_KEY, MAX_LENGTH_METADATA_KEY}
@@ -354,6 +354,21 @@ class TableReaderJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Spark
     }
 
     "getCount()" should {
+      "include source JDBC options in the native count connection config" in {
+        val readerConfig = conf.getConfig("reader")
+          .withValue("option.TrustServerCertificate", ConfigValueFactory.fromAnyRef(true))
+          .withValue("option.fetchsize", ConfigValueFactory.fromAnyRef(123))
+          .withValue("option.batchsize", ConfigValueFactory.fromAnyRef(456))
+
+        val jdbcTableReaderConfig = TableReaderJdbcConfig.load(readerConfig, readerConfig, "reader")
+        val nativeJdbcConfig = TableReaderJdbcBase.getNativeJdbcConfig(jdbcTableReaderConfig, readerConfig)
+
+        assert(nativeJdbcConfig.extraOptions("TrustServerCertificate") == "true")
+        assert(nativeJdbcConfig.fetchSize.contains(123))
+        assert(!nativeJdbcConfig.extraOptions.contains("fetchsize"))
+        assert(!nativeJdbcConfig.extraOptions.contains("batchsize"))
+      }
+
       "return count for a table snapshot-like query" in {
         val testConfig = conf
         val reader = TableReaderJdbc(testConfig.getConfig("reader"), testConfig.getConfig("reader"), "reader")


### PR DESCRIPTION
## Summary
- Build native JDBC connection config from the same source `option.*` settings used for Spark JDBC reads.
- Use that native config for count queries and JDBC metadata calls so options such as `TrustServerCertificate` are honored outside Spark reads too.
- Preserve native fetch-size handling while keeping Spark-only `batchsize` out of DriverManager properties.

Fixes #758.

## Testing
- `git diff --check`
- Not run: Scala/Spark test suite locally because this environment does not have `java`, `mvn`, or `sbt` available on `PATH`.