### PR TITLE
#774 Make Hive table existence check configurable

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveConfig.scala
@@ -21,7 +21,8 @@ import za.co.absa.pramen.api.DataFormat
 import za.co.absa.pramen.core.metastore.model.HiveDefaultConfig._
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.ConfigUtils
-import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates
+import za.co.absa.pramen.core.utils.hive.ExistenceCheckStrategy.SelectQuery
+import za.co.absa.pramen.core.utils.hive.{ExistenceCheckStrategy, HiveQueryTemplates}
 import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates._
 
 /**
@@ -58,7 +59,7 @@ import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates._
   * @param jdbcConfig              Hive JDBC configuration to use instead of Spark metastore if needed
   * @param ignoreFailures          Whether to ignore errors when creating or repairing tables. If true, only warnings will be emitted on Hive errors.
   * @param alwaysEscapeColumnNames If true, column names are always escaped when executing SQL against Hive.
-  * @param optimizeExistQuery      If true, Pramen uses Hive-specific SQL dialect to check table existence to ensure data won't be touched.
+  * @param existenceCheckStrategy  Specifies the strategy for checking Hive table existence. Different strategies could be more efficient depending on Hive version.
   */
 case class HiveConfig(
                        hiveApi: HiveApi,
@@ -67,7 +68,7 @@ case class HiveConfig(
                        jdbcConfig: Option[JdbcConfig],
                        ignoreFailures: Boolean,
                        alwaysEscapeColumnNames: Boolean,
-                       optimizeExistQuery: Boolean
+                       existenceCheckStrategy: ExistenceCheckStrategy
                      )
 
 object HiveConfig {
@@ -123,6 +124,19 @@ object HiveConfig {
     val hiveOptimizeExistQuery = ConfigUtils.getOptionBoolean(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$HIVE_OPTIMIZE_EXIST_QUERY_KEY")
       .getOrElse(defaults.optimizeExistQuery)
 
+    val hiveOptimizeExistQueryOpt = ConfigUtils.getOptionString(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$HIVE_TABLE_EXISTENCE_CHECK_STRATEGY_KEY")
+      .map(s => ExistenceCheckStrategy.fromString(s))
+      .orElse(defaults.tableExistenceCheckStrategy)
+
+    val hiveExistenceCheckStrategy = hiveOptimizeExistQueryOpt match {
+      case Some(st) => st
+      case None     =>
+        if (hiveOptimizeExistQuery)
+          ExistenceCheckStrategy.MetadataAndDescribeQuery
+        else
+          SelectQuery
+    }
+
     HiveConfig(
       hiveApi = hiveApi,
       database = database,
@@ -130,7 +144,7 @@ object HiveConfig {
       jdbcConfig = jdbcConfig,
       ignoreFailures,
       alwaysEscapeColumnNames,
-      hiveOptimizeExistQuery
+      hiveExistenceCheckStrategy
     )
   }
 
@@ -143,8 +157,9 @@ object HiveConfig {
     */
   def fromDefaults(defaults: HiveDefaultConfig, format: DataFormat): HiveConfig = {
     val templates = defaults.templates.getOrElse(format.name, HiveQueryTemplates.getDefaultQueryTemplates)
+    val strategy = defaults.tableExistenceCheckStrategy.getOrElse(ExistenceCheckStrategy.MetadataAndDescribeQuery)
 
-    HiveConfig(defaults.hiveApi, defaults.database, templates, defaults.jdbcConfig, defaults.ignoreFailures, alwaysEscapeColumnNames = true, optimizeExistQuery = true)
+    HiveConfig(defaults.hiveApi, defaults.database, templates, defaults.jdbcConfig, defaults.ignoreFailures, alwaysEscapeColumnNames = true, strategy)
   }
 
   def getNullConfig: HiveConfig = HiveConfig(
@@ -154,5 +169,5 @@ object HiveConfig {
     None,
     ignoreFailures = false,
     alwaysEscapeColumnNames = true,
-    optimizeExistQuery = true)
+    ExistenceCheckStrategy.MetadataAndDescribeQuery)
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveDefaultConfig.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/model/HiveDefaultConfig.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.metastore.model
 import com.typesafe.config.Config
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.utils.ConfigUtils
-import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates
+import za.co.absa.pramen.core.utils.hive.{ExistenceCheckStrategy, HiveQueryTemplates}
 
 /**
   * Hive configuration for Pramen.
@@ -98,7 +98,8 @@ case class HiveDefaultConfig(
                               jdbcConfig: Option[JdbcConfig],
                               ignoreFailures: Boolean,
                               alwaysEscapeColumnNames: Boolean,
-                              optimizeExistQuery: Boolean
+                              optimizeExistQuery: Boolean,
+                              tableExistenceCheckStrategy: Option[ExistenceCheckStrategy]
                             )
 
 object HiveDefaultConfig {
@@ -110,6 +111,7 @@ object HiveDefaultConfig {
   val HIVE_ALWAYS_ESCAPE_COLUMN_NAMES = "escape.column.names"
   val HIVE_DATABASE_KEY = "database"
   val HIVE_OPTIMIZE_EXIST_QUERY_KEY = "optimize.exist.query"
+  val HIVE_TABLE_EXISTENCE_CHECK_STRATEGY_KEY = "table.existence.check.strategy"
 
   /**
     * Gets global Hive configuration and query templates for all supported formats.
@@ -140,7 +142,10 @@ object HiveDefaultConfig {
       (format, HiveQueryTemplates.fromConfig(ConfigUtils.getOptionConfig(conf, prefix)))
     }).toMap
 
-    HiveDefaultConfig(hiveApi, database, templates, jdbcConfig, ignoreFailures, alwaysEscapeColumnNames, hiveOptimizeExistQuery)
+    val hiveOptimizeExistQueryOpt = ConfigUtils.getOptionString(conf, s"$HIVE_TEMPLATE_CONFIG_PREFIX.$HIVE_TABLE_EXISTENCE_CHECK_STRATEGY_KEY")
+      .map(s => ExistenceCheckStrategy.fromString(s))
+
+    HiveDefaultConfig(hiveApi, database, templates, jdbcConfig, ignoreFailures, alwaysEscapeColumnNames, hiveOptimizeExistQuery, hiveOptimizeExistQueryOpt)
   }
 
   def getNullConfig: HiveDefaultConfig = HiveDefaultConfig(
@@ -150,6 +155,7 @@ object HiveDefaultConfig {
     None,
     ignoreFailures = false,
     alwaysEscapeColumnNames = true,
-    optimizeExistQuery = true
+    optimizeExistQuery = true,
+    None
   )
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -72,6 +72,7 @@ object ThreadClosableRegistry {
     val threadCloseables = closeables.asScala.filter(_._1 == threadId).map(_._2).toList
     threadCloseables.reverse.foreach { closeable =>
       try {
+        log.info(s"Closing closable of type ${closeable.getClass.getCanonicalName} for the thread $threadId...")
         closeable.close()
       } catch {
         case NonFatal(ex) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/ExistenceCheckStrategy.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/ExistenceCheckStrategy.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.pramen.core.utils.hive
 
-trait ExistenceCheckStrategy
+sealed trait ExistenceCheckStrategy
 
 object ExistenceCheckStrategy {
   case object MetadataQuery extends ExistenceCheckStrategy

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/ExistenceCheckStrategy.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/ExistenceCheckStrategy.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.utils.hive
+
+trait ExistenceCheckStrategy
+
+object ExistenceCheckStrategy {
+  case object MetadataQuery extends ExistenceCheckStrategy
+
+  case object DescribeTable extends ExistenceCheckStrategy
+
+  case object MetadataAndDescribeQuery extends ExistenceCheckStrategy
+
+  case object SelectQuery extends ExistenceCheckStrategy
+
+  def fromString(s: String): ExistenceCheckStrategy = {
+    s.toLowerCase match {
+      case "metadata_query"              => MetadataQuery
+      case "describe_table"              => DescribeTable
+      case "metadata_and_describe_query" => MetadataAndDescribeQuery
+      case "select_query"                => SelectQuery
+      case other                         => throw new IllegalArgumentException(s"Unknown existence check strategy: '$other'. " +
+        s"Valid values are: 'metadata_query', 'describe_table', 'metadata_and_describe_query', 'select_query'.")
+    }
+  }
+}

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelper.scala
@@ -77,7 +77,7 @@ object HiveHelper {
         val queryExecutor = hiveConfig.jdbcConfig match {
           case Some(jdbcConfig) =>
             log.info(s"Using Hive SQL API by connecting to the Hive metastore via JDBC.")
-            new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), hiveConfig.optimizeExistQuery)
+            new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), hiveConfig.existenceCheckStrategy)
           case None             =>
             log.info(s"Using Hive SQL API by connecting to the Hive metastore via Spark.")
             new QueryExecutorSpark()

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/HiveHelperSql.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.pramen.core.utils.hive
 
-import org.apache.spark.sql.execution.datasources.PartitioningUtils.PartitionValues
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 import za.co.absa.pramen.core.utils.SparkUtils

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -154,12 +154,10 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
       val table = getEscapedMetadataString(tableName, metadata)
 
       log.info(s"Checking existence of table '$db.$tableName' using metadata query...")
-      val exists = for (rs <- metadata.getTables(null, db, table, HIVE_TABLE_TYPES)) yield {
+      for (rs <- metadata.getTables(null, db, table, HIVE_TABLE_TYPES)) yield {
         val r = rs.next
         r
       }
-      log.info(s"Table '$db.$tableName' exists = $exists")
-      exists
     } catch {
       case ex: InterruptedException =>
         throw ex
@@ -174,7 +172,7 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
 
     val query = s"DESCRIBE $fullTableName"
 
-    val exists = Try {
+    Try {
       log.info(s"Checking existence of table '$fullTableName' using DESCRIBE TABLE query...")
       execute(query)
     } match {
@@ -189,15 +187,13 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
       case _ =>
         true
     }
-    log.info(s"Table '$fullTableName' exists = $exists")
-    exists
   }
 
   def doesTableExistUsingSqlQuery(databaseNameOpt: Option[String], tableName: String): Boolean = {
     val fullTableName = HiveHelper.getFullTable(databaseNameOpt, tableName)
 
     val query = s"SELECT 1 FROM $fullTableName WHERE 0 = 1"
-    val exists = Try {
+    Try {
       log.info(s"Checking existence of table '$fullTableName' using the query: '$query'...")
       execute(query)
     } match {
@@ -212,8 +208,6 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
       case _ =>
         true
     }
-    log.info(s"Table '$fullTableName' exists = $exists")
-    exists
   }
 
   def getEscapedMetadataString(s: String, metaData: DatabaseMetaData): String = {

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -25,7 +25,7 @@ import java.sql._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Try}
 
-class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: Boolean) extends QueryExecutor {
+class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy: ExistenceCheckStrategy) extends QueryExecutor {
   import QueryExecutorJdbc._
 
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -37,15 +37,19 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
   override def doesTableExist(dbName: Option[String], tableName: String): Boolean = {
     val fullTableName = HiveHelper.getFullTable(dbName, tableName)
 
-    val exists = if (optimizedExistQuery) {
-      if (doesTableExistUsingHiveMetadata(dbName, tableName)) {
-        true
-      } else {
-        log.info(s"Table $fullTableName is not in metadata. Checking via 'DESCRIBE TABLE'...")
+    val exists = existenceCheckStrategy match {
+      case ExistenceCheckStrategy.MetadataQuery =>
+        doesTableExistUsingHiveMetadata(dbName, tableName)
+      case ExistenceCheckStrategy.DescribeTable =>
         doesTableExistUsingDescribeTable(dbName, tableName)
-      }
-    } else {
-      doesTableExistUsingSqlQuery(dbName, tableName)
+      case ExistenceCheckStrategy.MetadataAndDescribeQuery =>
+        if (doesTableExistUsingHiveMetadata(dbName, tableName)) {
+          true
+        } else {
+          doesTableExistUsingDescribeTable(dbName, tableName)
+        }
+      case ExistenceCheckStrategy.SelectQuery =>
+        doesTableExistUsingSqlQuery(dbName, tableName)
     }
 
     if (exists)
@@ -170,7 +174,8 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
 
     val query = s"DESCRIBE $fullTableName"
 
-    Try {
+    val exists = Try {
+      log.info(s"Checking existence of table '$fullTableName' using DESCRIBE TABLE query...")
       execute(query)
     } match {
       case Failure(ex) =>
@@ -184,13 +189,16 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       case _ =>
         true
     }
+    log.info(s"Table '$fullTableName' exists = $exists")
+    exists
   }
 
   def doesTableExistUsingSqlQuery(databaseNameOpt: Option[String], tableName: String): Boolean = {
     val fullTableName = HiveHelper.getFullTable(databaseNameOpt, tableName)
 
     val query = s"SELECT 1 FROM $fullTableName WHERE 0 = 1"
-    Try {
+    val exists = Try {
+      log.info(s"Checking existence of table '$fullTableName' using the query: '$query'...")
       execute(query)
     } match {
       case Failure(ex) =>
@@ -204,6 +212,8 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
       case _ =>
         true
     }
+    log.info(s"Table '$fullTableName' exists = $exists")
+    exists
   }
 
   def getEscapedMetadataString(s: String, metaData: DatabaseMetaData): String = {
@@ -218,9 +228,9 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, optimizedExistQuery: B
 object QueryExecutorJdbc {
   val HIVE_TABLE_TYPES = scala.Array[String]("TABLE", "VIEW", "MATERIALIZED VIEW")
 
-  def fromJdbcConfig(jdbcConfig: JdbcConfig, optimizedExistQuery: Boolean): QueryExecutorJdbc = {
+  def fromJdbcConfig(jdbcConfig: JdbcConfig, existenceCheckStrategy: ExistenceCheckStrategy): QueryExecutorJdbc = {
     val jdbcUrlSelector = JdbcUrlSelector(jdbcConfig)
 
-    new QueryExecutorJdbc(jdbcUrlSelector, optimizedExistQuery)
+    new QueryExecutorJdbc(jdbcUrlSelector, existenceCheckStrategy)
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
@@ -19,7 +19,7 @@ package za.co.absa.pramen.core.metastore.model
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import za.co.absa.pramen.api.DataFormat
-import za.co.absa.pramen.core.utils.hive.HiveQueryTemplates
+import za.co.absa.pramen.core.utils.hive.{ExistenceCheckStrategy, HiveQueryTemplates}
 
 class HiveConfigSuite extends AnyWordSpec {
   "fromConfigWithDefaults()" should {
@@ -33,7 +33,8 @@ class HiveConfigSuite extends AnyWordSpec {
         None,
         ignoreFailures = true,
         alwaysEscapeColumnNames = false,
-        optimizeExistQuery = true)
+        optimizeExistQuery = true,
+        tableExistenceCheckStrategy = None)
 
       val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, defaultConfig, DataFormat.Parquet("dummy"))
 
@@ -42,7 +43,7 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.jdbcConfig.isEmpty)
       assert(hiveConfig.ignoreFailures)
       assert(!hiveConfig.alwaysEscapeColumnNames)
-      assert(hiveConfig.optimizeExistQuery)
+      assert(hiveConfig.existenceCheckStrategy == ExistenceCheckStrategy.MetadataAndDescribeQuery)
       assert(hiveConfig.templates.createTableTemplate.contains("create1"))
       assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only1"))
       assert(hiveConfig.templates.replaceSchemaTemplate.contains("update1"))
@@ -76,6 +77,7 @@ class HiveConfigSuite extends AnyWordSpec {
           |   add.partition.template = "add_partition2"
           |   drop.table.template = "drop2"
           |   optimize.exist.query = false
+          |   table.existence.check.strategy = "describe_table"
           |}
           |""".stripMargin)
 
@@ -86,7 +88,9 @@ class HiveConfigSuite extends AnyWordSpec {
         None,
         ignoreFailures = false,
         alwaysEscapeColumnNames = false,
-        optimizeExistQuery = true)
+        optimizeExistQuery = true,
+        tableExistenceCheckStrategy = None
+      )
 
       val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, defaultConfig, DataFormat.Parquet("dummy"))
 
@@ -96,7 +100,7 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.jdbcConfig.map(_.driver).contains("driver2"))
       assert(hiveConfig.ignoreFailures)
       assert(hiveConfig.alwaysEscapeColumnNames)
-      assert(!hiveConfig.optimizeExistQuery)
+      assert(hiveConfig.existenceCheckStrategy == ExistenceCheckStrategy.DescribeTable)
       assert(hiveConfig.templates.createTableTemplate.contains("create2"))
       assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only2"))
       assert(hiveConfig.templates.replaceSchemaTemplate.contains("replace2"))
@@ -115,7 +119,8 @@ class HiveConfigSuite extends AnyWordSpec {
         None,
         ignoreFailures = true,
         alwaysEscapeColumnNames = true,
-        optimizeExistQuery = true)
+        optimizeExistQuery = true,
+        tableExistenceCheckStrategy = Some(ExistenceCheckStrategy.DescribeTable))
 
       val hiveConfig = HiveConfig.fromDefaults(defaultConfig, DataFormat.Parquet("dummy"))
 
@@ -124,7 +129,7 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.jdbcConfig.isEmpty)
       assert(hiveConfig.ignoreFailures)
       assert(hiveConfig.alwaysEscapeColumnNames)
-      assert(hiveConfig.optimizeExistQuery)
+      assert(hiveConfig.existenceCheckStrategy == ExistenceCheckStrategy.DescribeTable)
       assert(hiveConfig.templates.createTableTemplate.contains("create"))
       assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only"))
       assert(hiveConfig.templates.replaceSchemaTemplate.contains("update"))
@@ -132,6 +137,34 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.templates.repairTableTemplate.contains("repair"))
       assert(hiveConfig.templates.addPartitionTemplate.contains("add_partition1"))
       assert(hiveConfig.templates.dropTableTemplate.contains("drop"))
+    }
+
+    "return the default existence strategy" in {
+      val defaultConfig = HiveDefaultConfig(
+        HiveApi.Sql,
+        Some("mydb"),
+        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "update1", "update_part1", "repair1", "add_partition1", "drop1")),
+        None,
+        ignoreFailures = true,
+        alwaysEscapeColumnNames = true,
+        optimizeExistQuery = true,
+        tableExistenceCheckStrategy = None)
+
+      val hiveConfig = HiveConfig.fromDefaults(defaultConfig, DataFormat.Parquet("dummy"))
+
+      assert(hiveConfig.hiveApi == HiveApi.Sql)
+      assert(hiveConfig.database.contains("mydb"))
+      assert(hiveConfig.jdbcConfig.isEmpty)
+      assert(hiveConfig.ignoreFailures)
+      assert(hiveConfig.alwaysEscapeColumnNames)
+      assert(hiveConfig.existenceCheckStrategy == ExistenceCheckStrategy.MetadataAndDescribeQuery)
+      assert(hiveConfig.templates.createTableTemplate.contains("create1"))
+      assert(hiveConfig.templates.createOnlyTableTemplate.contains("create_only1"))
+      assert(hiveConfig.templates.replaceSchemaTemplate.contains("update1"))
+      assert(hiveConfig.templates.replacePartitionSchemaTemplate.contains("update_part1"))
+      assert(hiveConfig.templates.repairTableTemplate.contains("repair1"))
+      assert(hiveConfig.templates.addPartitionTemplate.contains("add_partition1"))
+      assert(hiveConfig.templates.dropTableTemplate.contains("drop1"))
     }
   }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/HiveConfigSuite.scala
@@ -108,6 +108,48 @@ class HiveConfigSuite extends AnyWordSpec {
       assert(hiveConfig.templates.addPartitionTemplate.contains("add_partition2"))
       assert(hiveConfig.templates.dropTableTemplate.contains("drop2"))
     }
+
+    "return Sql Query table existence strategy when optimize.exist.query = false fallback" in {
+      val conf = ConfigFactory.parseString(
+        """api = spark_catalog
+          |database = mydb2
+          |
+          |ignore.failures = true
+          |escape.column.names = true
+          |
+          |jdbc {
+          |  driver = driver2
+          |  url = url2
+          |  user = user2
+          |  password = pass2
+          |}
+          |
+          |conf {
+          |   optimize.exist.query = false
+          |}
+          |""".stripMargin)
+
+      val defaultConfig = HiveDefaultConfig(
+        HiveApi.Sql,
+        Some("mydb1"),
+        Map("parquet" -> HiveQueryTemplates("create1", "create_only1", "replace1", "replace_part1", "repair1", "add_partition1", "drop1")),
+        None,
+        ignoreFailures = false,
+        alwaysEscapeColumnNames = false,
+        optimizeExistQuery = true,
+        tableExistenceCheckStrategy = None
+      )
+
+      val hiveConfig = HiveConfig.fromConfigWithDefaults(conf, defaultConfig, DataFormat.Parquet("dummy"))
+
+      assert(hiveConfig.hiveApi == HiveApi.SparkCatalog)
+      assert(hiveConfig.database.contains("mydb2"))
+      assert(hiveConfig.jdbcConfig.nonEmpty)
+      assert(hiveConfig.jdbcConfig.map(_.driver).contains("driver2"))
+      assert(hiveConfig.ignoreFailures)
+      assert(hiveConfig.alwaysEscapeColumnNames)
+      assert(hiveConfig.existenceCheckStrategy == ExistenceCheckStrategy.SelectQuery)
+    }
   }
 
   "fromDefaults()" should {

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/model/MetaTableSuite.scala
@@ -234,7 +234,7 @@ class MetaTableSuite extends AnyWordSpec {
         Some(JdbcConfig("driver", Some("url"),
           user = Some("user"),
           password = Some("pass")
-        )), ignoreFailures = true, alwaysEscapeColumnNames = false, optimizeExistQuery = true)
+        )), ignoreFailures = true, alwaysEscapeColumnNames = false, optimizeExistQuery = true, None)
 
       val appConf = ConfigFactory.parseString("pramen.default.records.per.partition = 100")
 
@@ -307,7 +307,7 @@ class MetaTableSuite extends AnyWordSpec {
         Some(JdbcConfig("driver1", Some("url1"),
           user = Some("user1"),
           password = Some("pass1")
-        )), ignoreFailures = false, alwaysEscapeColumnNames = false, optimizeExistQuery = true)
+        )), ignoreFailures = false, alwaysEscapeColumnNames = false, optimizeExistQuery = true, None)
 
       val appConf = ConfigFactory.parseString("pramen.default.records.per.partition = 100")
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/ExistenceCheckStrategySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/ExistenceCheckStrategySuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.tests.utils.hive
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.utils.hive.ExistenceCheckStrategy
+
+class ExistenceCheckStrategySuite extends AnyWordSpec {
+  "fromString" should {
+    "return MetadataQuery when 'metadata_query' is specified" in {
+      val strategy = ExistenceCheckStrategy.fromString("metadata_query")
+
+      assert(strategy == ExistenceCheckStrategy.MetadataQuery)
+    }
+
+    "return DescribeTable when 'describe_table' is specified" in {
+      val strategy = ExistenceCheckStrategy.fromString("describe_table")
+
+      assert(strategy == ExistenceCheckStrategy.DescribeTable)
+    }
+
+    "return MetadataAndDescribeQuery when 'metadata_and_describe_query' is specified" in {
+      val strategy = ExistenceCheckStrategy.fromString("metadata_and_describe_query")
+
+      assert(strategy == ExistenceCheckStrategy.MetadataAndDescribeQuery)
+    }
+
+    "return SelectQuery when 'select_query' is specified" in {
+      val strategy = ExistenceCheckStrategy.fromString("select_query")
+
+      assert(strategy == ExistenceCheckStrategy.SelectQuery)
+    }
+
+    "throw IllegalArgumentException when an incorrect strategy string is specified" in {
+      val ex = intercept[IllegalArgumentException] {
+        ExistenceCheckStrategy.fromString("invalid_strategy")
+      }
+
+      assert(ex.getMessage.contains("invalid_strategy"))
+    }
+  }
+
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
@@ -24,7 +24,7 @@ import za.co.absa.pramen.core.fixtures.RelationalDbFixture
 import za.co.absa.pramen.core.reader.JdbcUrlSelector
 import za.co.absa.pramen.core.reader.model.JdbcConfig
 import za.co.absa.pramen.core.samples.RdbExampleTable
-import za.co.absa.pramen.core.utils.hive.QueryExecutorJdbc
+import za.co.absa.pramen.core.utils.hive.{ExistenceCheckStrategy, QueryExecutorJdbc}
 
 import java.sql.SQLSyntaxErrorException
 
@@ -48,21 +48,21 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
 
   "QueryExecutorJdbc" should {
     "be constructed from JdbcConfig" in {
-      val qe = QueryExecutorJdbc.fromJdbcConfig(jdbcConfig, optimizedExistQuery = false)
+      val qe = QueryExecutorJdbc.fromJdbcConfig(jdbcConfig, existenceCheckStrategy = ExistenceCheckStrategy.SelectQuery)
 
       qe.execute("UPDATE company SET id = 200 WHERE id = 100")
       qe.close()
     }
 
     "execute JDBC queries" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = true)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataAndDescribeQuery)
 
       qe.execute("SELECT * FROM company")
       qe.close()
     }
 
     "execute CREATE TABLE queries" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = false)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.SelectQuery)
 
       qe.execute("CREATE TABLE my_table (id INT)")
 
@@ -74,7 +74,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "check table existence" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = true)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataAndDescribeQuery)
 
       qe.execute("CREATE TABLE MY_TABLE2 (id INT)")
 
@@ -88,7 +88,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "throw an exception on errors" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = false)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.SelectQuery)
 
       val ex = intercept[SQLSyntaxErrorException] {
         qe.execute("SELECT * FROM does_not_exist")
@@ -98,7 +98,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "return true if the table is found" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = false)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.SelectQuery)
 
       val exist = qe.doesTableExist(None, "company")
 
@@ -108,7 +108,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "return false if the table is not found" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = false)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.SelectQuery)
 
       val exist = qe.doesTableExist(Option(database), "does_not_exist")
 
@@ -118,7 +118,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "return false if the table is not found in an optimized query" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = true)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
 
       val exist = qe.doesTableExist(Option(database), "does_not_exist")
 
@@ -128,7 +128,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
     }
 
     "return false if the table is not found in an optimized query without a database" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = true)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
 
       val exist = qe.doesTableExist(None, "does_not_exist")
 
@@ -145,7 +145,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
       whenMock(sel.jdbcConfig).thenReturn(jdbcConfig)
       whenMock(sel.getNewConnection(anyInt())).thenReturn((conn, "dummyurl"))
 
-      val qe = new QueryExecutorJdbc(sel, true)
+      val qe = new QueryExecutorJdbc(sel, existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
       qe.execute("SELECT * FROM company")
 
       var execution = 0
@@ -176,7 +176,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
         .thenReturn((conn, "dummyurl"))
         .thenThrow(new RuntimeException("fail the second time"))
 
-      val qe = new QueryExecutorJdbc(sel, true)
+      val qe = new QueryExecutorJdbc(sel, existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
 
       var execution = 0
       var actionExecuted = false
@@ -211,7 +211,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
         .thenThrow(new RuntimeException("fail the second time"))
         .thenReturn((conn, "dummyurl"))
 
-      val qe = new QueryExecutorJdbc(sel, true)
+      val qe = new QueryExecutorJdbc(sel, existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
 
       var execution = 0
       var actionExecuted = false
@@ -235,7 +235,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
 
   "getEscapedMetadataString" should {
     "escape % and _" in {
-      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), optimizedExistQuery = true)
+      val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
       val metadata = getConnection.getMetaData
 
       val actual = qe.getEscapedMetadataString("100% escaped_table", metadata)

--- a/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/StandardizationSink.scala
+++ b/pramen/extras/src/main/scala/za/co/absa/pramen/extras/sink/StandardizationSink.scala
@@ -432,7 +432,12 @@ object StandardizationSink extends ExternalChannelFactory[StandardizationSink] {
         val queryExecutor = standardizationConfig.hiveJdbcConfig match {
           case Some(hiveJdbcConfig) =>
             log.info(s"Using Hive SQL API by connecting to the Hive metastore via JDBC.")
-            QueryExecutorJdbc.fromJdbcConfig(hiveJdbcConfig, standardizationConfig.hiveOptimizeExistQuery)
+            val strategy = if (standardizationConfig.hiveOptimizeExistQuery) {
+              ExistenceCheckStrategy.MetadataAndDescribeQuery
+            } else {
+              ExistenceCheckStrategy.SelectQuery
+            }
+            QueryExecutorJdbc.fromJdbcConfig(hiveJdbcConfig, strategy)
           case None                 =>
             log.info(s"Using Hive SQL API by connecting to the Hive metastore via Spark.")
             QueryExecutorSpark(spark)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `table.existence.check.strategy` to choose how Hive checks table existence (metadata-based, describe-based, combined fallback, or SQL-query-based), with defaults applied when unset.
  * Existing Hive existence-check behavior now uses the selected strategy end-to-end, with fallback to the previous boolean setting if no strategy is provided.

* **Bug Fixes**
  * Ensured the same existence-check strategy is consistently used across Hive JDBC execution paths.

* **Tests**
  * Added/updated test coverage for strategy parsing, default/override behavior, and executor wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->