### PR TITLE
#778 Allow specifying closeable type when closing it via ThreadCloseableRegistry.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -50,15 +50,24 @@ object ThreadClosableRegistry {
     *
     * @param closeable The AutoCloseable resource to close
     */
-  def closeCloseable(closeable: AutoCloseable): Unit = {
+  def closeCloseable(closeable: AutoCloseable, closeableType: String = ""): Unit = {
     unregisterCloseable(closeable)
 
+    val closeableTypeFixed = if (closeableType.isEmpty) {
+      val clazz = closeable.getClass
+      if (clazz.getCanonicalName != null)
+        clazz.getCanonicalName
+      else
+        clazz.getName
+    } else
+      closeableType
+
     try {
-      log.info(s"Closing closeable of type ${closeable.getClass.getCanonicalName}...")
+      log.info(s"Closing closeable of type $closeableTypeFixed...")
       closeable.close()
     } catch {
       case NonFatal(ex) =>
-        log.warn(s"Error closing resource of type ${closeable.getClass.getCanonicalName}.", ex)
+        log.warn(s"Error closing resource of type $closeableTypeFixed.", ex)
     }
   }
 

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -51,7 +51,9 @@ object ThreadClosableRegistry {
     * @param closeable The AutoCloseable resource to close
     */
   def closeCloseable(closeable: AutoCloseable, closeableType: String = ""): Unit = {
-    unregisterCloseable(closeable)
+    val found = unregisterCloseable(closeable)
+    if (!found)
+      return
 
     val closeableTypeFixed = if (closeableType.isEmpty) {
       val clazz = closeable.getClass
@@ -75,17 +77,19 @@ object ThreadClosableRegistry {
     * Unregisters a closeable resource from the registry.
     * This removes the resource regardless of which thread it was registered from.
     *
-    * @param closeable The AutoCloseable resource to unregister
+    * @param closeable The AutoCloseable resource to unregister.
+    * @return True if the resource was found and unregistered, false otherwise.
     */
-  def unregisterCloseable(closeable: AutoCloseable): Unit = synchronized {
+  def unregisterCloseable(closeable: AutoCloseable): Boolean = synchronized {
     val iterator = closeables.iterator()
     while (iterator.hasNext) {
       val (_, c) = iterator.next()
       if (c == closeable) {
         iterator.remove()
-        return
+        return true
       }
     }
+    false
   }
 
   /**

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/runner/task/ThreadClosableRegistry.scala
@@ -55,14 +55,7 @@ object ThreadClosableRegistry {
     if (!found)
       return
 
-    val closeableTypeFixed = if (closeableType.isEmpty) {
-      val clazz = closeable.getClass
-      if (clazz.getCanonicalName != null)
-        clazz.getCanonicalName
-      else
-        clazz.getName
-    } else
-      closeableType
+    val closeableTypeFixed = getClassName(closeable, closeableType)
 
     try {
       log.info(s"Closing closeable of type $closeableTypeFixed...")
@@ -106,12 +99,15 @@ object ThreadClosableRegistry {
 
     threadCloseables.reverse.foreach { closeable =>
       unregisterCloseable(closeable)
+
+      val closeableTypeFixed = getClassName(closeable, "")
+
       try {
-        log.info(s"Closing closable of type ${closeable.getClass.getCanonicalName} for the thread $threadId...")
+        log.info(s"Closing closable of type $closeableTypeFixed for the thread $threadId...")
         closeable.close()
       } catch {
         case NonFatal(ex) =>
-          log.warn(s"Error closing resource for thread $threadId.", ex)
+          log.warn(s"Error closing resource of type $closeableTypeFixed for thread $threadId.", ex)
       }
     }
   }
@@ -124,5 +120,16 @@ object ThreadClosableRegistry {
     */
   def getCloseableCount(threadId: Long): Int = synchronized {
     closeables.asScala.count(_._1 == threadId)
+  }
+
+  private def getClassName(obj: AnyRef, providedType: String): String = {
+    if (providedType.isEmpty) {
+      val clazz = obj.getClass
+      if (clazz.getCanonicalName != null)
+        clazz.getCanonicalName
+      else
+        clazz.getName
+    } else
+      providedType
   }
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/utils/hive/QueryExecutorJdbc.scala
@@ -92,8 +92,7 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
       try {
         statement.execute(query)
       } finally {
-        ThreadClosableRegistry.unregisterCloseable(autoCloseStatement)
-        autoCloseStatement.close()
+        ThreadClosableRegistry.closeCloseable(autoCloseStatement, s"java.sql.Statement(${query.take(5)}...)")
       }
     }
   }
@@ -106,7 +105,7 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
     if (conn != null) {
       try {
         log.info("Closing the JDBC connection to Hive...")
-        ThreadClosableRegistry.closeCloseable(conn)
+        ThreadClosableRegistry.closeCloseable(conn, "java.sql.Connection")
         this.synchronized {
           connection = null
         }
@@ -220,14 +219,6 @@ class QueryExecutorJdbc(jdbcUrlSelector: JdbcUrlSelector, existenceCheckStrategy
         true
     }
   }
-
-  def getEscapedMetadataString(s: String, metaData: DatabaseMetaData): String = {
-    val esc = metaData.getSearchStringEscape
-
-    s.replace(esc, s"${esc}$esc")
-      .replace("%", s"$esc%")
-      .replace("_", s"${esc}_")
-  }
 }
 
 object QueryExecutorJdbc {
@@ -237,5 +228,13 @@ object QueryExecutorJdbc {
     val jdbcUrlSelector = JdbcUrlSelector(jdbcConfig)
 
     new QueryExecutorJdbc(jdbcUrlSelector, existenceCheckStrategy)
+  }
+
+  def getEscapedMetadataString(s: String, metaData: DatabaseMetaData): String = {
+    val esc = metaData.getSearchStringEscape
+
+    s.replace(esc, s"${esc}$esc")
+      .replace("%", s"$esc%")
+      .replace("_", s"${esc}_")
   }
 }

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
@@ -133,12 +133,20 @@ class ThreadClosableRegistrySuite extends AnyWordSpec with Matchers  {
       val (closeable, getCount) = createCountingCloseable()
 
       ThreadClosableRegistry.registerCloseable(closeable)
-      ThreadClosableRegistry.closeCloseable(closeable)
       ThreadClosableRegistry.closeCloseable(closeable, "test")
       getCount() shouldBe 1
 
       // Cleanup again - should not call close again
       ThreadClosableRegistry.cleanupThread(currentThreadId)
+      getCount() shouldBe 1
+    }
+
+    "double close should invoke close only once" in {
+      val (closeable, getCount) = createCountingCloseable()
+
+      ThreadClosableRegistry.registerCloseable(closeable)
+      ThreadClosableRegistry.closeCloseable(closeable)
+      ThreadClosableRegistry.closeCloseable(closeable, "test")
       getCount() shouldBe 1
     }
 

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/runner/task/ThreadClosableRegistrySuite.scala
@@ -134,6 +134,7 @@ class ThreadClosableRegistrySuite extends AnyWordSpec with Matchers  {
 
       ThreadClosableRegistry.registerCloseable(closeable)
       ThreadClosableRegistry.closeCloseable(closeable)
+      ThreadClosableRegistry.closeCloseable(closeable, "test")
       getCount() shouldBe 1
 
       // Cleanup again - should not call close again

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/tests/utils/hive/QueryExecutorJdbcSuite.scala
@@ -238,7 +238,7 @@ class QueryExecutorJdbcSuite extends AnyWordSpec with BeforeAndAfterAll with Rel
       val qe = new QueryExecutorJdbc(JdbcUrlSelector(jdbcConfig), existenceCheckStrategy = ExistenceCheckStrategy.MetadataQuery)
       val metadata = getConnection.getMetaData
 
-      val actual = qe.getEscapedMetadataString("100% escaped_table", metadata)
+      val actual = QueryExecutorJdbc.getEscapedMetadataString("100% escaped_table", metadata)
 
       qe.close()
 


### PR DESCRIPTION
## Overview
Improves logging of automatic closing of autocloseables when the thread is terminated.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Improves logging of automatic closing of autocloseables when the thread is terminated

<!-- Add attached issue that this PR solves. -->
## Related
Closes #778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of database statements and connections during query execution and shutdown.
  * Enhanced close handling to avoid duplicate close attempts and provide clearer close logging context.
  * Preserved metadata escaping behavior while reorganizing its implementation for consistency.
* **Tests**
  * Expanded registry cleanup coverage, including double-close scenarios and expected close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->