### PR TITLE
#761 Fix handling of special characters in column names by adding backtick escaping in schema corrections.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -277,18 +277,18 @@ object JdbcSparkUtils {
       field.dataType match {
         case t: DecimalType if t.scale == 0 && t.precision <= 9 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to int")
-          newSchema += s"${field.name} integer"
+          newSchema += s"`${field.name}` integer"
         case t: DecimalType if t.scale == 0 && t.precision <= 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to long")
-          newSchema += s"${field.name} long"
+          newSchema += s"`${field.name}` long"
         case t: DecimalType if t.scale > 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal(38, 18)")
-          newSchema += s"${field.name} decimal(38, 18)"
+          newSchema += s"`${field.name}` decimal(38, 18)"
         case t: DecimalType if fixPrecision && t.scale > 0 =>
           val fixedPrecision = if (t.precision + t.scale > 38) 38 else t.precision + t.scale
           if (fixedPrecision > t.precision) {
             log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal($fixedPrecision, ${t.scale})")
-            newSchema += s"${field.name} decimal($fixedPrecision, ${t.scale})"
+            newSchema += s"`${field.name}` decimal($fixedPrecision, ${t.scale})"
           }
         case _ =>
           field

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/JdbcSparkUtils.scala
@@ -271,24 +271,29 @@ object JdbcSparkUtils {
     * @return An optional custom schema string that can be applied when reading the JDBC source.
     */
   def getCorrectedDecimalsSchema(df: DataFrame, fixPrecision: Boolean): Option[String] = {
+    def escapeColumn(name: String): String = {
+      val escapedName = name.replace("`", "``")
+      s"`$escapedName`"
+    }
+
     val newSchema = new ListBuffer[String]
 
     df.schema.fields.foreach(field => {
       field.dataType match {
         case t: DecimalType if t.scale == 0 && t.precision <= 9 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to int")
-          newSchema += s"`${field.name}` integer"
+          newSchema += s"${escapeColumn(field.name)} integer"
         case t: DecimalType if t.scale == 0 && t.precision <= 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to long")
-          newSchema += s"`${field.name}` long"
+          newSchema += s"${escapeColumn(field.name)} long"
         case t: DecimalType if t.scale > 18 =>
           log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal(38, 18)")
-          newSchema += s"`${field.name}` decimal(38, 18)"
+          newSchema += s"${escapeColumn(field.name)} decimal(38, 18)"
         case t: DecimalType if fixPrecision && t.scale > 0 =>
           val fixedPrecision = if (t.precision + t.scale > 38) 38 else t.precision + t.scale
           if (fixedPrecision > t.precision) {
             log.info(s"Correct '${field.name}' (prec=${t.precision}, scale=${t.scale}) to decimal($fixedPrecision, ${t.scale})")
-            newSchema += s"`${field.name}` decimal($fixedPrecision, ${t.scale})"
+            newSchema += s"${escapeColumn(field.name)} decimal($fixedPrecision, ${t.scale})"
           }
         case _ =>
           field

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/JdbcSparkUtilsSuite.scala
@@ -209,7 +209,7 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = false)
 
-      assert(customFields.contains("value integer"))
+      assert(customFields.contains("`value` integer"))
     }
 
     "correct decimal to long" in {
@@ -218,7 +218,7 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = false)
 
-      assert(customFields.contains("value long"))
+      assert(customFields.contains("`value` long"))
     }
 
     "correct too big scale" in {
@@ -231,7 +231,7 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = false)
 
-      assert(customFields.contains("value decimal(38, 18)"))
+      assert(customFields.contains("`value` decimal(38, 18)"))
     }
 
     "correct invalid precision" in {
@@ -244,7 +244,7 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = true)
 
-      assert(customFields.contains("value decimal(38, 18)"))
+      assert(customFields.contains("`value` decimal(38, 18)"))
     }
 
     "correct invalid precision with small scale" in {
@@ -257,7 +257,7 @@ class JdbcSparkUtilsSuite extends AnyWordSpec with BeforeAndAfterAll with SparkT
 
       val customFields = JdbcSparkUtils.getCorrectedDecimalsSchema(df, fixPrecision = true)
 
-      assert(customFields.contains("value decimal(38, 16)"))
+      assert(customFields.contains("`value` decimal(38, 16)"))
     }
 
     "do nothing if the field is okay" in {


### PR DESCRIPTION
Closes #761

## Test Evidence
The change confirmed fixed the ingestion from the original dataset that contain parenthesis in decimal field names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrected decimal fields in generated Spark SQL schemas by safely quoting field names, reducing issues with special characters or reserved words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->