### PR TITLE
#768 Add `replaceHivePartitionSchema` method to support partition-level schema replacement in Hive helpers.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveConfig.scala
@@ -108,6 +108,9 @@ object HiveConfig {
     val replaceSchemaTemplate = ConfigUtils.getOptionString(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$REPLACE_SCHEMA_TEMPLATE_KEY")
       .getOrElse(defaultTemplates.replaceSchemaTemplate)
 
+    val replacePartitionSchemaTemplate = ConfigUtils.getOptionString(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$REPLACE_PARTITION_SCHEMA_TEMPLATE_KEY")
+      .getOrElse(defaultTemplates.replacePartitionSchemaTemplate)
+
     val repairTableTemplate = ConfigUtils.getOptionString(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$REPAIR_TABLE_TEMPLATE_KEY")
       .getOrElse(defaultTemplates.repairTableTemplate)
 
@@ -123,7 +126,7 @@ object HiveConfig {
     HiveConfig(
       hiveApi = hiveApi,
       database = database,
-      templates = HiveQueryTemplates(createTableTemplate, createOnlyTableTemplate, replaceSchemaTemplate, repairTableTemplate, addPartitionTableTemplate, dropTableTemplate),
+      templates = HiveQueryTemplates(createTableTemplate, createOnlyTableTemplate, replaceSchemaTemplate, replacePartitionSchemaTemplate, repairTableTemplate, addPartitionTableTemplate, dropTableTemplate),
       jdbcConfig = jdbcConfig,
       ignoreFailures,
       alwaysEscapeColumnNames,
@@ -147,7 +150,7 @@ object HiveConfig {
   def getNullConfig: HiveConfig = HiveConfig(
     HiveApi.Sql,
     None,
-    HiveQueryTemplates(DEFAULT_CREATE_TABLE_TEMPLATE, DEFAULT_CREATE_ONLY_TABLE_TEMPLATE, DEFAULT_REPLACE_SCHEMA_TEMPLATE, DEFAULT_REPAIR_TABLE_TEMPLATE, DEFAULT_ADD_PARTITION_TEMPLATE, DEFAULT_DROP_TABLE_TEMPLATE),
+    HiveQueryTemplates(DEFAULT_CREATE_TABLE_TEMPLATE, DEFAULT_CREATE_ONLY_TABLE_TEMPLATE, DEFAULT_REPLACE_SCHEMA_TEMPLATE, DEFAULT_REPLACE_PARTITION_SCHEMA, DEFAULT_REPAIR_TABLE_TEMPLATE, DEFAULT_ADD_PARTITION_TEMPLATE, DEFAULT_DROP_TABLE_TEMPLATE),
     None,
     ignoreFailures = false,
     alwaysEscapeColumnNames = true,

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
@@ -44,6 +44,12 @@ abstract class HiveHelper {
                              databaseName: Option[String],
                              tableName: String): Unit
 
+  def replaceHivePartitionSchema(schema: StructType,
+                                 partitionBy: Seq[String],
+                                 partitionValues: Seq[String],
+                                 databaseName: Option[String],
+                                 tableName: String): Unit
+
   def repairHiveTable(databaseName: Option[String],
                       tableName: String,
                       format: HiveFormat): Unit

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSparkCatalog.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSparkCatalog.scala
@@ -17,6 +17,7 @@
 package za.co.absa.pramen.core.utils.hive
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.PartitioningUtils.PartitionValues
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.api.CatalogTable
@@ -97,6 +98,34 @@ class HiveHelperSparkCatalog(spark: SparkSession) extends HiveHelper {
 
     val sql = HiveQueryTemplates.DEFAULT_REPLACE_SCHEMA_TEMPLATE
       .replace("@fullTableName", fullTableName)
+      .replace("@schema", schemaDDL)
+
+    log.info(s"Executing: $sql")
+    spark.sql(sql).collect()
+  }
+
+  override def replaceHivePartitionSchema(schema: StructType,
+                                          partitionBy: Seq[String],
+                                          partitionValues: Seq[String],
+                                          databaseName: Option[String],
+                                          tableName: String): Unit = {
+    if (partitionBy.length != partitionValues.length) {
+      throw new IllegalArgumentException(s"Partition columns and values must have the same length. Columns: $partitionBy, values: $partitionValues")
+    }
+
+    val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
+    val partitionClause = partitionBy.zip(partitionValues).map { case (col, value) => s"$col='$value'" }.mkString(", ")
+
+    val partitionColsLower = partitionBy.map(_.toLowerCase())
+    val nonPartitionFields = SparkUtils.transformSchemaForCatalog(schema)
+      .filter(field => !partitionColsLower.contains(field.name.toLowerCase()))
+      .filter(field => field.name.trim.nonEmpty)
+
+    val schemaDDL = SparkUtils.escapeColumnsSparkDDL(StructType(nonPartitionFields).toDDL)
+
+    val sql = HiveQueryTemplates.DEFAULT_REPLACE_PARTITION_SCHEMA
+      .replace("@fullTableName", fullTableName)
+      .replace("@partitionClause", partitionClause)
       .replace("@schema", schemaDDL)
 
     log.info(s"Executing: $sql")

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.pramen.core.utils.hive
 
+import org.apache.spark.sql.execution.datasources.PartitioningUtils.PartitionValues
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.utils.SparkUtils
@@ -84,6 +85,24 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
     )
 
     queryExecutor.execute(sqlHiveCreate)
+  }
+
+  override def replaceHivePartitionSchema(schema: StructType,
+                                          partitionBy: Seq[String],
+                                          partitionValues: Seq[String],
+                                          databaseName: Option[String],
+                                          tableName: String): Unit = {
+    if (partitionBy.length != partitionValues.length) {
+      throw new IllegalArgumentException(s"Partition columns and values must have the same length. Columns: $partitionBy, values: $partitionValues")
+    }
+    val fullTableName = HiveHelper.getFullTable(databaseName, tableName)
+    val partitionClause = partitionBy.zip(partitionValues).map { case (col, value) => s"$col='$value'" }.mkString(", ")
+    val schemaDDL = getTableDDL(schema, partitionBy)
+
+    log.info(s"Replacing partition schema for $fullTableName, partition: $partitionClause...")
+
+    val sql = applyPartitionTemplate(hiveConfig.replacePartitionSchemaTemplate, fullTableName, "", partitionClause, schemaDDL)
+    queryExecutor.execute(sql)
   }
 
   override def repairHiveTable(databaseName: Option[String],
@@ -213,10 +232,12 @@ class HiveHelperSql(val queryExecutor: QueryExecutor,
   private def applyPartitionTemplate(template: String,
                                      fullTableName: String,
                                      partitionPath: String = "",
-                                     partitionClause: String = ""
+                                     partitionClause: String = "",
+                                     schemaDDL: String = ""
                                     ): String = {
     template.replace("@fullTableName", fullTableName)
       .replace("@partitionPath", partitionPath)
       .replace("@partitionClause", partitionClause)
+      .replace("@schema", schemaDDL)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveQueryTemplates.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveQueryTemplates.scala
@@ -23,6 +23,7 @@ case class HiveQueryTemplates(
                                createTableTemplate: String,
                                createOnlyTableTemplate: String,
                                replaceSchemaTemplate: String,
+                               replacePartitionSchemaTemplate: String,
                                repairTableTemplate: String,
                                addPartitionTemplate: String,
                                dropTableTemplate: String
@@ -54,6 +55,7 @@ object HiveQueryTemplates {
   val CREATE_TABLE_TEMPLATE_KEY = "create.table.template"
   val CREATE_ONLY_TABLE_TEMPLATE_KEY = "create.only.table.template"
   val REPLACE_SCHEMA_TEMPLATE_KEY = "replace.schema.template"
+  val REPLACE_PARTITION_SCHEMA_TEMPLATE_KEY = "replace.partition.schema.template"
   val REPAIR_TABLE_TEMPLATE_KEY = "repair.table.template"
   val ADD_PARTITION_TEMPLATE_KEY = "add.partition.template"
   val DROP_TABLE_TEMPLATE_KEY = "drop.table.template"
@@ -76,7 +78,9 @@ object HiveQueryTemplates {
       |OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
       |LOCATION '@path';""".stripMargin
 
-  val DEFAULT_REPLACE_SCHEMA_TEMPLATE: String = "ALTER TABLE @fullTableName REPLACE COLUMNS ( @schema )"
+  val DEFAULT_REPLACE_SCHEMA_TEMPLATE: String = "ALTER TABLE @fullTableName REPLACE COLUMNS ( @schema ) CASCADE"
+
+  val DEFAULT_REPLACE_PARTITION_SCHEMA: String = "ALTER TABLE @fullTableName PARTITION (@partitionClause) REPLACE COLUMNS ( @schema )"
 
   val DEFAULT_REPAIR_TABLE_TEMPLATE: String = "MSCK REPAIR TABLE @fullTableName"
 
@@ -95,6 +99,9 @@ object HiveQueryTemplates {
     val replaceSchemaTemplate = ConfigUtils.getOptionString(conf, REPLACE_SCHEMA_TEMPLATE_KEY)
       .getOrElse(DEFAULT_REPLACE_SCHEMA_TEMPLATE)
 
+    val replacePartitionSchemaTemplate = ConfigUtils.getOptionString(conf, REPLACE_PARTITION_SCHEMA_TEMPLATE_KEY)
+      .getOrElse(DEFAULT_REPLACE_PARTITION_SCHEMA)
+
     val repairTableTemplate = ConfigUtils.getOptionString(conf, REPAIR_TABLE_TEMPLATE_KEY)
       .getOrElse(DEFAULT_REPAIR_TABLE_TEMPLATE)
 
@@ -108,6 +115,7 @@ object HiveQueryTemplates {
       createTableTemplate = createTableTemplate,
       createOnlyTableTemplate = createOnlyTableTemplate,
       replaceSchemaTemplate = replaceSchemaTemplate,
+      replacePartitionSchemaTemplate = replacePartitionSchemaTemplate,
       repairTableTemplate = repairTableTemplate,
       addPartitionTemplate = addPartitionTemplate,
       dropTableTemplate = dropTableTemplate
@@ -119,6 +127,7 @@ object HiveQueryTemplates {
       createTableTemplate = DEFAULT_CREATE_TABLE_TEMPLATE,
       createOnlyTableTemplate = DEFAULT_CREATE_ONLY_TABLE_TEMPLATE,
       replaceSchemaTemplate = DEFAULT_REPLACE_SCHEMA_TEMPLATE,
+      replacePartitionSchemaTemplate = DEFAULT_REPLACE_PARTITION_SCHEMA,
       repairTableTemplate = DEFAULT_REPAIR_TABLE_TEMPLATE,
       addPartitionTemplate = DEFAULT_ADD_PARTITION_TEMPLATE,
       dropTableTemplate = DEFAULT_DROP_TABLE_TEMPLATE

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
@@ -46,6 +46,7 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.templates.createTableTemplate.contains("create1"))
       assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only1"))
       assert(hiveConfig.templates.replaceSchemaTemplate.contains("update1"))
+      assert(hiveConfig.templates.replacePartitionSchemaTemplate.contains("update_part1"))
       assert(hiveConfig.templates.repairTableTemplate.contains("repair1"))
       assert(hiveConfig.templates.addPartitionTemplate.contains("add_partition1"))
       assert(hiveConfig.templates.dropTableTemplate.contains("drop1"))
@@ -70,6 +71,7 @@ class HiveConfigSuite extends AnyWordSpec {
           |   create.table.template = "create2"
           |   create.only.table.template = "create_only2"
           |   replace.schema.template = "replace2"
+          |   replace.partition.schema.template = "replace_part2"
           |   repair.table.template = "repair2"
           |   add.partition.template = "add_partition2"
           |   drop.table.template = "drop2"
@@ -126,6 +128,7 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.templates.createTableTemplate.contains("create"))
       assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only"))
       assert(hiveConfig.templates.replaceSchemaTemplate.contains("update"))
+      assert(hiveConfig.templates.replacePartitionSchemaTemplate.contains("update_part"))
       assert(hiveConfig.templates.repairTableTemplate.contains("repair"))
       assert(hiveConfig.templates.addPartitionTemplate.contains("add_partition1"))
       assert(hiveConfig.templates.dropTableTemplate.contains("drop"))

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
@@ -29,7 +29,7 @@ class HiveConfigSuite extends AnyWordSpec {
       val defaultConfig = HiveDefaultConfig(
         HiveApi.SparkCatalog,
         Some("mydb1"),
-        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "update1", "repair1", "add_partition1", "drop1")),
+        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "update1", "update_part1", "repair1", "add_partition1", "drop1")),
         None,
         ignoreFailures = true,
         alwaysEscapeColumnNames = false,
@@ -80,7 +80,7 @@ class HiveConfigSuite extends AnyWordSpec {
       val defaultConfig = HiveDefaultConfig(
         HiveApi.Sql,
         Some("mydb1"),
-        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "replace1", "repair1", "add_partition1", "drop1")),
+        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "replace1", "replace_part1", "repair1", "add_partition1", "drop1")),
         None,
         ignoreFailures = false,
         alwaysEscapeColumnNames = false,
@@ -109,7 +109,7 @@ class HiveConfigSuite extends AnyWordSpec {
       val defaultConfig = HiveDefaultConfig(
         HiveApi.Sql,
         Some("mydb"),
-        Map("parquet" -> HiveQueryTemplates("create", "create_only", "update", "repair", "add_partition1", "drop")),
+        Map("parquet" -> HiveQueryTemplates("create", "create_only", "update", "update_part", "repair", "add_partition1", "drop")),
         None,
         ignoreFailures = true,
         alwaysEscapeColumnNames = true,

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -247,6 +247,7 @@ class MetaTableSuite extends AnyWordSpec {
       assert(metaTable.hiveConfig.templates.createTableTemplate == "create")
       assert(metaTable.hiveConfig.templates.createOnlyTableTemplate == "create_only")
       assert(metaTable.hiveConfig.templates.replaceSchemaTemplate == "update")
+      assert(metaTable.hiveConfig.templates.replacePartitionSchemaTemplate == "update_part")
       assert(metaTable.hiveConfig.templates.repairTableTemplate == "repair")
       assert(metaTable.hiveConfig.templates.addPartitionTemplate == "add_partition")
       assert(metaTable.hiveConfig.templates.dropTableTemplate == "drop")
@@ -291,6 +292,7 @@ class MetaTableSuite extends AnyWordSpec {
           |     create.table.template = "create2"
           |     create.only.table.template = "create_only2"
           |     replace.schema.template = "replace2"
+          |     replace.partition.schema.template = "replace_part2"
           |     repair.table.template = "repair2"
           |     add.partition.template = "add_partition2"
           |     drop.table.template = "drop2"
@@ -318,6 +320,7 @@ class MetaTableSuite extends AnyWordSpec {
       assert(metaTable.hiveConfig.templates.createTableTemplate == "create2")
       assert(metaTable.hiveConfig.templates.createOnlyTableTemplate == "create_only2")
       assert(metaTable.hiveConfig.templates.replaceSchemaTemplate == "replace2")
+      assert(metaTable.hiveConfig.templates.replacePartitionSchemaTemplate == "replace_part2")
       assert(metaTable.hiveConfig.templates.repairTableTemplate == "repair2")
       assert(metaTable.hiveConfig.templates.addPartitionTemplate == "add_partition2")
       assert(metaTable.hiveConfig.templates.dropTableTemplate == "drop2")

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -230,7 +230,7 @@ class MetaTableSuite extends AnyWordSpec {
 
       val defaultHiveConfig = HiveDefaultConfig(HiveApi.Sql,
         Some("mydb"),
-        Map("parquet" -> HiveQueryTemplates("create", "create_only", "update", "repair", "add_partition", "drop")),
+        Map("parquet" -> HiveQueryTemplates("create", "create_only", "update", "update_part", "repair", "add_partition", "drop")),
         Some(JdbcConfig("driver", Some("url"),
           user = Some("user"),
           password = Some("pass")
@@ -301,7 +301,7 @@ class MetaTableSuite extends AnyWordSpec {
       val defaultHiveConfig = HiveDefaultConfig(
         HiveApi.Sql,
         Some("mydb1"),
-        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "replace1", "repair1", "add_partition1", "drop1")),
+        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "replace1", "replace_part1", "repair1", "add_partition1", "drop1")),
         Some(JdbcConfig("driver1", Some("url1"),
           user = Some("user1"),
           password = Some("pass1")

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
@@ -167,6 +167,24 @@ class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixt
       }
     }
 
+    "execute expected query for replacing partition schema of a partitioned table" in {
+      withTempDirectory("hive_test") { tempDir =>
+        val path = getParquetPath(tempDir)
+
+        val expected = "ALTER TABLE `db`.`tbl` PARTITION (a='AA', b='22') REPLACE COLUMNS ( `c` INT )".stripMargin
+
+        val qe = new QueryExecutorMock(tableExists = false)
+        val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig, true)
+        val schema = spark.read.parquet(path).withColumn("b", lit(1)).schema
+
+        hiveHelper.replaceHivePartitionSchema(schema, "a" :: "b" :: Nil, Seq("AA", "22"), Some("db"), "tbl")
+
+        val actual = qe.queries.mkString("\n")
+
+        compareText(actual, expected)
+      }
+    }
+
     "repair table with database" in {
       val expected = "MSCK REPAIR TABLE `db`.`tbl`"
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/HiveHelperSqlSuite.scala
@@ -153,7 +153,7 @@ class HiveHelperSqlSuite extends AnyWordSpec with SparkTestBase with TempDirFixt
       withTempDirectory("hive_test") { tempDir =>
         val path = getParquetPath(tempDir)
 
-        val expected = "ALTER TABLE `db`.`tbl` REPLACE COLUMNS ( `c` INT )".stripMargin
+        val expected = "ALTER TABLE `db`.`tbl` REPLACE COLUMNS ( `c` INT ) CASCADE".stripMargin
 
         val qe = new QueryExecutorMock(tableExists = false)
         val hiveHelper = new HiveHelperSql(qe, defaultHiveConfig, true)


### PR DESCRIPTION
Closes #768 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating the schema of a specific Hive partition.
  * Expanded Hive template configuration to include a new partition-schema replacement option, with sensible defaults.

* **Bug Fixes**
  * Improved handling of Hive SQL generation so partition schema changes are applied correctly.
  * Updated default and test configurations to stay aligned with the latest Hive template set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->