### PR TITLE
#776 Make sure all closeables opened in another thread are closed on successful path.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelector.scala
@@ -59,7 +59,7 @@ trait JdbcUrlSelector extends AutoCloseable {
   @throws[SQLException]
   def getConnection: (Connection, String)
 
-  /** Returns an new JDBC connection with the URL that has successfully connected. */
+  /** Returns a new JDBC connection with the URL that has successfully connected. */
   def getNewConnection(retriesLeft: Int): (Connection, String)
 }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -152,9 +152,9 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
       case Success(connection) => (connection, currentUrl)
       case Failure(ex)         =>
         ex match {
-          case ex: InterruptedException =>
+          case _: InterruptedException =>
             throw ex
-          case ex: Throwable            =>
+          case _: Throwable            =>
             if (retriesLeft > 1) {
               val newUrl = getNextUrl
               val backoffS = Random.nextInt(BACKOFF_MAX_S - BACKOFF_MIN_S) + BACKOFF_MIN_S

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/reader/JdbcUrlSelectorImpl.scala
@@ -151,15 +151,20 @@ class JdbcUrlSelectorImpl(val jdbcDriverJarPath: Option[String], val jdbcConfig:
     } match {
       case Success(connection) => (connection, currentUrl)
       case Failure(ex)         =>
-        if (retriesLeft > 1) {
-          val newUrl = getNextUrl
-          val backoffS = Random.nextInt(BACKOFF_MAX_S - BACKOFF_MIN_S) + BACKOFF_MIN_S
-          log.error(s"JDBC connection error for $currentUrl. Retries left: ${retriesLeft - 1}. Retrying... in $backoffS seconds", ex)
-          Thread.sleep(backoffS * 1000)
-          log.info(s"Trying URL: $newUrl")
-          getNewConnection(retriesLeft - 1)
-        } else {
-          throw ex
+        ex match {
+          case ex: InterruptedException =>
+            throw ex
+          case ex: Throwable            =>
+            if (retriesLeft > 1) {
+              val newUrl = getNextUrl
+              val backoffS = Random.nextInt(BACKOFF_MAX_S - BACKOFF_MIN_S) + BACKOFF_MIN_S
+              log.error(s"JDBC connection error for $currentUrl. Retries left: ${retriesLeft - 1}. Retrying... in $backoffS seconds", ex)
+              Thread.sleep(backoffS * 1000)
+              log.info(s"Trying URL: $newUrl")
+              getNewConnection(retriesLeft - 1)
+            } else {
+              throw ex
+            }
         }
     }
   }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -45,16 +45,16 @@ object ThreadClosableRegistry {
   }
 
   /**
-    * Closes a closeable resource and unregisters is as an transactional atomic operation.
-    * The resource will be automatically closed when [[cleanupThread]] is called for this thread.
+    * Unregisters a closeable resource from the registry and then closes it.
+    * Close exceptions are logged and swallowed; they are not rethrown.
     *
-    * @param closeable The AutoCloseable resource to register
+    * @param closeable The AutoCloseable resource to close
     */
   def closeCloseable(closeable: AutoCloseable): Unit = {
     unregisterCloseable(closeable)
 
     try {
-      log.info(s"Closing closable of type ${closeable.getClass.getCanonicalName}...")
+      log.info(s"Closing closeable of type ${closeable.getClass.getCanonicalName}...")
       closeable.close()
     } catch {
       case NonFatal(ex) =>

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -45,6 +45,24 @@ object ThreadClosableRegistry {
   }
 
   /**
+    * Closes a closeable resource and unregisters is as an transactional atomic operation.
+    * The resource will be automatically closed when [[cleanupThread]] is called for this thread.
+    *
+    * @param closeable The AutoCloseable resource to register
+    */
+  def closeCloseable(closeable: AutoCloseable): Unit = {
+    unregisterCloseable(closeable)
+
+    try {
+      log.info(s"Closing closable of type ${closeable.getClass.getCanonicalName}...")
+      closeable.close()
+    } catch {
+      case NonFatal(ex) =>
+        log.warn(s"Error closing resource of type ${closeable.getClass.getCanonicalName}.", ex)
+    }
+  }
+
+  /**
     * Unregisters a closeable resource from the registry.
     * This removes the resource regardless of which thread it was registered from.
     *
@@ -68,18 +86,30 @@ object ThreadClosableRegistry {
     *
     * @param threadId The ID of the thread whose resources should be cleaned up
     */
-  def cleanupThread(threadId: Long): Unit = synchronized {
-    val threadCloseables = closeables.asScala.filter(_._1 == threadId).map(_._2).toList
+  def cleanupThread(threadId: Long): Unit = {
+    val threadCloseables = this.synchronized {
+      closeables.asScala.filter(_._1 == threadId).map(_._2).toList
+    }
+
     threadCloseables.reverse.foreach { closeable =>
+      unregisterCloseable(closeable)
       try {
         log.info(s"Closing closable of type ${closeable.getClass.getCanonicalName} for the thread $threadId...")
         closeable.close()
       } catch {
         case NonFatal(ex) =>
           log.warn(s"Error closing resource for thread $threadId.", ex)
-      } finally {
-        unregisterCloseable(closeable)
       }
     }
+  }
+
+  /**
+    * Returns the number of closeable resources currently registered for the specified thread.
+    *
+    * @param threadId The ID of the thread whose registered closeable count should be retrieved
+    * @return The number of closeable resources registered for the given thread
+    */
+  def getCloseableCount(threadId: Long): Int = synchronized {
+    closeables.asScala.count(_._1 == threadId)
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/ThreadUtils.scala
@@ -27,6 +27,8 @@ import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 
 object ThreadUtils {
+  val MIN_WAIT_AFTER_INTERRUPT_MS = 1000
+
   private val log = LoggerFactory.getLogger(this.getClass)
 
   /**
@@ -59,16 +61,26 @@ object ThreadUtils {
     thread.setUncaughtExceptionHandler(handler)
 
     thread.start()
+    val threadId = thread.getId
+    val closeWaitMillis = Math.max(cleanupTimeout.toMillis, MIN_WAIT_AFTER_INTERRUPT_MS)
     val waitMillis = timeout.toMillis
     if (waitMillis > 0) {
       thread.join(waitMillis)
     }
 
-    if (thread.isAlive) {
-      val stackTrace = thread.getStackTrace
-      val threadId = thread.getId
+    val isAlive = thread.isAlive
+    val stackTrace = if (isAlive) {
+      val st = thread.getStackTrace
+      thread.interrupt()
+      thread.join(closeWaitMillis)
+      st
+    } else
+      Array.empty[StackTraceElement]
 
-      // Execute cleanup BEFORE interrupt - e.g. close the JDBC connection/statement
+    val closeableCount = ThreadClosableRegistry.getCloseableCount(threadId)
+    if (closeableCount > 0) {
+      log.info(s"Found $closeableCount closeables for thread $threadId. Cleaning up...")
+
       val future = DetachedRunService.runWithTimeoutThenDetach[Unit](cleanupTimeout) {
         ThreadClosableRegistry.cleanupThread(threadId)
       }
@@ -81,9 +93,9 @@ object ThreadUtils {
         case None              =>
           log.info(s"Timeout cleanup for thread $threadId is still running. Setting it to continue in a detached thread...")
       }
+    }
 
-      thread.interrupt()
-
+    if (isAlive) {
       val prettyTimeout = TimeUtils.prettyPrintElapsedTimeShort(timeout.toMillis)
       val cause = new RuntimeException("The task has been interrupted by Pramen.")
       cause.setStackTrace(stackTrace)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -98,10 +98,17 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
   }
 
   override def close(): Unit = {
-    if (connection != null) {
-      ThreadClosableRegistry.unregisterCloseable(connection)
+    val conn = this.synchronized {
+      connection
+    }
+
+    if (conn != null) {
       try {
-        connection.close()
+        log.info("Closing the JDBC connection to Hive...")
+        ThreadClosableRegistry.closeCloseable(conn)
+        this.synchronized {
+          connection = null
+        }
       } catch {
         case ex: InterruptedException => throw ex
         case NonFatal(ex) => log.warn("Failed to close JDBC connection", ex)

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -185,9 +185,9 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
     } match {
       case Failure(ex) =>
         ex match {
-          case ex: InterruptedException =>
+          case _: InterruptedException =>
             throw ex
-          case ex: Throwable =>
+          case _: Throwable =>
             log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
         }
         false
@@ -206,9 +206,9 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
     } match {
       case Failure(ex) =>
         ex match {
-          case ex: InterruptedException =>
+          case _: InterruptedException =>
             throw ex
-          case ex: Throwable =>
+          case _: Throwable =>
             log.info(s"The query resulted in an error, assuming the table $fullTableName does not exist (${ex.getMessage}).")
         }
         false

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
@@ -129,6 +129,18 @@ class ThreadClosableRegistrySuite extends AnyWordSpec with Matchers  {
       getCount() shouldBe 1
     }
 
+    "do nothing when closeable was already closed by the thread" in {
+      val (closeable, getCount) = createCountingCloseable()
+
+      ThreadClosableRegistry.registerCloseable(closeable)
+      ThreadClosableRegistry.closeCloseable(closeable)
+      getCount() shouldBe 1
+
+      // Cleanup again - should not call close again
+      ThreadClosableRegistry.cleanupThread(currentThreadId)
+      getCount() shouldBe 1
+    }
+
     "close resources in LIFO order (last registered, first closed)" in {
       val closeOrder = mutable.ArrayBuffer[Int]()
 


### PR DESCRIPTION
Closes #776 

<!-- What problem does it solve or what feature does it add? -->
## Overview
Makes sure all closeables opened in another thread are closed on successful path.

<!-- Summarize the key changes for release notes. -->
## Release Notes
  - Improved handling of interrupted database connection attempts by stopping retries immediately.
  - Improved cleanup of timed-out operations and registered resources.
  - Prevented resources from being closed more than once.
  - Strengthened JDBC connection shutdown handling.

<!-- Add attached issue that this PR solves. -->
## Related

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit
* **Documentation**
  * Corrected grammar in JDBC connection documentation.

* **Tests**
  * Added coverage for avoiding duplicate resource closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->