### PR TITLE
#772 Add timeouts for thread cleanups and fix handling of InterruptedException

### DIFF
--- a/pramen/core/src/main/resources/reference.conf
+++ b/pramen/core/src/main/resources/reference.conf
@@ -238,6 +238,9 @@ pramen {
     connection.backoff.min.ms = 10000
     connection.backoff.max.ms = 60000
 
+    # By default 5 minutes is the timeout for cancelling SQL queries, including Hive when accessed via JDBC.
+    cancellation.timeout.seconds = 300
+
     # If true, restores the legacy behavior when sink exceptions were wrapped in "Unable to write to sink" exception.
     wrap.sink.exceptions = false
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/config/Keys.scala
@@ -56,6 +56,8 @@ object Keys {
 
   val WRAP_SINK_EXCEPTION = "pramen.internal.wrap.sink.exceptions"
 
+  val SQL_QUERY_CANCELLATION_TIMEOUT = "pramen.internal.cancellation.timeout.seconds"
+
   final val KEYS_TO_REDACT: Set[String] = Set("password", "secret", "pwd", "access.key", "api.key", "api_key", "session.token", "access_key", "session_token", "auth.user.info")
 
   final val CONFIG_KEYS_TO_REDACT = Set(

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/TaskRunnerBase.scala
@@ -26,6 +26,7 @@ import za.co.absa.pramen.api.lock.TokenLockFactory
 import za.co.absa.pramen.api.status._
 import za.co.absa.pramen.core.app.config.RuntimeConfig
 import za.co.absa.pramen.core.bookkeeper.Bookkeeper
+import za.co.absa.pramen.core.config.Keys.SQL_QUERY_CANCELLATION_TIMEOUT
 import za.co.absa.pramen.core.exceptions.{FatalErrorWrapper, LazyJobErrorWrapper, ReasonException}
 import za.co.absa.pramen.core.journal.Journal
 import za.co.absa.pramen.core.journal.model.TaskCompleted
@@ -63,6 +64,7 @@ abstract class TaskRunnerBase(conf: Config,
   implicit val localDateOrdering: Ordering[LocalDate] = Ordering.by(_.toEpochDay)
 
   private val log = LoggerFactory.getLogger(this.getClass)
+  private val sqlCancellationTimeoutSeconds = ConfigUtils.getOptionInt(conf, SQL_QUERY_CANCELLATION_TIMEOUT).getOrElse(300)
 
   /**
     * Runs tasks in parallel (if possible) and returns their futures. Subclasses should override this method.
@@ -148,7 +150,7 @@ abstract class TaskRunnerBase(conf: Config,
         @volatile var runStatus: RunStatus = null
 
         try {
-          ThreadUtils.runWithTimeout(Duration(timeout, TimeUnit.SECONDS)) {
+          ThreadUtils.runWithTimeout(Duration(timeout, TimeUnit.SECONDS), Duration(sqlCancellationTimeoutSeconds, TimeUnit.SECONDS)) {
             log.info(s"Running ${task.job.name} with the hard timeout = $timeout seconds.")
             runStatus = doValidateOrSkipTask(task)
           }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
@@ -19,26 +19,31 @@ package za.co.absa.pramen.core.utils
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.exceptions.TimeoutException
 import za.co.absa.pramen.core.runner.task.ThreadClosableRegistry
-import za.co.absa.pramen.core.utils.impl.ThreadWithException
+import za.co.absa.pramen.core.utils.impl.{DetachedRunService, ThreadWithException}
 
 import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success}
 
 object ThreadUtils {
   private val log = LoggerFactory.getLogger(this.getClass)
 
   /**
-    * Executes an action with a timeout. If the timeout is breached the task is killed (using Thread.interrupt())
+    * Executes an action with a timeout. If the timeout is breached, cleanup is performed
+    * (e.g. closing JDBC connections) and then the task is killed (using Thread.interrupt()).
     *
-    * If the task times out, an exception is thrown.
+    * If the task times out, a [[TimeoutException]] is thrown.
     *
-    * Any exception is passed to the caller.
+    * Any exception thrown by the action is re-thrown to the caller.
     *
-    * @param timeout The task timeout.
-    * @param action  An action to execute.
+    * @param timeout        The task timeout.
+    * @param cleanupTimeout The timeout for the cleanup operation before interrupting the thread.
+    * @param action         An action to execute.
+    * @throws TimeoutException if the action does not complete within the specified timeout.
     */
   @throws[TimeoutException]
-  def runWithTimeout(timeout: Duration)(action: => Unit): Unit = {
+  def runWithTimeout(timeout: Duration, cleanupTimeout: Duration = Duration(5, TimeUnit.MINUTES))(action: => Unit): Unit = {
     val thread = new ThreadWithException {
       override def run(): Unit = {
         action
@@ -58,13 +63,20 @@ object ThreadUtils {
 
     if (thread.isAlive) {
       val stackTrace = thread.getStackTrace
+      val threadId = thread.getId
 
-      try {
-        // Execute cleanup BEFORE interrupt - e.g. close the JDBC connection/statement
-        ThreadClosableRegistry.cleanupThread(thread.getId)
-      } catch {
-        case ex: Throwable =>
-          log.warn(s"Exception during timeout cleanup: ${ex.getMessage}")
+      // Execute cleanup BEFORE interrupt - e.g. close the JDBC connection/statement
+      val future = DetachedRunService.runWithTimeoutThenDetach[Unit](cleanupTimeout) {
+        ThreadClosableRegistry.cleanupThread(threadId)
+      }
+
+      future.value match {
+        case Some(Success(_))  =>
+          log.info(s"Cleanup for thread $threadId completed successfully. All SQL queries were cancelled and connections closed.")
+        case Some(Failure(ex)) =>
+          log.warn(s"Exception during thread $threadId cleanup: ${ex.getMessage}")
+        case None              =>
+          log.info(s"Timeout cleanup for thread $threadId is still running. Setting it to continue in a detached thread...")
       }
 
       thread.interrupt()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
@@ -59,7 +59,10 @@ object ThreadUtils {
     thread.setUncaughtExceptionHandler(handler)
 
     thread.start()
-    thread.join(timeout.toMillis)
+    val waitMillis = timeout.toMillis
+    if (waitMillis > 0) {
+      thread.join(waitMillis)
+    }
 
     if (thread.isAlive) {
       val stackTrace = thread.getStackTrace

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -149,12 +149,12 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
 
       val table = getEscapedMetadataString(tableName, metadata)
 
-      log.warn(s"Checking existence of table '$db.$tableName' using metadata query...")
+      log.info(s"Checking existence of table '$db.$tableName' using metadata query...")
       val exists = for (rs <- metadata.getTables(null, db, table, HIVE_TABLE_TYPES)) yield {
         val r = rs.next
         r
       }
-      log.warn(s"Table '$db.$tableName' exists = $exists")
+      log.info(s"Table '$db.$tableName' exists = $exists")
       exists
     } catch {
       case ex: InterruptedException =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -61,6 +61,9 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
     log.info(s"Executing SQL: $query")
 
     executeActionOnConnection { conn =>
+      if (Thread.currentThread().isInterrupted) {
+        throw new InterruptedException(s"Current thread is interrupted. Aborting SQL execution: $query")
+      }
       val statement = conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
 
       val autoCloseStatement: AutoCloseable = new AutoCloseable {
@@ -96,6 +99,7 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       try {
         connection.close()
       } catch {
+        case ex: InterruptedException => throw ex
         case NonFatal(ex) => log.warn("Failed to close JDBC connection", ex)
       }
     }
@@ -107,6 +111,8 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       action(currentConnection)
     } catch {
       case ex: SQLException =>
+        throw ex
+      case ex: InterruptedException =>
         throw ex
       case NonFatal(ex) =>
         log.warn(s"Got an error on existing connection. Retrying...", ex)
@@ -143,11 +149,16 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
 
       val table = getEscapedMetadataString(tableName, metadata)
 
-      for (rs <- metadata.getTables(null, db, table, HIVE_TABLE_TYPES)) yield {
-        val exists = rs.next
-        exists
+      log.warn(s"Checking existence of table '$db.$tableName' using metadata query...")
+      val exists = for (rs <- metadata.getTables(null, db, table, HIVE_TABLE_TYPES)) yield {
+        val r = rs.next
+        r
       }
+      log.warn(s"Table '$db.$tableName' exists = $exists")
+      exists
     } catch {
+      case ex: InterruptedException =>
+        throw ex
       case NonFatal(ex) =>
         log.warn(s"Metadata table existence check failed for '$tableName'. Falling back to DESCRIBE TABLE (${ex.getMessage}).")
         false
@@ -163,7 +174,12 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       execute(query)
     } match {
       case Failure(ex) =>
-        log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
+        ex match {
+          case ex: InterruptedException =>
+            throw ex
+          case ex: Throwable =>
+            log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
+        }
         false
       case _ =>
         true
@@ -178,7 +194,12 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       execute(query)
     } match {
       case Failure(ex) =>
-        log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
+        ex match {
+          case ex: InterruptedException =>
+            throw ex
+          case ex: Throwable =>
+            log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
+        }
         false
       case _ =>
         true

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
@@ -17,6 +17,7 @@
 package za.co.absa.pramen.core.utils.impl
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 object DetachedRunService {
   /**
@@ -36,6 +37,31 @@ object DetachedRunService {
     val fut = thread.getFuture
     thread.setDaemon(true)
     thread.start()
+
+    fut
+  }
+
+  /**
+    * Executes the given action on a separate daemon thread, waiting up to the specified timeout
+    * for the result. If the action completes within the timeout, the result is returned in a
+    * completed Future. If the timeout elapses before the action completes, the thread continues
+    * running in a detached manner (as a daemon thread) and the returned Future will eventually
+    * be completed when the action finishes.
+    *
+    * @param timeout the maximum duration to wait for the action to complete before detaching
+    * @param action  the by-name computation to execute on a detached daemon thread
+    * @return a Future containing the result of the action, or a failed Future if the action throws an exception
+    */
+  def runWithTimeoutThenDetach[T](timeout: Duration)(action: => T): Future[T] = {
+    val thread = new ThreadWithResult[T] {
+      override def runWitResult(): T = action
+    }
+
+    val fut = thread.getFuture
+    thread.setDaemon(true)
+    thread.start()
+
+    thread.join(timeout.toMillis)
 
     fut
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.impl
+
+import scala.concurrent.Future
+
+object DetachedRunService {
+  /**
+    * Executes the given action on a separate daemon thread, returning a Future that will be
+    * completed with the result of the action or failed with any exception thrown during execution.
+    *
+    * The thread is marked as a daemon thread, meaning it will not prevent the JVM from shutting down.
+    *
+    * @param action the by-name computation to execute on a detached daemon thread
+    * @return a Future containing the result of the action, or a failed Future if the action throws an exception
+    */
+  def runDetached[T](action: => T): Future[T] = {
+    val thread = new ThreadWithResult[T] {
+      override def runWitResult(): T = action
+    }
+
+    val fut = thread.getFuture
+    thread.setDaemon(true)
+    thread.start()
+
+    fut
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/DetachedRunService.scala
@@ -61,7 +61,10 @@ object DetachedRunService {
     thread.setDaemon(true)
     thread.start()
 
-    thread.join(timeout.toMillis)
+    val waitMillis = timeout.toMillis
+    if (waitMillis > 0) {
+      thread.join(waitMillis)
+    }
 
     fut
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ThreadWithResult.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/impl/ThreadWithResult.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.impl
+
+import scala.concurrent.{Future, Promise}
+
+/**
+  * An abstract thread that computes a result of type T and makes it available as a Future.
+  *
+  * Subclasses must implement the `runWitResult` method to define the computation to be performed.
+  * When the thread is started, it executes `runWitResult` and completes an internal Promise with
+  * the result. If the computation throws an exception, the Promise is failed with that exception.
+  *
+  * The result of the computation can be obtained via the `getFuture` method, which returns a Future
+  * that will be completed once the thread finishes execution.
+  *
+  * @tparam T the type of the result produced by this thread
+  */
+abstract class ThreadWithResult[T] extends Thread {
+  private val resultPromise: Promise[T] = Promise[T]()
+
+  def runWitResult(): T
+  
+  def getFuture: Future[T] = resultPromise.future
+
+  override def run(): Unit = {
+    try {
+      val result = runWitResult()
+      resultPromise.success(result)
+    } catch {
+      case ex: Throwable => resultPromise.failure(ex)
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ThreadUtilsSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/ThreadUtilsSuite.scala
@@ -16,9 +16,12 @@
 
 package za.co.absa.pramen.core.tests.utils
 
+import com.github.yruslan.channel.{Channel, WriteChannel}
 import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.runner.task.ThreadClosableRegistry
 import za.co.absa.pramen.core.utils.ThreadUtils
 
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 
@@ -52,6 +55,63 @@ class ThreadUtilsSuite extends AnyWordSpec {
 
       assert(ex.getMessage == "test")
     }
+
+    "closable is called when registered" in {
+      val (closeable1, getCount1) = createCountingCloseable(0)
+
+      val timeout = Duration(1, TimeUnit.SECONDS)
+      val ex = intercept[RuntimeException] {
+        ThreadUtils.runWithTimeout(timeout, timeout) {
+          ThreadClosableRegistry.registerCloseable(closeable1)
+          Thread.sleep(10000)
+        }
+      }
+
+      assert(ex.getMessage.startsWith("Timeout expired"))
+      assert(getCount1() == 1)
+    }
+
+    "closable continues to run in detached thread when timed out" in {
+      val ch = Channel.make[Int]
+      val (closeable1, _) = createCountingCloseable(1000, Some(ch))
+
+      val start = Instant.now
+      val timeout = Duration(1, TimeUnit.SECONDS)
+      val closeTimeout = Duration(1, TimeUnit.MILLISECONDS)
+      val ex = intercept[RuntimeException] {
+        ThreadUtils.runWithTimeout(timeout, closeTimeout) {
+          ThreadClosableRegistry.registerCloseable(closeable1)
+          Thread.sleep(10000)
+        }
+      }
+
+      assert(ex.getMessage.startsWith("Timeout expired"))
+
+      val num = ch.recv()
+      assert(num == 2)
+
+      val finish = Instant.now
+      assert(java.time.Duration.between(start, finish).getSeconds < 10)
+    }
+  }
+
+  private def createCountingCloseable(waitTimeMs: Int, closingChannel: Option[WriteChannel[Int]] = None): (AutoCloseable, () => Int) = {
+    var count = 0
+    val closeable = new AutoCloseable {
+      override def close(): Unit = {
+        this.synchronized {
+          count += 1
+        }
+        if (waitTimeMs > 0) {
+          Thread.sleep(waitTimeMs)
+          this.synchronized {
+            count += 1
+          }
+          closingChannel.foreach(c => c.send(count) )
+        }
+      }
+    }
+    (closeable, () => count)
   }
 
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/impl/DetachedRunServiceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/impl/DetachedRunServiceSuite.scala
@@ -1,0 +1,46 @@
+package za.co.absa.pramen.core.tests.utils.impl
+
+import com.github.yruslan.channel.Channel
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.utils.impl._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class DetachedRunServiceSuite extends AnyWordSpec {
+  "runDetached" should {
+    "execution should return the expected result" in {
+      val fut = DetachedRunService.runDetached {
+        42
+      }
+
+      val result = Await.result(fut, 5.seconds)
+      assert(result == 42)
+    }
+
+    "execution should be delayed" in {
+      val channel = Channel.make[Int]
+      val fut = DetachedRunService.runDetached {
+        channel.recv()
+      }
+
+      assert(!fut.isCompleted)
+      channel.send(42)
+
+      val result = Await.result(fut, 5.seconds)
+      assert(result == 42)
+    }
+
+    "execution should propagate the exception" in {
+      val fut = DetachedRunService.runDetached {
+        throw new RuntimeException("Test")
+        42
+      }
+
+      val ex = intercept[RuntimeException] {
+        Await.result(fut, 5.seconds)
+      }
+      assert(ex.getMessage == "Test")
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/impl/DetachedRunServiceSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/impl/DetachedRunServiceSuite.scala
@@ -1,11 +1,29 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.pramen.core.tests.utils.impl
 
 import com.github.yruslan.channel.Channel
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.core.utils.impl._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Success
 
 class DetachedRunServiceSuite extends AnyWordSpec {
   "runDetached" should {
@@ -41,6 +59,44 @@ class DetachedRunServiceSuite extends AnyWordSpec {
         Await.result(fut, 5.seconds)
       }
       assert(ex.getMessage == "Test")
+    }
+  }
+
+  "runWithTimeoutThenDetach" should {
+    "execute normally when timeout is not breached" in {
+      val timeout = Duration(1, TimeUnit.SECONDS)
+      val ch = Channel.make[Int](1)
+
+      val fut = DetachedRunService.runWithTimeoutThenDetach(timeout) {
+        ch.send(1)
+        42
+      }
+
+      val num = ch.recv()
+      assert(num == 1)
+      val result = Await.result(fut, 5.seconds)
+      assert(result == 42)
+    }
+
+    "execute in detached thread anyway when timeout is breached" in {
+      val timeout = Duration(1, TimeUnit.MILLISECONDS)
+      val ch = Channel.make[Int]
+      var isDaemonThread = false
+
+      val fut = DetachedRunService.runWithTimeoutThenDetach(timeout) {
+        ch.send(1)
+        this.synchronized {
+          isDaemonThread = Thread.currentThread().isDaemon
+        }
+        42
+      }
+
+      val num = ch.recv()
+      assert(num == 1)
+
+      val result = Await.result(fut, 5.seconds)
+      assert(result == 42)
+      assert(isDaemonThread)
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable SQL cancellation timeout (default: 5 minutes).

* **Bug Fixes**
  * Improved interruption handling during SQL execution and Hive table existence checks.
  * Enhanced task timeout behavior to perform cleanup with a configurable delay and continue cleanup in the background when needed.

* **Tests**
  * Added coverage for the updated detached execution and timeout/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->