### PR TITLE
#783 Add support for the optional `copy` flag in the 'raw' format, allowing files to be skipped from copying while still counted in the size stats.

### DIFF
--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
@@ -100,7 +100,7 @@ class MetastorePersistenceRaw(path: String,
 
           fsUtilsTrg.copyFileWithRetry(srcPath, trgPath) match {
             case None => Seq.empty[String]
-            case Some(ex) if ex.getMessage != null => Seq(ex.getMessage)
+            case Some(ex) => Seq(Option(ex.getMessage).getOrElse(ex.getClass.getName))
           }
         } else {
           None

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/MetastorePersistenceRaw.scala
@@ -59,7 +59,7 @@ class MetastorePersistenceRaw(path: String,
       throw new IllegalArgumentException("The 'raw' persistent format data frame should have 'path' column.")
     }
 
-    val files = df.select(RAW_PATH_FIELD_KEY).collect().map(_.getString(0))
+    val files = RawFile.fromDf(df)
 
     val outputDir = if (partitionScheme == PartitionScheme.Overwrite)
       new Path(path)
@@ -80,23 +80,30 @@ class MetastorePersistenceRaw(path: String,
 
     fsUtilsTrg.createDirectoryRecursive(outputDir)
 
-    var copiedSize = 0L
+    var processedSize = 0L
 
     val warnings: Seq[String] = if (files.isEmpty) {
       log.info("Nothing to save")
       Seq.empty[String]
     } else {
       files.flatMap { file =>
-        val srcPath = new Path(file)
-        val trgPath = new Path(outputDir, srcPath.getName)
+        val srcPath = new Path(file.filePath)
+
         val fsSrc = srcPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
 
-        log.info(s"Copying file from $srcPath to $trgPath")
+        processedSize += fsSrc.getContentSummary(srcPath).getLength
 
-        copiedSize += fsSrc.getContentSummary(srcPath).getLength
-        fsUtilsTrg.copyFileWithRetry(srcPath, trgPath) match {
-          case None => Seq.empty[String]
-          case Some(ex) if ex.getMessage != null => Seq(ex.getMessage)
+        if (file.needsCopying) {
+          val trgPath = new Path(outputDir, srcPath.getName)
+
+          log.info(s"Copying file from $srcPath to $trgPath")
+
+          fsUtilsTrg.copyFileWithRetry(srcPath, trgPath) match {
+            case None => Seq.empty[String]
+            case Some(ex) if ex.getMessage != null => Seq(ex.getMessage)
+          }
+        } else {
+          None
         }
       }
     }
@@ -105,25 +112,25 @@ class MetastorePersistenceRaw(path: String,
       val list = getListOfFilesRange(infoDate, infoDate)
       if (list.isEmpty) {
         MetaTableStats(
-          Option(copiedSize),
+          Option(processedSize),
           None,
-          Some(copiedSize),
+          Some(processedSize),
           warnings
         )
       } else {
         val totalSize = list.map(_.getLen).sum
         MetaTableStats(
           Option(totalSize),
-          Some(copiedSize),
+          Some(processedSize),
           Some(totalSize),
           warnings
         )
       }
     } else {
       MetaTableStats(
-        Option(copiedSize),
+        Option(processedSize),
         None,
-        Some(copiedSize),
+        Some(processedSize),
         warnings
       )
     }
@@ -230,5 +237,6 @@ class MetastorePersistenceRaw(path: String,
 
 object MetastorePersistenceRaw {
   val RAW_PATH_FIELD_KEY = "path"
+  val RAW_COPY_FIELD_KEY = "copy"
   val RAW_OFFSET_FIELD_KEY = "file_name"
 }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/RawFile.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/RawFile.scala
@@ -41,7 +41,10 @@ object RawFile {
     }
 
     if (df.schema.exists(_.name == RAW_COPY_FIELD_KEY)) {
-      df.select(RAW_PATH_FIELD_KEY, RAW_COPY_FIELD_KEY).collect().map(row => RawFile(row.getString(0), row.getBoolean(1)))
+      df.select(RAW_PATH_FIELD_KEY, RAW_COPY_FIELD_KEY).collect().map { row =>
+        val needsCopying = if (row.isNullAt(1)) true else row.getBoolean(1)
+        RawFile(row.getString(0), needsCopying)
+      }
     } else {
       df.select(RAW_PATH_FIELD_KEY).collect().map(row => RawFile(row.getString(0), needsCopying = true))
     }

--- a/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/RawFile.scala
+++ b/pramen/core/src/main/scala/za/co/absa/pramen/core/metastore/peristence/RawFile.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.peristence
+
+import org.apache.spark.sql.DataFrame
+import za.co.absa.pramen.core.metastore.peristence.MetastorePersistenceRaw.{RAW_COPY_FIELD_KEY, RAW_PATH_FIELD_KEY}
+
+case class RawFile(filePath: String, needsCopying: Boolean)
+
+
+object RawFile {
+
+  /**
+    * Converts a data frame of the 'raw' persistent format, which is just a list of files, to a Seq[RawFile].
+    *
+    * The data frame must contain the file path column. If the flag column determining whether a file
+    * needs to be copied is present, its value is used, otherwise all returned files are marked as
+    * requiring copying.
+    *
+    * @param df A data frame in the 'raw' persistent format containing at least the file path column.
+    * @return A sequence of raw files collected from the data frame.
+    * @throws IllegalArgumentException if the data frame does not contain the file path column.
+    */
+  def fromDf(df: DataFrame): Seq[RawFile] = {
+    if (!df.schema.exists(_.name == RAW_PATH_FIELD_KEY)) {
+      throw new IllegalArgumentException("The 'raw' persistent format data frame should have 'path' column.")
+    }
+
+    if (df.schema.exists(_.name == RAW_COPY_FIELD_KEY)) {
+      df.select(RAW_PATH_FIELD_KEY, RAW_COPY_FIELD_KEY).collect().map(row => RawFile(row.getString(0), row.getBoolean(1)))
+    } else {
+      df.select(RAW_PATH_FIELD_KEY).collect().map(row => RawFile(row.getString(0), needsCopying = true))
+    }
+  }
+}

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceRawSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/MetastorePersistenceRawSuite.scala
@@ -148,6 +148,27 @@ class MetastorePersistenceRawSuite extends AnyWordSpec with SparkTestBase with T
       }
     }
 
+    "do not copy files marked as not to copy" in {
+      withTempDirectory("metastore_raw") { tempDir =>
+        val file1 = new Path(tempDir, "1.dat")
+        val file2 = new Path(tempDir, "2.dat")
+
+        fsUtils.fs.create(file1).close()
+        fsUtils.fs.create(file2).close()
+
+        val files = Seq((file1.toUri.toString, false), (file2.toUri.toString, true)).toDF("path", "copy")
+
+        val persistence = new MetastorePersistenceRaw(tempDir, infoDateColumn, infoDateFormat, PartitionScheme.PartitionByDay, Some(SaveMode.Overwrite))
+
+        persistence.saveTable(infoDate, files, None)
+
+        val partitionPath = new Path(tempDir, s"$infoDateColumn=$infoDate")
+
+        assert(!fsUtils.exists(new Path(partitionPath, "1.dat")))
+        assert(fsUtils.exists(new Path(partitionPath, "2.dat")))
+      }
+    }
+
     "delete existing partition directory if it exists" in {
       withTempDirectory("metastore_raw") { tempDir =>
         val file1 = new Path(tempDir, "1.dat")

--- a/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/RawFileSuite.scala
+++ b/pramen/core/src/test/scala/za/co/absa/pramen/core/metastore/persistence/RawFileSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.pramen.core.metastore.persistence
+
+import org.scalatest.wordspec.AnyWordSpec
+import za.co.absa.pramen.core.base.SparkTestBase
+import za.co.absa.pramen.core.metastore.peristence.MetastorePersistenceRaw.{RAW_COPY_FIELD_KEY, RAW_PATH_FIELD_KEY}
+import za.co.absa.pramen.core.metastore.peristence.RawFile
+
+class RawFileSuite extends AnyWordSpec with SparkTestBase {
+  import spark.implicits._
+
+  "fromDf" should {
+    "return a list of files with the default copy flag" in {
+      val df = Seq("file1.txt", "file2.tst").toDF(RAW_PATH_FIELD_KEY)
+
+      val files = RawFile.fromDf(df)
+
+      assert(files.exists(_.filePath == "file1.txt"))
+      assert(files.exists(_.filePath == "file2.tst"))
+      assert(files.forall(_.needsCopying))
+    }
+
+    "return a list of files with the explicit copy flag" in {
+      val df = Seq(("file1.txt", false), ("file2.tst", true)).toDF(RAW_PATH_FIELD_KEY, RAW_COPY_FIELD_KEY)
+
+      val files = RawFile.fromDf(df)
+
+      assert(files.exists(f => f.filePath == "file1.txt" && !f.needsCopying))
+      assert(files.exists(f => f.filePath == "file2.tst" && f.needsCopying))
+    }
+
+    "throw an exception when the DataFrame is missing required columns" in {
+      val df = Seq("file1.txt", "file2.tst").toDF("wrong_column")
+
+      assertThrows[IllegalArgumentException] {
+        RawFile.fromDf(df)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview

<!-- Summarize the key changes for release notes. -->
## Release Notes
  - Raw file processing now supports optional copy indicators.
  - Files marked as not requiring copying are skipped, while eligible files are copied as before.
  - Processing statistics now report the total source size handled.

<!-- Add attached issue that this PR solves. -->
## Related
Closes #783 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raw file processing now supports optional copy indicators.
  * Files marked as not requiring copying are skipped, while eligible files are copied as before.
  * Processing statistics now report the total source size handled.

* **Bug Fixes**
  * Copy failures continue to generate warnings without stopping other file processing.
  * Invalid raw file data is rejected with clear validation errors.

* **Tests**
  * Added coverage for copy flags, skipped files, copied files, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->