### PR TITLE
#739 Add snapshot properties (info_date, batch_id) to Iceberg writes.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
@@ -58,22 +58,27 @@ class MetastorePersistenceIceberg(table: CatalogTable,
       case _ => (false, "Writing to")
     }
 
+    val writerOptionsWithAdditionalMetadata = writeOptions ++ Map(
+      s"snapshot-property.$infoDateColumn" -> infoDate.toString,
+      s"snapshot-property.$batchIdColumn" -> batchId.toString,
+    )
+
     val tableExists = CatalogUtils.doesTableExist(table)
 
     if (tableExists) {
       log.info(s"$operationStr to table $fullTableName...")
       if (isAppend) {
-        appendToTable(dfToSave, fullTableName, writeOptions)
+        appendToTable(dfToSave, fullTableName, writerOptionsWithAdditionalMetadata)
       } else {
         if (partitionScheme == PartitionScheme.Overwrite) {
-          overwriteFullTable(dfToSave, fullTableName, writeOptions)
+          overwriteFullTable(dfToSave, fullTableName, writerOptionsWithAdditionalMetadata)
         } else {
-          overwriteDailyPartition(infoDate, dfToSave, fullTableName, infoDateColumn, writeOptions)
+          overwriteDailyPartition(infoDate, dfToSave, fullTableName, infoDateColumn, writerOptionsWithAdditionalMetadata)
         }
       }
     } else {
       log.info(s"Creating Iceberg table ${table.getFullTableName}...")
-      createIcebergTable(dfToSave, fullTableName, infoDateColumn, location, description, partitionScheme, tableProperties, writeOptions)
+      createIcebergTable(dfToSave, fullTableName, infoDateColumn, location, description, partitionScheme, tableProperties, writerOptionsWithAdditionalMetadata)
     }
 
     getStats(infoDate, onlyForCurrentBatchId = false)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceIceberg.scala
@@ -60,7 +60,7 @@ class MetastorePersistenceIceberg(table: CatalogTable,
 
     val writerOptionsWithAdditionalMetadata = writeOptions ++ Map(
       s"snapshot-property.$infoDateColumn" -> infoDate.toString,
-      s"snapshot-property.$batchIdColumn" -> batchId.toString,
+      s"snapshot-property.$batchIdColumn" -> batchId.toString
     )
 
     val tableExists = CatalogUtils.doesTableExist(table)

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceIcebergLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceIcebergLongSuite.scala
@@ -76,7 +76,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table1" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByDay)
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByDay)
 
         runBasicTests(mt)
 
@@ -88,6 +88,15 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assert(partitionColumns.length == 1)
         assert(partitionColumns.head == "info_date")
 
+        // Get all snapshot properties from the Iceberg table
+        val location = new Path(hadoopTempDir, s"pramen/iceberg_catalog/default/$tableName").toString
+        val ht = new HadoopTables
+        val table = ht.load(location)
+        val snapshotProperties = table.currentSnapshot().summary().asScala
+
+        assert(snapshotProperties("info_date") == infoDate2.toString)
+        assert(snapshotProperties("pramen_batchid") == "0")
+
         spark.sql(s"DELETE FROM $tableName").count()
         spark.sql(s"DROP TABLE IF EXISTS $tableName").count()
       }
@@ -96,7 +105,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table2" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByMonth("info_month", "info_year"))
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByMonth("info_month", "info_year"))
 
         runBasicTests(mt)
 
@@ -117,7 +126,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table3" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByYearMonth("info_month"))
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByYearMonth("info_month"))
 
         assertThrows[UnsupportedOperationException] {
           runBasicTests(mt)
@@ -128,7 +137,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table4" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByYear("info_year"))
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.PartitionByYear("info_year"))
 
         runBasicTests(mt)
 
@@ -148,7 +157,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table5" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.NotPartitioned)
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.NotPartitioned)
 
         runBasicTests(mt)
 
@@ -167,7 +176,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assume(spark.version.split('.').head.toInt >= 3, s"Ignored for too old Iceberg for Spark ${spark.version}")
 
         val tableName = "mt_iceberg_part_table6" + Math.abs(Random.nextInt()).toString
-        val mt = getDeltaMtPersistence(Query.Table(tableName), PartitionScheme.Overwrite)
+        val mt = getIcebergMtPersistence(Query.Table(tableName), PartitionScheme.Overwrite)
 
         runOverwritingTests(mt)
 
@@ -206,8 +215,8 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
       .toSeq*/
   }
 
-  def getDeltaMtPersistence(query: Query,
-                            partitionScheme: PartitionScheme = PartitionScheme.PartitionByDay): MetastorePersistence = {
+  def getIcebergMtPersistence(query: Query,
+                              partitionScheme: PartitionScheme = PartitionScheme.PartitionByDay): MetastorePersistence = {
     val catalogTable = CatalogTable(None, None, query.query)
     val mt = MetaTableFactory.getDummyMetaTable(name = "table1",
       format = DataFormat.Iceberg(catalogTable, None),

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceIcebergLongSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceIcebergLongSuite.scala
@@ -17,6 +17,7 @@
 package za.co.absa.pramen.core.metastore.persistence
 
 import org.apache.hadoop.fs.Path
+import org.apache.iceberg.Table
 import org.apache.iceberg.hadoop.HadoopTables
 import org.scalatest.Assertion
 import org.scalatest.wordspec.AnyWordSpec
@@ -89,10 +90,7 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
         assert(partitionColumns.head == "info_date")
 
         // Get all snapshot properties from the Iceberg table
-        val location = new Path(hadoopTempDir, s"pramen/iceberg_catalog/default/$tableName").toString
-        val ht = new HadoopTables
-        val table = ht.load(location)
-        val snapshotProperties = table.currentSnapshot().summary().asScala
+        val snapshotProperties = loadIcebergTable(tableName).currentSnapshot().summary().asScala
 
         assert(snapshotProperties("info_date") == infoDate2.toString)
         assert(snapshotProperties("pramen_batchid") == "0")
@@ -193,10 +191,13 @@ class MetastorePersistenceIcebergLongSuite extends AnyWordSpec
     }
   }
 
-  def getTablePartitions(tableName: String): Seq[String] = {
+  def loadIcebergTable(tableName: String): Table = {
     val location = new Path(hadoopTempDir, s"pramen/iceberg_catalog/default/$tableName").toString
-    val ht = new HadoopTables
-    val table = ht.load(location)
+    new HadoopTables().load(location)
+  }
+
+  def getTablePartitions(tableName: String): Seq[String] = {
+    val table = loadIcebergTable(tableName)
 
     table.spec()
       .fields()


### PR DESCRIPTION
Closes #739 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Iceberg metastore persistence now adds snapshot metadata for key fields consistently across appends, full overwrite, daily partition overwrite, and initial table creation.
  * Saved table snapshots now reliably reflect the expected write date and batch ID for improved traceability.

* **Tests**
  * Expanded Iceberg persistence tests to cover all partition schemes and overwrite scenarios.
  * Added snapshot-summary assertions (e.g., for info date and batch ID) and improved how tables are loaded/validated during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->